### PR TITLE
M2-05: add production deployment smoke checks

### DIFF
--- a/.github/workflows/deploy-channels.yml
+++ b/.github/workflows/deploy-channels.yml
@@ -10,6 +10,7 @@ on:
 env:
   VITE_AZURE_CLIENT_ID: ${{ vars.VITE_AZURE_CLIENT_ID }}
   WEBSITE_REPO_FULL_NAME: ${{ vars.WEBSITE_REPO_FULL_NAME || 'Jon2050/Jon2050_Webpage' }}
+  PRODUCTION_APP_BASE_URL: ${{ vars.PRODUCTION_APP_BASE_URL || 'https://jon2050.de/conspectus/webapp/' }}
 
 permissions:
   contents: write
@@ -332,3 +333,26 @@ jobs:
           fi
 
           echo "Dispatched conspectus-mobile-production-ready to ${WEBSITE_REPO_FULL_NAME}."
+
+  verify-production-smoke:
+    name: Verify Production Deployment Smoke
+    runs-on: ubuntu-latest
+    needs:
+      - publish-production-artifact
+      - dispatch-production-ready
+    if: needs.dispatch-production-ready.result == 'success'
+    steps:
+      - name: Checkout source commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.publish-production-artifact.outputs.commit_sha }}
+
+      - name: Run production deployment smoke checks
+        run: >-
+          node scripts/verify-production-deploy-smoke.mjs
+          --base-url "${{ env.PRODUCTION_APP_BASE_URL }}"
+          --commit-sha "${{ needs.publish-production-artifact.outputs.commit_sha }}"
+          --deploy-run-id "${{ needs.publish-production-artifact.outputs.deploy_run_id }}"
+          --max-attempts 36
+          --retry-delay-seconds 10
+          --request-timeout-ms 10000

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -580,7 +580,7 @@ Pipeline stages:
 4. On successful `main` quality runs, publish a production artifact with deployment metadata (`commit SHA`, UTC build time, run IDs).
 5. `Preview Cleanup` removes stale preview paths when branches are deleted.
 6. Website repo consumes main artifact and deploys to `jon2050.de/conspectus/webapp/`.
-7. Post-deploy smoke check for app shell availability.
+7. Post-dispatch production smoke checks validate deployed app route, manifest, service worker URL, HTML bootstrap markers, and `deploy-metadata.json` identity fields.
 
 ## 8.3 Approved Cross-Repo Deployment Architecture (M2-01)
 
@@ -614,6 +614,8 @@ Producer/consumer CI contract (automation-only, no manual copy):
      - Producer dispatch token MUST be scoped to trigger workflow events in the website repository.
      - Producer workflow secret `WEBSITE_REPO_DISPATCH_TOKEN` is required for dispatch.
      - Producer workflow variable `WEBSITE_REPO_FULL_NAME` may override the default consumer target (`Jon2050/Jon2050_Webpage`).
