### PR TITLE
M2-01: approve cross-repo artifact handoff architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Operational notes:
 - Failed `Quality` runs do not produce preview deployments or production artifacts.
 - `Deploy Channels` includes a hard post-deploy preview availability check; if GitHub Pages is unavailable or the preview URL is not reachable, the workflow fails.
 - `Preview Cleanup` removes stale `gh-pages/previews/<branch-slug>/` content when a branch is deleted.
+- Canonical cross-repo producer/consumer architecture decision (M2-01): `docs/Architecture-and-Implementation-Plan.md` section `8.3`.
 
 ## Issue Labeling Rules
 

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -141,7 +141,7 @@ An issue is only considered done when:
 - Depends on: `M1-08`
 - GitHub: [#94](https://github.com/Jon2050/Conspectus-Mobile/issues/94)
 
-### :green_circle: M2-01 Decide cross-repo deployment architecture
+### :white_check_mark: M2-01 Decide cross-repo deployment architecture
 - Label: `infra`
 - Milestone: `M2 - Website Integration + Early Deploy`
 - Summary: Work includes options: artifact handoff, submodule, subtree, package pull and one strategy and document rationale. It also covers failure/rollback behavior for the chosen strategy.


### PR DESCRIPTION
## Summary\n- document the approved M2-01 cross-repo deployment strategy as artifact handoff\n- add deterministic producer/consumer CI contract (repository_dispatch payload, artifact identity, metadata validation, atomic replace)\n- document failure and rollback behavior and mark alternatives as rejected for MVP\n- mark M2-01 done in backlog tracker\n\n## Acceptance Criteria Mapping\n- AC1: documented one approved deployment architecture in Architecture Plan section 8.3\n- AC2: documented automation-only contract so both repos can implement without manual copy steps\n\n## Validation\n- npm run format\n- npm run lint\n- npm run typecheck\n- npm run test\n- npm run build\n\nCloses #14