### PR TITLE
Fix Website Deploy Smoke trigger condition

### DIFF
--- a/.github/workflows/website-deploy-smoke.yml
+++ b/.github/workflows/website-deploy-smoke.yml
@@ -21,7 +21,6 @@ jobs:
   verify-production-smoke:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Follow-up to #104.\n\nWebsite Deploy Smoke was skipped because workflow_run.event for Deploy Channels is workflow_run, not push.\n\nThis removes the incorrect event guard so the smoke workflow runs for successful Deploy Channels runs on main.