+   - After dispatch, producer workflow MUST run deployment smoke checks against the production app base URL (`https://jon2050.de/conspectus/webapp/` by default; override via `PRODUCTION_APP_BASE_URL` repository variable).
+   - Smoke checks MUST fail closed, verify deployed `deploy-metadata.json` identity fields (`commitSha`, `deployRunId`) against expected handoff context, and include deploy identity context in logs for correlation with artifact metadata and dispatch payload.
 2. Consumer (website repository):
    - Trigger on `repository_dispatch` (`conspectus-mobile-production-ready`) and read payload fields as the single source of artifact identity.
    - Resolve artifact deterministically via GitHub Actions API using `deployRunId`:

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -169,7 +169,7 @@ An issue is only considered done when:
 - Depends on: `M2-03`
 - GitHub: [#19](https://github.com/Jon2050/Conspectus-Mobile/issues/19)
 
-### :green_circle: M2-05 Add deployment smoke checks in website pipeline
+### :white_check_mark: M2-05 Add deployment smoke checks in website pipeline
 - Label: `test`
 - Milestone: `M2 - Website Integration + Early Deploy`
 - Summary: Work includes HTTP checks for app route, manifest, and service worker URLs and HTML response sanity check for app bootstrap. It also covers Fail deploy if checks fail.

--- a/scripts/verify-production-deploy-smoke.d.mts
+++ b/scripts/verify-production-deploy-smoke.d.mts
@@ -1,0 +1,20 @@
+export interface SmokeCheckOptions {
+  baseUrl: string;
+  commitSha: string;
+  deployRunId: string;
+  maxAttempts: number;
+  retryDelaySeconds: number;
+  requestTimeoutMs: number;
+}
+
+export type SleepFunction = (milliseconds: number) => Promise<void>;
+
+export function parseArgs(argv: string[]): SmokeCheckOptions;
+
+export function runSmokeChecks(
+  options: SmokeCheckOptions,
+  fetchImpl?: typeof fetch,
+  sleepImpl?: SleepFunction,
+): Promise<void>;
+
+export function main(argv?: string[]): Promise<void>;

--- a/scripts/verify-production-deploy-smoke.mjs
+++ b/scripts/verify-production-deploy-smoke.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import { setTimeout as delay } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
+
+const REQUIRED_ARGS = new Set(['baseUrl', 'commitSha', 'deployRunId']);
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const normalizeBaseUrl = (value) => {
+  const trimmedValue = value.trim();
+  assert(trimmedValue.length > 0, 'Missing required --base-url argument.');
+  assert(
+    trimmedValue.startsWith('http://') || trimmedValue.startsWith('https://'),
+    `Invalid --base-url value "${trimmedValue}". Use an absolute http/https URL.`,
+  );
+  return trimmedValue.endsWith('/') ? trimmedValue : `${trimmedValue}/`;
+};
+
+export const parseArgs = (argv) => {
+  const args = {
+    baseUrl: '',
+    commitSha: '',
+    deployRunId: '',
+    maxAttempts: '24',
+    retryDelaySeconds: '10',
+    requestTimeoutMs: '10000',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+    if (!current.startsWith('--')) {
+      continue;
+    }
+
+    const key = current.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    if (!(key in args)) {
+      continue;
+    }
+
+    args[key] = argv[index + 1] ?? '';
+    index += 1;
+  }
+
+  for (const requiredArg of REQUIRED_ARGS) {
+    assert(args[requiredArg], `Missing required --${requiredArg} argument.`);
+  }
+
+  const maxAttempts = Number(args.maxAttempts);
+  const retryDelaySeconds = Number(args.retryDelaySeconds);
+  const requestTimeoutMs = Number(args.requestTimeoutMs);
+
+  assert(
+    Number.isInteger(maxAttempts) && maxAttempts > 0,
+    '--max-attempts must be a positive integer.',
+  );
+  assert(
+    Number.isInteger(retryDelaySeconds) && retryDelaySeconds >= 0,
+    '--retry-delay-seconds must be a non-negative integer.',
+  );
+  assert(
+    Number.isInteger(requestTimeoutMs) && requestTimeoutMs > 0,
+    '--request-timeout-ms must be a positive integer.',
+  );
+
+  return {
+    baseUrl: normalizeBaseUrl(args.baseUrl),
+    commitSha: args.commitSha,
+    deployRunId: args.deployRunId,
+    maxAttempts,
+    retryDelaySeconds,
+    requestTimeoutMs,
+  };
+};
+
+const buildContextLabel = ({ commitSha, deployRunId }) =>
+  `commitSha=${commitSha} deployRunId=${deployRunId}`;
+
+const ensureBootstrapMarkers = (html) => {
+  assert(
+    /id=["']app["']/.test(html),
+    'HTML bootstrap sanity check failed: missing app root element id="app".',
+  );
+  assert(
+    /<script\b[^>]*type=["']module["'][^>]*>/i.test(html),
+    'HTML bootstrap sanity check failed: missing module bootstrap script tag.',
+  );
+};
+
+const ensureDeployIdentity = (metadataText, options) => {
+  let metadata;
+  try {
+    metadata = JSON.parse(metadataText);
+  } catch {
+    throw new Error('deploy-metadata is not valid JSON.');
+  }
+
+  const expectedBasePath = new URL(options.baseUrl).pathname;
+  assert(
+    metadata.basePath === expectedBasePath,
+    `deploy-metadata basePath mismatch. Expected "${expectedBasePath}", got "${metadata.basePath}".`,
+  );
+  assert(
+    String(metadata.commitSha) === options.commitSha,
+    `deploy-metadata commitSha mismatch. Expected "${options.commitSha}", got "${metadata.commitSha}".`,
+  );
+  assert(
+    String(metadata.deployRunId) === options.deployRunId,
+    `deploy-metadata deployRunId mismatch. Expected "${options.deployRunId}", got "${metadata.deployRunId}".`,
+  );
+};
+
+const fetchWithTimeout = async (fetchImpl, url, requestTimeoutMs) => {
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), requestTimeoutMs);
+
+  try {
+    return await fetchImpl(url, {
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: {
+        accept: 'text/html,*/*;q=0.9',
+      },
+    });
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+};
+
+const createChecks = (options) => [
+  {
+    name: 'app-route',
+    url: options.baseUrl,
+    validateBody: ensureBootstrapMarkers,
+  },
+  {
+    name: 'manifest',
+    url: new URL('manifest.webmanifest', options.baseUrl).toString(),
+  },
+  {
+    name: 'service-worker',
+    url: new URL('sw.js', options.baseUrl).toString(),
+  },
+  {
+    name: 'deploy-metadata',
+    url: new URL('deploy-metadata.json', options.baseUrl).toString(),
+    validateBody: (bodyText) => ensureDeployIdentity(bodyText, options),
+  },
+];
+
+export const runSmokeChecks = async (options, fetchImpl = fetch, sleepImpl = delay) => {
+  const contextLabel = buildContextLabel(options);
+  const checks = createChecks(options);
+  let lastErrors = [];
+
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
+    lastErrors = [];
+    console.log(
+      `[verify-production-deploy-smoke] ${contextLabel} starting attempt ${attempt}/${options.maxAttempts}.`,
+    );
+
+    for (const check of checks) {
+      try {
+        const response = await fetchWithTimeout(fetchImpl, check.url, options.requestTimeoutMs);
+        assert(response.status === 200, `${check.name} returned HTTP ${response.status}.`);
+
+        if (check.validateBody) {
+          const bodyText = await response.text();
+          check.validateBody(bodyText);
+        }
+
+        console.log(
+          `[verify-production-deploy-smoke] ${contextLabel} check=${check.name} status=${response.status} url=${check.url}`,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const checkError = `check=${check.name} url=${check.url} error="${message}"`;
+        lastErrors.push(checkError);
+        console.error(`[verify-production-deploy-smoke] ${contextLabel} ${checkError}`);
+      }
+    }
+
+    if (lastErrors.length === 0) {
+      console.log(
+        `[verify-production-deploy-smoke] ${contextLabel} all deployment smoke checks passed for ${options.baseUrl}`,
+      );
+      return;
+    }
+
+    if (attempt < options.maxAttempts) {
+      console.log(
+        `[verify-production-deploy-smoke] ${contextLabel} attempt ${attempt}/${options.maxAttempts} failed; retrying in ${options.retryDelaySeconds}s.`,
+      );
+      await sleepImpl(options.retryDelaySeconds * 1000);
+    }
+  }
+
+  throw new Error(
+    `[verify-production-deploy-smoke] ${contextLabel} failed after ${options.maxAttempts} attempt(s). Last errors: ${lastErrors.join(' | ')}`,
+  );
+};
+
+export const main = async (argv = process.argv.slice(2)) => {
+  const options = parseArgs(argv);
+  await runSmokeChecks(options);
+};
+
+const isCliInvocation =
+  typeof process.argv[1] === 'string' && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isCliInvocation) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-production-deploy-smoke.test.ts
+++ b/scripts/verify-production-deploy-smoke.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { parseArgs, runSmokeChecks } from './verify-production-deploy-smoke.mjs';
+
+const baseOptions = {
+  baseUrl: 'https://jon2050.de/conspectus/webapp/',
+  commitSha: 'abc123',
+  deployRunId: '2002',
+  maxAttempts: 1,
+  retryDelaySeconds: 0,
+  requestTimeoutMs: 1000,
+};
+
+const appHtml = `<!doctype html>
+<html lang="en">
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/conspectus/webapp/assets/index.js"></script>
+  </body>
+</html>`;
+
+const validDeployMetadata = JSON.stringify({
+  channel: 'production',
+  basePath: '/conspectus/webapp/',
+  commitSha: 'abc123',
+  deployRunId: '2002',
+});
+
+const asResponse = (status: number, body: string) =>
+  new Response(body, {
+    status,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+    },
+  });
+
+type FetchMock = ReturnType<typeof vi.fn> & typeof fetch;
+type MockHttpResponse = {
+  status: number;
+  body: string;
+};
+
+const resolveUrl = (input: string | URL | Request) => {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+};
+
+const createFetchByUrl = (responses: Record<string, MockHttpResponse>): FetchMock =>
+  vi.fn(async (input: string | URL | Request) => {
+    const resolvedUrl = resolveUrl(input);
+    const response = responses[resolvedUrl];
+    if (response) {
+      return asResponse(response.status, response.body);
+    }
+
+    return asResponse(404, 'not found');
+  }) as FetchMock;
+
+const createHealthyResponses = (): Record<string, MockHttpResponse> => ({
+  'https://jon2050.de/conspectus/webapp/': {
+    status: 200,
+    body: appHtml,
+  },
+  'https://jon2050.de/conspectus/webapp/manifest.webmanifest': {
+    status: 200,
+    body: '{"start_url":"/conspectus/webapp/","scope":"/conspectus/webapp/"}',
+  },
+  'https://jon2050.de/conspectus/webapp/sw.js': {
+    status: 200,
+    body: 'self.addEventListener("install", () => {});',
+  },
+  'https://jon2050.de/conspectus/webapp/deploy-metadata.json': {
+    status: 200,
+    body: validDeployMetadata,
+  },
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('verify-production-deploy-smoke script', () => {
+  it('passes when required deployment URLs are reachable and identity matches', async () => {
+    const fetchMock = createFetchByUrl(createHealthyResponses());
+    const sleepMock = vi.fn(async () => undefined);
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await expect(runSmokeChecks(baseOptions, fetchMock, sleepMock)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(consoleLog).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'commitSha=abc123 deployRunId=2002 all deployment smoke checks passed',
+      ),
+    );
+  });
+
+  it('fails when manifest URL check is not HTTP 200', async () => {
+    const responses = createHealthyResponses();
+    responses['https://jon2050.de/conspectus/webapp/manifest.webmanifest'] = {
+      status: 404,
+      body: 'missing',
+    };
+    const fetchMock = createFetchByUrl(responses);
+    const sleepMock = vi.fn(async () => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(runSmokeChecks(baseOptions, fetchMock, sleepMock)).rejects.toThrow(
+      'check=manifest',
+    );
+  });
+
+  it('fails when service worker URL check is not HTTP 200', async () => {
+    const responses = createHealthyResponses();
+    responses['https://jon2050.de/conspectus/webapp/sw.js'] = {
+      status: 404,
+      body: 'missing',
+    };
+    const fetchMock = createFetchByUrl(responses);
+    const sleepMock = vi.fn(async () => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(runSmokeChecks(baseOptions, fetchMock, sleepMock)).rejects.toThrow(
+      'check=service-worker',
+    );
+  });
+
+  it('fails HTML sanity check when bootstrap markers are missing', async () => {
+    const responses = createHealthyResponses();
+    responses['https://jon2050.de/conspectus/webapp/'] = {
+      status: 200,
+      body: '<!doctype html><html><body><main>Missing app root</main></body></html>',
+    };
+    const fetchMock = createFetchByUrl(responses);
+    const sleepMock = vi.fn(async () => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(runSmokeChecks(baseOptions, fetchMock, sleepMock)).rejects.toThrow(
+      'check=app-route',
+    );
+  });
+
+  it('fails when deploy metadata identity does not match expected deploy context', async () => {
+    const responses = createHealthyResponses();
+    responses['https://jon2050.de/conspectus/webapp/deploy-metadata.json'] = {
+      status: 200,
+      body: JSON.stringify({
+        basePath: '/conspectus/webapp/',
+        commitSha: 'different-sha',
+        deployRunId: '2002',
+      }),
+    };
+    const fetchMock = createFetchByUrl(responses);
+    const sleepMock = vi.fn(async () => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(runSmokeChecks(baseOptions, fetchMock, sleepMock)).rejects.toThrow(
+      'check=deploy-metadata',
+    );
+  });
+
+  it('retries failed checks and succeeds when a later attempt passes', async () => {
+    const responses = createHealthyResponses();
+    let manifestAttempts = 0;
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const resolvedUrl = resolveUrl(input);
+      if (resolvedUrl === 'https://jon2050.de/conspectus/webapp/manifest.webmanifest') {
+        manifestAttempts += 1;
+        if (manifestAttempts === 1) {
+          return asResponse(503, 'temporarily unavailable');
+        }
+      }
+
+      const response = responses[resolvedUrl];
+      if (response) {
+        return asResponse(response.status, response.body);
+      }
+
+      return asResponse(404, 'not found');
+    }) as FetchMock;
+    const sleepMock = vi.fn(async () => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(
+      runSmokeChecks(
+        {
+          ...baseOptions,
+          maxAttempts: 2,
+          retryDelaySeconds: 1,
+        },
+        fetchMock,
+        sleepMock,
+      ),
+    ).resolves.toBeUndefined();
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+    expect(sleepMock).toHaveBeenCalledWith(1000);
+  });
+
+  it('normalizes cli args and applies numeric defaults', () => {
+    const args = parseArgs([
+      '--base-url',
+      'https://jon2050.de/conspectus/webapp',
+      '--commit-sha',
+      'abc123',
+      '--deploy-run-id',
+      '2002',
+    ]);
+
+    expect(args).toEqual({
+      baseUrl: 'https://jon2050.de/conspectus/webapp/',
+      commitSha: 'abc123',
+      deployRunId: '2002',
+      maxAttempts: 24,
+      retryDelaySeconds: 10,
+      requestTimeoutMs: 10000,
+    });
+  });
+});

--- a/scripts/verify-production-handoff.mjs
+++ b/scripts/verify-production-handoff.mjs
@@ -114,7 +114,7 @@ const main = () => {
   });
 
   console.log(
-    `[verify-production-handoff] verified artifact "${args.artifactName}" and deploy metadata traceability.`,
+    `[verify-production-handoff] commitSha=${args.commitSha} deployRunId=${args.deployRunId} verified artifact "${args.artifactName}" and deploy metadata traceability.`,
   );
 };
 

--- a/scripts/verify-production-handoff.test.ts
+++ b/scripts/verify-production-handoff.test.ts
@@ -83,7 +83,9 @@ describe('verify-production-handoff script', () => {
         '2002',
       ]);
 
-      expect(result.stdout).toContain('[verify-production-handoff] verified artifact');
+      expect(result.stdout).toContain(
+        '[verify-production-handoff] commitSha=abc123 deployRunId=2002 verified artifact',
+      );
     } finally {
       rmSync(fixturePath, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Summary\nImplements issue #21 (M2-05) in this repository by adding production deployment smoke verification in the Deploy Channels workflow and covering it with tests/docs updates.\n\n## Acceptance Criteria Mapping\n1. Pipeline blocks bad deployments\n- Added scripts/verify-production-deploy-smoke.mjs and wired it as required workflow job erify-production-smoke.\n- Script fails closed on bad HTTP status, missing HTML bootstrap markers, and deploy identity mismatch via deploy-metadata.json (commitSha/deployRunId).\n\n2. Smoke checks run after every deploy\n- erify-production-smoke runs on every successful production dispatch path (main deploy flow) and fails the deploy workflow if checks do not pass.\n\n3. Logs include deploy identity context\n- Smoke verifier logs include commitSha and deployRunId for each attempt/check.\n- Updated erify-production-handoff success log to include the same identity context.\n\n## Tests\n- Added scripts/verify-production-deploy-smoke.test.ts for success/failure/retry/identity scenarios.\n- Updated scripts/verify-production-handoff.test.ts for identity log assertion.\n\n## Docs\n- Updated architecture source-of-truth (docs/Architecture-and-Implementation-Plan.md) with implemented smoke-check contract details.\n- Updated backlog status marker for M2-05 to done in docs/GitHub-Issues-MVP-Backlog.md.\n\nCloses #21