### PR TITLE
M3-01: Define Entra SPA registration contract and redirect URIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Required
+# Application (client) ID from docs/auth/Entra-App-Registration.md
 VITE_AZURE_CLIENT_ID=replace-with-your-entra-client-id
 
 # Optional deployment overrides

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ Provide fast mobile access to a personal Conspectus SQLite database stored in On
 ## Environment Setup
 
 Create a `.env` file in the repository root. Use `.env.example` as the template.
+Before setting env values, complete the Entra registration contract in `docs/auth/Entra-App-Registration.md`.
 
 Required variable:
 
-- `VITE_AZURE_CLIENT_ID`: Microsoft Entra SPA client ID used for MSAL login.
+- `VITE_AZURE_CLIENT_ID`: Microsoft Entra `Application (client) ID` from the SPA registration in `docs/auth/Entra-App-Registration.md`.
   - CI/CD requirement: this repository variable must also be set in GitHub Actions repository variables.
 
 Optional deployment variables:
@@ -55,6 +56,7 @@ Startup validation:
 Canonical source-of-truth by topic:
 
 - Environment variables and defaults: this `README.md` (`## Environment Setup`).
+- Entra app registration contract (account type, SPA platform, redirect URIs): `docs/auth/Entra-App-Registration.md`.
 - Module import conventions and aliases: this `README.md` (`## Architecture Modules`).
 - Sync/caching model (`eTag`, `If-Match`, conflict recovery): `docs/Architecture-and-Implementation-Plan.md` (`## 3.4 Sync and Caching Strategy`).
 
@@ -70,6 +72,7 @@ Canonical source-of-truth by topic:
 - Architecture and implementation plan: `docs/Architecture-and-Implementation-Plan.md`
 - Desktop parity reference used for DB/business-rule alignment: `docs/Conspectus-Desktop-Info.md`
 - MVP tracker/index of milestone issues: `docs/GitHub-Issues-MVP-Backlog.md`
+- Entra app registration runbook (`M3-01`): `docs/auth/Entra-App-Registration.md`
 - M2-07 installability verification record: [#25](https://github.com/Jon2050/Conspectus-Mobile/issues/25)
 - M2-08 two-repo deployment runbook record: [#27](https://github.com/Jon2050/Conspectus-Mobile/issues/27)
 

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -19,6 +19,7 @@ Canonical sections by topic:
 
 - Sync/caching model (`eTag`, `If-Match`, conflict recovery): this document, `## 3.4 Sync and Caching Strategy`.
 - Environment variable definitions/defaults: `README.md`, `## Environment Setup`.
+- Entra app registration contract (SPA account type + redirect URIs): `docs/auth/Entra-App-Registration.md`.
 - Module import conventions and aliases: `README.md`, `## Architecture Modules`.
 
 ---
@@ -314,8 +315,8 @@ Substeps:
 
 1. Register Entra app for SPA redirect flow (personal accounts).
 2. Configure redirect URIs:
-   - production path
-   - local dev path
+   - `https://jon2050.de/conspectus/webapp/` (production)
+   - `http://localhost:5173/` (local development)
 3. Implement MSAL bootstrapping and login state store.
 4. Implement sign-in and sign-out UX.
 5. Implement OneDrive file picker/select flow (or Graph file browse fallback).
@@ -326,6 +327,10 @@ Substeps:
 7. Add settings actions:
    - "Change DB file"
    - "Reset local app data"
+
+M3 sequencing note:
+
+- `M3-01` defines the app registration contract (`docs/auth/Entra-App-Registration.md`) and is required before `M3-02` (Graph scopes) and `M3-03` (MSAL bootstrap implementation).
 
 Deliverables:
 

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -220,7 +220,7 @@ An issue is only considered done when:
 - Depends on: `M2-04, M2-05`
 - GitHub: [#27](https://github.com/Jon2050/Conspectus-Mobile/issues/27)
 
-### :green_circle: M3-01 Create Microsoft Entra app registration (SPA, personal accounts)
+### :white_check_mark: M3-01 Create Microsoft Entra app registration (SPA, personal accounts)
 
 - Label: `feature`
 - Milestone: `M3 - Auth + OneDrive Binding`

--- a/docs/auth/Entra-App-Registration.md
+++ b/docs/auth/Entra-App-Registration.md
@@ -1,0 +1,43 @@
+# M3-01 Entra App Registration (SPA, Personal Accounts)
+
+This document is the repository contract for issue [#29](https://github.com/Jon2050/Conspectus-Mobile/issues/29).
+
+Goal:
+
+- Register one Microsoft Entra application for Conspectus-Mobile authentication.
+- Configure it as a single-page application (SPA) for personal Microsoft accounts.
+- Define the redirect URI contract used by local development and production.
+
+## Required Entra Registration Settings
+
+Create or update an app registration with the following values:
+
+1. Supported account types:
+   - `Personal Microsoft accounts only`
+2. Platform configuration:
+   - `Single-page application (SPA)`
+3. Redirect URIs:
+   - `http://localhost:5173/`
+   - `https://jon2050.de/conspectus/webapp/`
+
+## Frontend Configuration Contract
+
+After registration, copy the `Application (client) ID` and configure:
+
+1. Local development:
+   - `.env` -> `VITE_AZURE_CLIENT_ID=<application-client-id>`
+2. CI/CD:
+   - GitHub repository variable `VITE_AZURE_CLIENT_ID=<application-client-id>`
+
+Notes:
+
+- The client ID is public metadata, not a secret.
+- Graph API delegated scopes and consent details are handled in `M3-02` (issue [#31](https://github.com/Jon2050/Conspectus-Mobile/issues/31)).
+
+## Verification Checklist (Issue Close Gate)
+
+- Entra app registration exists and is accessible to the project owner.
+- Supported account type is set to personal Microsoft accounts only.
+- SPA platform is configured.
+- Both redirect URIs listed above are configured exactly.
+- The same `Application (client) ID` is set in local `.env` and repository variable `VITE_AZURE_CLIENT_ID`.


### PR DESCRIPTION
## Summary\n- add canonical M3-01 runbook for Microsoft Entra app registration (docs/auth/Entra-App-Registration.md)\n- document exact SPA redirect URI contract for local and production environments\n- clarify VITE_AZURE_CLIENT_ID source and configuration path in README/.env example\n- update architecture doc and backlog status marker for M3-01\n\n## Acceptance Criteria Mapping\n- [x] AC1 App registration contract with correct redirect URIs is defined in-repo:\n  - required account type (Personal Microsoft accounts only)\n  - required platform (SPA)\n  - redirect URIs (http://localhost:5173/, https://jon2050.de/conspectus/webapp/)\n  - verification checklist in docs/auth/Entra-App-Registration.md\n- [x] AC2 Client ID availability for frontend configuration is documented and enforced:\n  - .env + GitHub repo variable path for VITE_AZURE_CLIENT_ID\n  - existing runtime validation remains in place\n\n## Validation\n- 
pm run format\n- 
pm run lint\n- 
pm run typecheck\n- 
pm run test\n- 
pm run build\n- 
pm run test:e2e not run (docs/config-contract-only change; no runtime UI behavior change)\n\nCloses #29