### PR TITLE
M2-03: implement deterministic production artifact handoff

### DIFF
--- a/.github/workflows/deploy-channels.yml
+++ b/.github/workflows/deploy-channels.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   VITE_AZURE_CLIENT_ID: ${{ vars.VITE_AZURE_CLIENT_ID }}
+  WEBSITE_REPO_FULL_NAME: ${{ vars.WEBSITE_REPO_FULL_NAME || 'Jon2050/conspectus' }}
 
 permissions:
   contents: write
@@ -184,6 +185,11 @@ jobs:
     needs:
       - prepare-context
     if: needs.prepare-context.outputs.is_main == 'true'
+    outputs:
+      artifact_name: ${{ steps.handoff.outputs.artifact_name }}
+      commit_sha: ${{ steps.handoff.outputs.commit_sha }}
+      quality_run_id: ${{ steps.handoff.outputs.quality_run_id }}
+      deploy_run_id: ${{ steps.handoff.outputs.deploy_run_id }}
     steps:
       - name: Checkout source commit
         uses: actions/checkout@v4
@@ -218,24 +224,111 @@ jobs:
           --channel production
           --base /conspectus/webapp/
 
+      - name: Resolve production handoff identity
+        id: handoff
+        run: |
+          build_time_utc="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          artifact_name="conspectus-mobile-production-${{ needs.prepare-context.outputs.head_sha }}"
+          {
+            echo "artifact_name=${artifact_name}"
+            echo "commit_sha=${{ needs.prepare-context.outputs.head_sha }}"
+            echo "quality_run_id=${{ github.event.workflow_run.id }}"
+            echo "deploy_run_id=${{ github.run_id }}"
+            echo "build_time_utc=${build_time_utc}"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Add production artifact metadata
         run: |
-          timestamp="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           cat > dist/deploy-metadata.json <<EOF
           {
             "channel": "production",
             "basePath": "/conspectus/webapp/",
             "sourceBranch": "${{ needs.prepare-context.outputs.branch_name }}",
-            "commitSha": "${{ needs.prepare-context.outputs.head_sha }}",
-            "buildTimeUtc": "${timestamp}",
-            "qualityRunId": "${{ github.event.workflow_run.id }}",
-            "deployRunId": "${{ github.run_id }}"
+            "commitSha": "${{ steps.handoff.outputs.commit_sha }}",
+            "buildTimeUtc": "${{ steps.handoff.outputs.build_time_utc }}",
+            "qualityRunId": "${{ steps.handoff.outputs.quality_run_id }}",
+            "deployRunId": "${{ steps.handoff.outputs.deploy_run_id }}"
           }
           EOF
 
       - name: Upload production artifact
         uses: actions/upload-artifact@v4
         with:
-          name: conspectus-mobile-production-${{ needs.prepare-context.outputs.head_sha }}
+          name: ${{ steps.handoff.outputs.artifact_name }}
           if-no-files-found: error
           path: dist
+
+      - name: Verify production handoff outputs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          artifacts_api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts"
+          artifacts_status="$(curl -sS -o artifacts-response.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "${artifacts_api_url}")"
+
+          if [ "${artifacts_status}" != '200' ]; then
+            echo "Failed to list run artifacts for production handoff verification." >&2
+            echo "Artifacts API status: ${artifacts_status}" >&2
+            cat artifacts-response.json >&2 || true
+            exit 1
+          fi
+
+          node scripts/verify-production-handoff.mjs \
+            --artifacts-json artifacts-response.json \
+            --metadata dist/deploy-metadata.json \
+            --artifact-name "${{ steps.handoff.outputs.artifact_name }}" \
+            --commit-sha "${{ steps.handoff.outputs.commit_sha }}" \
+            --quality-run-id "${{ steps.handoff.outputs.quality_run_id }}" \
+            --deploy-run-id "${{ steps.handoff.outputs.deploy_run_id }}"
+
+  dispatch-production-ready:
+    name: Dispatch Production Ready
+    runs-on: ubuntu-latest
+    needs:
+      - publish-production-artifact
+    if: needs.publish-production-artifact.result == 'success'
+    steps:
+      - name: Validate producer dispatch token
+        run: |
+          if [ -z "${{ secrets.WEBSITE_REPO_DISPATCH_TOKEN }}" ]; then
+            echo "Missing required secret WEBSITE_REPO_DISPATCH_TOKEN." >&2
+            echo "This token must be scoped to trigger workflow events in ${WEBSITE_REPO_FULL_NAME}." >&2
+            exit 1
+          fi
+
+      - name: Trigger deterministic website handoff event
+        env:
+          DISPATCH_TOKEN: ${{ secrets.WEBSITE_REPO_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          cat > dispatch-payload.json <<EOF
+          {
+            "event_type": "conspectus-mobile-production-ready",
+            "client_payload": {
+              "commitSha": "${{ needs.publish-production-artifact.outputs.commit_sha }}",
+              "deployRunId": "${{ needs.publish-production-artifact.outputs.deploy_run_id }}",
+              "qualityRunId": "${{ needs.publish-production-artifact.outputs.quality_run_id }}",
+              "artifactName": "${{ needs.publish-production-artifact.outputs.artifact_name }}"
+            }
+          }
+          EOF
+
+          dispatch_status="$(curl -sS -o dispatch-response.txt -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${WEBSITE_REPO_FULL_NAME}/dispatches" \
+            --data-binary @dispatch-payload.json)"
+
+          if [ "${dispatch_status}" != '204' ]; then
+            echo "Failed to dispatch production-ready event to ${WEBSITE_REPO_FULL_NAME}." >&2
+            echo "Dispatch API status: ${dispatch_status}" >&2
+            cat dispatch-response.txt >&2 || true
+            exit 1
+          fi
+
+          echo "Dispatched conspectus-mobile-production-ready to ${WEBSITE_REPO_FULL_NAME}."

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Operational notes:
 - Failed `Quality` runs do not produce preview deployments or production artifacts.
 - `Deploy Channels` includes a hard post-deploy preview availability check; if GitHub Pages is unavailable or the preview URL is not reachable, the workflow fails.
 - `Preview Cleanup` removes stale `gh-pages/previews/<branch-slug>/` content when a branch is deleted.
+- Production handoff dispatch requires repository secret `WEBSITE_REPO_DISPATCH_TOKEN` (scoped to trigger workflow events in the website repo).
+- Production handoff target repository defaults to `Jon2050/conspectus` and can be overridden with repository variable `WEBSITE_REPO_FULL_NAME`.
 - Canonical cross-repo producer/consumer architecture decision (M2-01): `docs/Architecture-and-Implementation-Plan.md` section `8.3`.
 
 ## Issue Labeling Rules

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -598,6 +598,7 @@ Producer/consumer CI contract (automation-only, no manual copy):
 1. Producer (`Conspectus-Mobile`):
    - Source workflow: `Deploy Channels` after successful `Quality` push runs.
    - Production artifact is published only for `main`.
+   - Every successful `main` deploy run MUST emit exactly one deployable production artifact; the producer workflow enforces this before handoff dispatch.
    - Artifact name format: `conspectus-mobile-production-<commitSha>`.
    - Artifact payload is `dist/` and MUST include `deploy-metadata.json` with:
      - `channel` (`production`)
@@ -611,6 +612,8 @@ Producer/consumer CI contract (automation-only, no manual copy):
      - Trigger `repository_dispatch` with event type `conspectus-mobile-production-ready`.
      - Payload MUST include `commitSha`, `deployRunId`, `qualityRunId`, and `artifactName`.
      - Producer dispatch token MUST be scoped to trigger workflow events in the website repository.
+     - Producer workflow secret `WEBSITE_REPO_DISPATCH_TOKEN` is required for dispatch.
+     - Producer workflow variable `WEBSITE_REPO_FULL_NAME` may override the default consumer target (`Jon2050/conspectus`).
 2. Consumer (website repository):
    - Trigger on `repository_dispatch` (`conspectus-mobile-production-ready`) and read payload fields as the single source of artifact identity.
    - Resolve artifact deterministically via GitHub Actions API using `deployRunId`:

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -155,7 +155,7 @@ An issue is only considered done when:
 - Depends on: `M2-01`
 - GitHub: [#15](https://github.com/Jon2050/Conspectus-Mobile/issues/15)
 
-### :green_circle: M2-03 Create PWA deploy workflow in PWA repo
+### :white_check_mark: M2-03 Create PWA deploy workflow in PWA repo
 - Label: `infra`
 - Milestone: `M2 - Website Integration + Early Deploy`
 - Summary: Work includes production bundle in CI and artifact for website repo consumption. It also covers Tag artifact with commit SHA and timestamp.
@@ -587,4 +587,3 @@ An issue is only considered done when:
 1. Create all `PM-*` issues.
 2. Create all issues in milestone order (`M1` to `M8`).
 3. Link dependencies during creation using issue references.
-

--- a/scripts/verify-production-handoff.mjs
+++ b/scripts/verify-production-handoff.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REQUIRED_ARGS = new Set([
+  'artifactsJson',
+  'metadata',
+  'artifactName',
+  'commitSha',
+  'qualityRunId',
+  'deployRunId',
+]);
+
+const ISO_UTC_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const parseArgs = (argv) => {
+  const args = {
+    artifactsJson: '',
+    metadata: '',
+    artifactName: '',
+    commitSha: '',
+    qualityRunId: '',
+    deployRunId: '',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+    if (!current.startsWith('--')) {
+      continue;
+    }
+
+    const key = current.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    if (!(key in args)) {
+      continue;
+    }
+
+    args[key] = argv[index + 1] ?? '';
+    index += 1;
+  }
+
+  for (const requiredArg of REQUIRED_ARGS) {
+    assert(args[requiredArg], `Missing required --${requiredArg} argument.`);
+  }
+
+  return args;
+};
+
+const readJson = (filePath) => {
+  const absolutePath = path.resolve(process.cwd(), filePath);
+  assert(fs.existsSync(absolutePath), `Missing expected file: ${absolutePath}`);
+
+  return JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+};
+
+const verifyArtifacts = (artifactsResponse, expectedArtifactName) => {
+  const artifacts = Array.isArray(artifactsResponse.artifacts) ? artifactsResponse.artifacts : [];
+  assert(
+    artifacts.length === 1,
+    `Expected exactly one artifact for this deploy run, found ${artifacts.length}.`,
+  );
+
+  const artifact = artifacts[0];
+  assert(
+    artifact.name === expectedArtifactName,
+    `Artifact name mismatch. Expected "${expectedArtifactName}", got "${artifact.name}".`,
+  );
+};
+
+const verifyMetadata = (metadata, expectedValues) => {
+  assert(
+    metadata.channel === 'production',
+    `Metadata channel mismatch. Expected "production", got "${metadata.channel}".`,
+  );
+  assert(
+    metadata.basePath === '/conspectus/webapp/',
+    `Metadata basePath mismatch. Expected "/conspectus/webapp/", got "${metadata.basePath}".`,
+  );
+  assert(metadata.sourceBranch, 'Metadata sourceBranch is required.');
+  assert(
+    metadata.commitSha === expectedValues.commitSha,
+    `Metadata commitSha mismatch. Expected "${expectedValues.commitSha}", got "${metadata.commitSha}".`,
+  );
+  assert(
+    ISO_UTC_TIMESTAMP_PATTERN.test(String(metadata.buildTimeUtc)),
+    `Metadata buildTimeUtc must use ISO UTC format (YYYY-MM-DDTHH:mm:ssZ). Got "${metadata.buildTimeUtc}".`,
+  );
+  assert(
+    String(metadata.qualityRunId) === expectedValues.qualityRunId,
+    `Metadata qualityRunId mismatch. Expected "${expectedValues.qualityRunId}", got "${metadata.qualityRunId}".`,
+  );
+  assert(
+    String(metadata.deployRunId) === expectedValues.deployRunId,
+    `Metadata deployRunId mismatch. Expected "${expectedValues.deployRunId}", got "${metadata.deployRunId}".`,
+  );
+};
+
+const main = () => {
+  const args = parseArgs(process.argv.slice(2));
+  const artifactsResponse = readJson(args.artifactsJson);
+  const metadata = readJson(args.metadata);
+
+  verifyArtifacts(artifactsResponse, args.artifactName);
+  verifyMetadata(metadata, {
+    commitSha: args.commitSha,
+    qualityRunId: args.qualityRunId,
+    deployRunId: args.deployRunId,
+  });
+
+  console.log(
+    `[verify-production-handoff] verified artifact "${args.artifactName}" and deploy metadata traceability.`,
+  );
+};
+
+main();

--- a/scripts/verify-production-handoff.test.ts
+++ b/scripts/verify-production-handoff.test.ts
@@ -1,0 +1,177 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const thisFilePath = fileURLToPath(import.meta.url);
+const scriptsDirectoryPath = path.dirname(thisFilePath);
+const repositoryRootPath = path.resolve(scriptsDirectoryPath, '..');
+const verifyScriptPath = path.resolve(scriptsDirectoryPath, 'verify-production-handoff.mjs');
+
+const createFixtureDirectory = () => mkdtempSync(path.join(tmpdir(), 'verify-production-handoff-'));
+
+const writeJson = (filePath: string, value: unknown) => {
+  writeFileSync(filePath, JSON.stringify(value, null, 2));
+};
+
+const runVerifier = (args: string[]) =>
+  spawnSync('node', [verifyScriptPath, ...args], {
+    cwd: repositoryRootPath,
+    encoding: 'utf8',
+  });
+
+const runVerifierOrThrow = (args: string[]) => {
+  const result = runVerifier(args);
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Expected verifier to succeed, but it failed.\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+
+  return result;
+};
+
+const runVerifierFailure = (args: string[]) => {
+  const result = runVerifier(args);
+  if (result.error) {
+    throw result.error;
+  }
+
+  expect(result.status).toBe(1);
+  return result;
+};
+
+describe('verify-production-handoff script', () => {
+  it('accepts a valid single-artifact handoff with traceable metadata', () => {
+    const fixturePath = createFixtureDirectory();
+    const artifactsPath = path.join(fixturePath, 'artifacts.json');
+    const metadataPath = path.join(fixturePath, 'deploy-metadata.json');
+    const artifactName = 'conspectus-mobile-production-abc123';
+
+    try {
+      writeJson(artifactsPath, {
+        artifacts: [{ name: artifactName }],
+      });
+      writeJson(metadataPath, {
+        channel: 'production',
+        basePath: '/conspectus/webapp/',
+        sourceBranch: 'main',
+        commitSha: 'abc123',
+        buildTimeUtc: '2026-03-01T10:20:30Z',
+        qualityRunId: '1001',
+        deployRunId: '2002',
+      });
+
+      const result = runVerifierOrThrow([
+        '--artifacts-json',
+        artifactsPath,
+        '--metadata',
+        metadataPath,
+        '--artifact-name',
+        artifactName,
+        '--commit-sha',
+        'abc123',
+        '--quality-run-id',
+        '1001',
+        '--deploy-run-id',
+        '2002',
+      ]);
+
+      expect(result.stdout).toContain('[verify-production-handoff] verified artifact');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('fails when more than one artifact is present for the deploy run', () => {
+    const fixturePath = createFixtureDirectory();
+    const artifactsPath = path.join(fixturePath, 'artifacts.json');
+    const metadataPath = path.join(fixturePath, 'deploy-metadata.json');
+    const artifactName = 'conspectus-mobile-production-abc123';
+
+    try {
+      writeJson(artifactsPath, {
+        artifacts: [{ name: artifactName }, { name: 'unexpected-artifact' }],
+      });
+      writeJson(metadataPath, {
+        channel: 'production',
+        basePath: '/conspectus/webapp/',
+        sourceBranch: 'main',
+        commitSha: 'abc123',
+        buildTimeUtc: '2026-03-01T10:20:30Z',
+        qualityRunId: '1001',
+        deployRunId: '2002',
+      });
+
+      const result = runVerifierFailure([
+        '--artifacts-json',
+        artifactsPath,
+        '--metadata',
+        metadataPath,
+        '--artifact-name',
+        artifactName,
+        '--commit-sha',
+        'abc123',
+        '--quality-run-id',
+        '1001',
+        '--deploy-run-id',
+        '2002',
+      ]);
+
+      expect(result.stderr).toContain(
+        'Expected exactly one artifact for this deploy run, found 2.',
+      );
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('fails when traceability identifiers do not match expected values', () => {
+    const fixturePath = createFixtureDirectory();
+    const artifactsPath = path.join(fixturePath, 'artifacts.json');
+    const metadataPath = path.join(fixturePath, 'deploy-metadata.json');
+    const artifactName = 'conspectus-mobile-production-abc123';
+
+    try {
+      writeJson(artifactsPath, {
+        artifacts: [{ name: artifactName }],
+      });
+      writeJson(metadataPath, {
+        channel: 'production',
+        basePath: '/conspectus/webapp/',
+        sourceBranch: 'main',
+        commitSha: 'wrong-sha',
+        buildTimeUtc: '2026-03-01T10:20:30Z',
+        qualityRunId: '1001',
+        deployRunId: '2002',
+      });
+
+      const result = runVerifierFailure([
+        '--artifacts-json',
+        artifactsPath,
+        '--metadata',
+        metadataPath,
+        '--artifact-name',
+        artifactName,
+        '--commit-sha',
+        'abc123',
+        '--quality-run-id',
+        '1001',
+        '--deploy-run-id',
+        '2002',
+      ]);
+
+      expect(result.stderr).toContain(
+        'Metadata commitSha mismatch. Expected "abc123", got "wrong-sha".',
+      );
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "scripts/**/*.test.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -92,7 +92,7 @@ export default defineConfig({
     }),
   ],
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     environment: 'node',
   },
   resolve: {


### PR DESCRIPTION
## Summary\n- implement M2-03 producer-side production artifact handoff in Deploy Channels\n- enforce single production artifact + traceable metadata verification before dispatch\n- emit deterministic repository_dispatch payload for website repo consumption\n- document producer dispatch secret/target repo configuration and mark backlog item done\n\n## Acceptance Criteria Mapping\n1. Exactly one deployable artifact per successful main production run\n   - verified in workflow via artifact API + verifier script\n2. Traceable metadata (commitSha, buildTimeUtc, run IDs)\n   - generated into dist/deploy-metadata.json and validated\n3. Deterministic handoff payload fields\n   - dispatch payload contains commitSha, deployRunId, qualityRunId, artifactName\n4. No manual artifact selection\n   - payload identities are emitted automatically by producer workflow\n\n## Validation\n- npm run format\n- npm run lint\n- npm run typecheck\n- npm run test\n- npm run build\n\nCloses #17