### PR TITLE
fix(ci): fail deploy when preview is not reachable

### DIFF
--- a/.github/workflows/deploy-channels.yml
+++ b/.github/workflows/deploy-channels.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   actions: read
+  pages: read
 
 concurrency:
   group: deploy-channels-${{ github.event.workflow_run.head_branch || github.run_id }}
@@ -122,7 +123,48 @@ jobs:
             deploy(preview): ${{ needs.prepare-context.outputs.branch_name }}
             (${{ needs.prepare-context.outputs.head_sha }})
 
-      - name: Preview URL
+      - name: Verify preview deployment availability
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREVIEW_URL: >-
+            https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/${{ needs.prepare-context.outputs.branch_slug }}/
+        run: |
+          set -euo pipefail
+
+          pages_api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/pages"
+          pages_status="$(curl -sS -o pages-response.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "${pages_api_url}")"
+
+          if [ "${pages_status}" != '200' ]; then
+            echo "GitHub Pages site is not configured/available for this repository." >&2
+            echo "Pages API status: ${pages_status}" >&2
+            cat pages-response.json >&2 || true
+            exit 1
+          fi
+
+          preview_index_url="${PREVIEW_URL}index.html"
+          max_attempts=30
+          for attempt in $(seq 1 "${max_attempts}"); do
+            preview_status="$(curl -sS -L -o preview-index.html -w '%{http_code}' "${preview_index_url}")"
+            if [ "${preview_status}" = '200' ] && grep -q 'id="app"' preview-index.html; then
+              echo "Preview deployment is reachable at ${PREVIEW_URL}"
+              exit 0
+            fi
+
+            if [ "${attempt}" -lt "${max_attempts}" ]; then
+              echo "Preview check attempt ${attempt}/${max_attempts} not ready (status ${preview_status}); retrying in 10s..."
+              sleep 10
+            fi
+          done
+
+          echo "Preview deployment did not become reachable in time: ${PREVIEW_URL}" >&2
+          echo "Last response status: ${preview_status}" >&2
+          cat preview-index.html >&2 || true
+          exit 1
+
+      - name: Preview URL (reachable)
         run: |
           echo "Preview URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/${{ needs.prepare-context.outputs.branch_slug }}/"
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Operational notes:
 - Preview builds use `DEPLOY_CHANNEL=preview` with deterministic path-safe branch slugging (single path segment, no nested branch folders) and isolate service worker scope/assets under `/<repo>/previews/<branch-slug>/`.
 - Production artifact builds use `DEPLOY_CHANNEL=production` and enforce `/conspectus/webapp/` for Vite `base`, PWA manifest `start_url`, and service worker scope.
 - Failed `Quality` runs do not produce preview deployments or production artifacts.
+- `Deploy Channels` includes a hard post-deploy preview availability check; if GitHub Pages is unavailable or the preview URL is not reachable, the workflow fails.
 - `Preview Cleanup` removes stale `gh-pages/previews/<branch-slug>/` content when a branch is deleted.
 
 ## Issue Labeling Rules


### PR DESCRIPTION
## Summary
Add a hard post-deploy availability gate to `Deploy Channels` so the workflow fails when GitHub Pages is unavailable or the preview URL is not reachable.

## Changes
- Added `pages: read` permission in deploy workflow.
- Added `Verify preview deployment availability` step after publishing preview:
  - checks GitHub Pages site API (`GET /repos/{owner}/{repo}/pages`) and fails on non-200
  - polls preview `index.html` for HTTP 200 and app shell marker (`id="app"`) with retry
  - fails workflow if preview never becomes reachable
- Documented this hard fail behavior in README deployment notes.

## Why
Previously the deployment pipeline could stay green even when preview hosting was not actually available.

## Verification
- `npm run format`
- `npm run lint`