### PR TITLE
M2-04: Finalize website artifact consumer integration contract

### DIFF
--- a/.github/workflows/deploy-channels.yml
+++ b/.github/workflows/deploy-channels.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   VITE_AZURE_CLIENT_ID: ${{ vars.VITE_AZURE_CLIENT_ID }}
-  WEBSITE_REPO_FULL_NAME: ${{ vars.WEBSITE_REPO_FULL_NAME || 'Jon2050/conspectus' }}
+  WEBSITE_REPO_FULL_NAME: ${{ vars.WEBSITE_REPO_FULL_NAME || 'Jon2050/Jon2050_Webpage' }}
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Operational notes:
 - `Deploy Channels` includes a hard post-deploy preview availability check; if GitHub Pages is unavailable or the preview URL is not reachable, the workflow fails.
 - `Preview Cleanup` removes stale `gh-pages/previews/<branch-slug>/` content when a branch is deleted.
 - Production handoff dispatch requires repository secret `WEBSITE_REPO_DISPATCH_TOKEN` (scoped to trigger workflow events in the website repo).
-- Production handoff target repository defaults to `Jon2050/conspectus` and can be overridden with repository variable `WEBSITE_REPO_FULL_NAME`.
+- Production handoff target repository defaults to `Jon2050/Jon2050_Webpage` and can be overridden with repository variable `WEBSITE_REPO_FULL_NAME`.
 - Canonical cross-repo producer/consumer architecture decision (M2-01): `docs/Architecture-and-Implementation-Plan.md` section `8.3`.
 
 ## Issue Labeling Rules

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -613,7 +613,7 @@ Producer/consumer CI contract (automation-only, no manual copy):
      - Payload MUST include `commitSha`, `deployRunId`, `qualityRunId`, and `artifactName`.
      - Producer dispatch token MUST be scoped to trigger workflow events in the website repository.
      - Producer workflow secret `WEBSITE_REPO_DISPATCH_TOKEN` is required for dispatch.
-     - Producer workflow variable `WEBSITE_REPO_FULL_NAME` may override the default consumer target (`Jon2050/conspectus`).
+     - Producer workflow variable `WEBSITE_REPO_FULL_NAME` may override the default consumer target (`Jon2050/Jon2050_Webpage`).
 2. Consumer (website repository):
    - Trigger on `repository_dispatch` (`conspectus-mobile-production-ready`) and read payload fields as the single source of artifact identity.
    - Resolve artifact deterministically via GitHub Actions API using `deployRunId`:
@@ -624,6 +624,8 @@ Producer/consumer CI contract (automation-only, no manual copy):
    - Validate identity match (`deploy-metadata.commitSha == dispatch.commitSha`, `deploy-metadata.deployRunId == dispatch.deployRunId`).
    - Perform atomic replace of website output directory `conspectus/webapp/` from the artifact contents.
    - Fail deployment if artifact download or metadata validation fails.
+   - Implementation note (M2-04): consumer automation is implemented in website repo workflow `.github/workflows/deploy.yml` on branch `master` in `Jon2050/Jon2050_Webpage`, with metadata validation script `scripts/validate-conspectus-deploy-metadata.mjs`.
+   - Consumer credential note (M2-04): website repo secret `CONSPECTUS_MOBILE_ARTIFACT_TOKEN` must provide `actions:read` access to `Jon2050/Conspectus-Mobile` artifacts.
 
 Failure and rollback behavior:
 1. If producer artifact generation fails, website deployment does not run for that revision.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -162,10 +162,10 @@ An issue is only considered done when:
 - Depends on: `M2-01, M2-02`
 - GitHub: [#17](https://github.com/Jon2050/Conspectus-Mobile/issues/17)
 
-### :green_circle: M2-04 Integrate PWA artifact consumption in website repo CI
+### :white_check_mark: M2-04 Integrate PWA artifact consumption in website repo CI
 - Label: `infra`
 - Milestone: `M2 - Website Integration + Early Deploy`
-- Summary: Work includes CI job in website repo to fetch approved PWA artifact and files to conspectus/webapp/ output location. It also covers Enforce atomic replace behavior.
+- Summary: Work includes CI job in website repo to fetch approved PWA artifact and files to conspectus/webapp/ output location. It also covers deterministic payload-driven artifact resolution, metadata identity validation, staged atomic replacement with rollback attempt, and fail-closed behavior.
 - Depends on: `M2-03`
 - GitHub: [#19](https://github.com/Jon2050/Conspectus-Mobile/issues/19)
 


### PR DESCRIPTION
## Summary\nFinalizes the M2-04 cross-repo artifact handoff integration from the PWA producer side and project source-of-truth docs.\n\n## What Changed\n- Updated producer dispatch default target repository to Jon2050/Jon2050_Webpage.\n- Updated README.md deployment channel notes with corrected default target.\n- Updated architecture section 8.3 with M2-04 implementation notes (consumer workflow + metadata validator + token requirement).\n- Marked backlog item M2-04 as done with acceptance-summary wording.\n\n## Acceptance Criteria Mapping\n1. Automatic deploy from dispatch payload: producer now defaults to the actual website consumer repo.\n2. Metadata + identity validation before publish: documented in architecture as enforced consumer contract (implemented in website PR #4).\n3. Atomic replace while protecting non-Conspectus content: documented staged swap + rollback semantics in source-of-truth docs.\n4. Fail-closed behavior: documented as required and implemented on consumer workflow side.\n\n## Verification\n- 
pm run format\n- 
pm run lint\n- 
pm run typecheck\n- 
pm run test\n- 
pm run build\n- 
pm run test:e2e skipped (no app runtime behavior/UI changes in this issue)\n\nWebsite implementation PR (merged): https://github.com/Jon2050/Jon2050_Webpage/pull/4\n\nCloses #19