### PR TITLE
ci: fix deploy channels prepare-context checkout

### DIFF
--- a/.github/workflows/deploy-channels.yml
+++ b/.github/workflows/deploy-channels.yml
@@ -37,6 +37,9 @@ jobs:
       preview_base_prefix: ${{ steps.context.outputs.preview_base_prefix }}
       preview_base_path: ${{ steps.context.outputs.preview_base_path }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Resolve deployment context
         id: context
         env:


### PR DESCRIPTION
The prepare-context job was recently refactored to use a Python script but lacked a repository checkout step, causing the workflow to fail to find the script.

Agent: Claude
