### PR TITLE
chore: show durations in ms and prioritize failures in test summary

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -121,16 +121,6 @@ jobs:
           --title "Unit Test Report"
           --files reports/vitest/junit-app.xml reports/vitest/junit-scripts.xml
 
-      - name: Upload unit test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-test-reports
-          if-no-files-found: ignore
-          retention-days: 30
-          path: |
-            reports/vitest/
-
       - name: Build and verify production channel paths/scope
         env:
           DEPLOY_CHANNEL: production
@@ -220,15 +210,3 @@ jobs:
           node scripts/publish-test-summary.mjs
           --title "E2E Test Report"
           --files reports/playwright/junit.xml
-
-      - name: Upload e2e test reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-test-reports
-          if-no-files-found: ignore
-          retention-days: 30
-          path: |
-            reports/playwright/
-            playwright-report/
-            test-results/

--- a/README.md
+++ b/README.md
@@ -119,11 +119,6 @@ CI test report view in GitHub:
   - `Unit Test Report` (all parsed Vitest test cases from JUnit XML)
   - `E2E Test Report` (all parsed Playwright test cases from JUnit XML)
 
-CI test report artifacts (raw files):
-
-- `unit-test-reports`: Vitest JUnit XML + logs from app and scripts test suites.
-- `e2e-test-reports`: Playwright JUnit XML + HTML report + raw test result attachments.
-
 ## Deployment Channels
 
 Deployment is split into two CI-gated channels:

--- a/scripts/publish-test-summary.mjs
+++ b/scripts/publish-test-summary.mjs
@@ -62,6 +62,19 @@ function detectStatus(testcaseBody) {
   return 'passed';
 }
 
+function parseDurationMilliseconds(durationSecondsValue) {
+  if (!durationSecondsValue) {
+    return null;
+  }
+
+  const seconds = Number.parseFloat(durationSecondsValue);
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return null;
+  }
+
+  return Math.round(seconds * 1000);
+}
+
 function parseJunitFile(filePath) {
   if (!fs.existsSync(filePath)) {
     return {
@@ -82,12 +95,13 @@ function parseJunitFile(filePath) {
     const testName = readAttribute(attributeBlock, 'name');
     const durationSeconds = readAttribute(attributeBlock, 'time');
     const status = detectStatus(testcaseBody);
+    const durationMilliseconds = parseDurationMilliseconds(durationSeconds);
 
     testCases.push({
       filePath,
       suiteName,
       testName,
-      durationSeconds,
+      durationMilliseconds,
       status,
     });
   }
@@ -115,12 +129,40 @@ function countByStatus(testCases, status) {
   return testCases.filter((testCase) => testCase.status === status).length;
 }
 
+function statusPriority(status) {
+  if (status === 'failed') {
+    return 0;
+  }
+
+  if (status === 'skipped') {
+    return 1;
+  }
+
+  return 2;
+}
+
+function sortTestCasesForDisplay(testCases) {
+  return testCases
+    .map((testCase, index) => ({ testCase, index }))
+    .sort((left, right) => {
+      const statusDelta =
+        statusPriority(left.testCase.status) - statusPriority(right.testCase.status);
+      if (statusDelta !== 0) {
+        return statusDelta;
+      }
+
+      return left.index - right.index;
+    })
+    .map((entry) => entry.testCase);
+}
+
 function toMarkdownTableRows(testCases) {
   return testCases
     .map((testCase) => {
       const suiteDisplay = testCase.suiteName || '(no suite)';
       const testDisplay = testCase.testName || '(unnamed testcase)';
-      const durationDisplay = testCase.durationSeconds || '-';
+      const durationDisplay =
+        testCase.durationMilliseconds === null ? '-' : `${testCase.durationMilliseconds} ms`;
       const fileDisplay = path.relative(process.cwd(), testCase.filePath);
       return `| ${statusIcon(testCase.status)} | ${suiteDisplay} | ${testDisplay} | ${durationDisplay} | ${fileDisplay} |`;
     })
@@ -135,6 +177,7 @@ function buildSummaryMarkdown(title, parsedFiles) {
   const failedCount = countByStatus(testCases, 'failed');
   const skippedCount = countByStatus(testCases, 'skipped');
   const parsedCount = parsedFiles.length - missingFiles.length;
+  const sortedTestCases = sortTestCasesForDisplay(testCases);
 
   const lines = [];
   lines.push(`## ${title}`);
@@ -158,9 +201,9 @@ function buildSummaryMarkdown(title, parsedFiles) {
     return lines.join('\n');
   }
 
-  lines.push('| Status | Suite | Test Case | Duration (s) | Report File |');
+  lines.push('| Status | Suite | Test Case | Duration (ms) | Report File |');
   lines.push('| --- | --- | --- | ---: | --- |');
-  lines.push(toMarkdownTableRows(testCases));
+  lines.push(toMarkdownTableRows(sortedTestCases));
   lines.push('');
 
   return lines.join('\n');


### PR DESCRIPTION
## Summary
- convert summary duration display to rounded integer milliseconds
- sort test rows so failed tests always appear first
- remove non-essential unit/e2e artifact uploads from Quality workflow (Summary tab remains the primary report)

## Validation
- npm run format
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm run test:e2e