### PR TITLE
chore: show test report directly in GitHub Actions Summary

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -114,6 +114,13 @@ jobs:
           npx vitest run --config vite.config.ts --reporter=default --reporter=junit --outputFile=reports/vitest/junit-app.xml | tee reports/vitest/vitest-app.log
           npx vitest run --config vitest.scripts.config.ts --reporter=default --reporter=junit --outputFile=reports/vitest/junit-scripts.xml | tee reports/vitest/vitest-scripts.log
 
+      - name: Publish unit test report summary
+        if: always()
+        run: >-
+          node scripts/publish-test-summary.mjs
+          --title "Unit Test Report"
+          --files reports/vitest/junit-app.xml reports/vitest/junit-scripts.xml
+
       - name: Upload unit test reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -206,6 +213,13 @@ jobs:
         env:
           PLAYWRIGHT_WEB_SERVER_BUILD: '0'
         run: npm run test:e2e
+
+      - name: Publish e2e test report summary
+        if: always()
+        run: >-
+          node scripts/publish-test-summary.mjs
+          --title "E2E Test Report"
+          --files reports/playwright/junit.xml
 
       - name: Upload e2e test reports
         if: always()

--- a/README.md
+++ b/README.md
@@ -112,7 +112,14 @@ Local quality scripts:
 
 CI runs these checks on every push and every pull request.
 
-CI test report artifacts:
+CI test report view in GitHub:
+
+- Open a `Quality` run and use the `Summary` tab.
+- The run summary includes:
+  - `Unit Test Report` (all parsed Vitest test cases from JUnit XML)
+  - `E2E Test Report` (all parsed Playwright test cases from JUnit XML)
+
+CI test report artifacts (raw files):
 
 - `unit-test-reports`: Vitest JUnit XML + logs from app and scripts test suites.
 - `e2e-test-reports`: Playwright JUnit XML + HTML report + raw test result attachments.

--- a/scripts/publish-test-summary.mjs
+++ b/scripts/publish-test-summary.mjs
@@ -1,0 +1,187 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  let title = 'Test Report';
+  const files = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--title' && index + 1 < argv.length) {
+      title = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (token === '--files') {
+      for (let fileIndex = index + 1; fileIndex < argv.length; fileIndex += 1) {
+        files.push(argv[fileIndex]);
+      }
+      break;
+    }
+  }
+
+  if (files.length === 0) {
+    throw new Error(
+      'Missing --files arguments. Example: --files reports/vitest/junit-app.xml reports/vitest/junit-scripts.xml',
+    );
+  }
+
+  return { title, files };
+}
+
+function decodeXmlEntities(value) {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+function readAttribute(attributeBlock, attributeName) {
+  const escapedAttributeName = attributeName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`${escapedAttributeName}="([^"]*)"`, 'i');
+  const match = attributeBlock.match(regex);
+  if (!match) {
+    return '';
+  }
+
+  return decodeXmlEntities(match[1]);
+}
+
+function detectStatus(testcaseBody) {
+  if (/<failure\b|<error\b/i.test(testcaseBody)) {
+    return 'failed';
+  }
+
+  if (/<skipped\b/i.test(testcaseBody)) {
+    return 'skipped';
+  }
+
+  return 'passed';
+}
+
+function parseJunitFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return {
+      filePath,
+      missing: true,
+      testCases: [],
+    };
+  }
+
+  const xml = fs.readFileSync(filePath, 'utf8');
+  const testcaseRegex = /<testcase\b([^>]*?)(?:\/>|>([\s\S]*?)<\/testcase>)/gi;
+  const testCases = [];
+
+  for (const match of xml.matchAll(testcaseRegex)) {
+    const attributeBlock = match[1] ?? '';
+    const testcaseBody = match[2] ?? '';
+    const suiteName = readAttribute(attributeBlock, 'classname');
+    const testName = readAttribute(attributeBlock, 'name');
+    const durationSeconds = readAttribute(attributeBlock, 'time');
+    const status = detectStatus(testcaseBody);
+
+    testCases.push({
+      filePath,
+      suiteName,
+      testName,
+      durationSeconds,
+      status,
+    });
+  }
+
+  return {
+    filePath,
+    missing: false,
+    testCases,
+  };
+}
+
+function statusIcon(status) {
+  if (status === 'passed') {
+    return 'PASS';
+  }
+
+  if (status === 'skipped') {
+    return 'SKIP';
+  }
+
+  return 'FAIL';
+}
+
+function countByStatus(testCases, status) {
+  return testCases.filter((testCase) => testCase.status === status).length;
+}
+
+function toMarkdownTableRows(testCases) {
+  return testCases
+    .map((testCase) => {
+      const suiteDisplay = testCase.suiteName || '(no suite)';
+      const testDisplay = testCase.testName || '(unnamed testcase)';
+      const durationDisplay = testCase.durationSeconds || '-';
+      const fileDisplay = path.relative(process.cwd(), testCase.filePath);
+      return `| ${statusIcon(testCase.status)} | ${suiteDisplay} | ${testDisplay} | ${durationDisplay} | ${fileDisplay} |`;
+    })
+    .join('\n');
+}
+
+function buildSummaryMarkdown(title, parsedFiles) {
+  const testCases = parsedFiles.flatMap((parsedFile) => parsedFile.testCases);
+  const missingFiles = parsedFiles.filter((parsedFile) => parsedFile.missing);
+  const totalCount = testCases.length;
+  const passedCount = countByStatus(testCases, 'passed');
+  const failedCount = countByStatus(testCases, 'failed');
+  const skippedCount = countByStatus(testCases, 'skipped');
+  const parsedCount = parsedFiles.length - missingFiles.length;
+
+  const lines = [];
+  lines.push(`## ${title}`);
+  lines.push('');
+  lines.push(`- Parsed report files: ${parsedCount}/${parsedFiles.length}`);
+  lines.push(
+    `- Totals: ${totalCount} tests | ${passedCount} passed | ${failedCount} failed | ${skippedCount} skipped`,
+  );
+
+  if (missingFiles.length > 0) {
+    lines.push(
+      `- Missing report files: ${missingFiles.map((file) => `\`${file.filePath}\``).join(', ')}`,
+    );
+  }
+
+  lines.push('');
+
+  if (totalCount === 0) {
+    lines.push('No test cases found in the provided JUnit report files.');
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  lines.push('| Status | Suite | Test Case | Duration (s) | Report File |');
+  lines.push('| --- | --- | --- | ---: | --- |');
+  lines.push(toMarkdownTableRows(testCases));
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function publishSummary(markdown) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, `${markdown}\n`, 'utf8');
+    return;
+  }
+
+  // Fallback for local script execution.
+  console.log(markdown);
+}
+
+function main() {
+  const { title, files } = parseArgs(process.argv.slice(2));
+  const parsedFiles = files.map((filePath) => parseJunitFile(filePath));
+  const markdown = buildSummaryMarkdown(title, parsedFiles);
+  publishSummary(markdown);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add scripts/publish-test-summary.mjs to parse JUnit XML and publish markdown tables to GITHUB_STEP_SUMMARY
- publish Unit Test Report and E2E Test Report sections in Quality workflow
- keep raw artifacts as before, and document Summary-tab location in README

## Result
- no ZIP download required for normal test visibility
- all current and future Vitest/Playwright test cases are listed in the GitHub run Summary page

## Validation
- npm run format
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm run test:e2e