### PR TITLE
Fix deployment smoke workflow sequencing for cross-repo handoff

### DIFF
--- a/.github/workflows/deploy-channels.yml
+++ b/.github/workflows/deploy-channels.yml
@@ -10,7 +10,6 @@ on:
 env:
   VITE_AZURE_CLIENT_ID: ${{ vars.VITE_AZURE_CLIENT_ID }}
   WEBSITE_REPO_FULL_NAME: ${{ vars.WEBSITE_REPO_FULL_NAME || 'Jon2050/Jon2050_Webpage' }}
-  PRODUCTION_APP_BASE_URL: ${{ vars.PRODUCTION_APP_BASE_URL || 'https://jon2050.de/conspectus/webapp/' }}
 
 permissions:
   contents: write
@@ -333,26 +332,3 @@ jobs:
           fi
 
           echo "Dispatched conspectus-mobile-production-ready to ${WEBSITE_REPO_FULL_NAME}."
-
-  verify-production-smoke:
-    name: Verify Production Deployment Smoke
-    runs-on: ubuntu-latest
-    needs:
-      - publish-production-artifact
-      - dispatch-production-ready
-    if: needs.dispatch-production-ready.result == 'success'
-    steps:
-      - name: Checkout source commit
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.publish-production-artifact.outputs.commit_sha }}
-
-      - name: Run production deployment smoke checks
-        run: >-
-          node scripts/verify-production-deploy-smoke.mjs
-          --base-url "${{ env.PRODUCTION_APP_BASE_URL }}"
-          --commit-sha "${{ needs.publish-production-artifact.outputs.commit_sha }}"
-          --deploy-run-id "${{ needs.publish-production-artifact.outputs.deploy_run_id }}"
-          --max-attempts 36
-          --retry-delay-seconds 10
-          --request-timeout-ms 10000

--- a/.github/workflows/website-deploy-smoke.yml
+++ b/.github/workflows/website-deploy-smoke.yml
@@ -1,0 +1,41 @@
+name: Website Deploy Smoke
+
+on:
+  workflow_run:
+    workflows:
+      - Deploy Channels
+    types:
+      - completed
+
+env:
+  PRODUCTION_APP_BASE_URL: ${{ vars.PRODUCTION_APP_BASE_URL || 'https://jon2050.de/conspectus/webapp/' }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: website-deploy-smoke-${{ github.event.workflow_run.id || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  verify-production-smoke:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Run production deployment smoke checks
+        run: >-
+          node scripts/verify-production-deploy-smoke.mjs
+          --base-url "${{ env.PRODUCTION_APP_BASE_URL }}"
+          --commit-sha "${{ github.event.workflow_run.head_sha }}"
+          --deploy-run-id "${{ github.event.workflow_run.id }}"
+          --max-attempts 36
+          --retry-delay-seconds 10
+          --request-timeout-ms 10000

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -580,7 +580,8 @@ Pipeline stages:
 4. On successful `main` quality runs, publish a production artifact with deployment metadata (`commit SHA`, UTC build time, run IDs).
 5. `Preview Cleanup` removes stale preview paths when branches are deleted.
 6. Website repo consumes main artifact and deploys to `jon2050.de/conspectus/webapp/`.
-7. Post-dispatch production smoke checks validate deployed app route, manifest, service worker URL, HTML bootstrap markers, and `deploy-metadata.json` identity fields.
+7. `Deploy Channels` publishes preview/artifact outputs and dispatches the production-ready event to the website repository.
+8. `Website Deploy Smoke` (separate workflow) runs after successful `Deploy Channels` main runs and validates deployed app route, manifest, service worker URL, HTML bootstrap markers, and `deploy-metadata.json` identity fields.
 
 ## 8.3 Approved Cross-Repo Deployment Architecture (M2-01)
 
@@ -614,8 +615,8 @@ Producer/consumer CI contract (automation-only, no manual copy):
      - Producer dispatch token MUST be scoped to trigger workflow events in the website repository.
      - Producer workflow secret `WEBSITE_REPO_DISPATCH_TOKEN` is required for dispatch.
      - Producer workflow variable `WEBSITE_REPO_FULL_NAME` may override the default consumer target (`Jon2050/Jon2050_Webpage`).
-   - After dispatch, producer workflow MUST run deployment smoke checks against the production app base URL (`https://jon2050.de/conspectus/webapp/` by default; override via `PRODUCTION_APP_BASE_URL` repository variable).
-   - Smoke checks MUST fail closed, verify deployed `deploy-metadata.json` identity fields (`commitSha`, `deployRunId`) against expected handoff context, and include deploy identity context in logs for correlation with artifact metadata and dispatch payload.
+   - Post-deploy production smoke checks MUST run in separate workflow `Website Deploy Smoke`, triggered by successful `Deploy Channels` runs on `main`.
+   - Smoke checks MUST target the production app base URL (`https://jon2050.de/conspectus/webapp/` by default; override via `PRODUCTION_APP_BASE_URL` repository variable), fail closed, verify deployed `deploy-metadata.json` identity fields (`commitSha`, `deployRunId`) against expected handoff context, and include deploy identity context in logs.
 2. Consumer (website repository):
    - Trigger on `repository_dispatch` (`conspectus-mobile-production-ready`) and read payload fields as the single source of artifact identity.
    - Resolve artifact deterministically via GitHub Actions API using `deployRunId`:


### PR DESCRIPTION
## Context\nFollow-up fix for #103 (M2-05 delivery).\n\n## Problem\nPlacing production smoke checks inside Deploy Channels caused the website consumer workflow to fail artifact resolution because it requires the producer run to already be success.\n\n## Fix\n- Remove erify-production-smoke job from Deploy Channels.\n- Add dedicated Website Deploy Smoke workflow triggered by successful Deploy Channels completion on main push runs.\n- Keep same smoke script and identity checks (commitSha, deployRunId) against deploy-metadata.json.\n- Update architecture contract docs to reflect the decoupled sequencing.\n\n## Verification\n- 
pm run format\n- 
pm run lint\n- 
pm run typecheck\n- 
pm run test\n- 
pm run build\n(all passed locally)