### PR TITLE
docs: enforce Entra registration state sync in M3 backlog/issue flow

### DIFF
--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -232,7 +232,7 @@ An issue is only considered done when:
 
 - Label: `security`
 - Milestone: `M3 - Auth + OneDrive Binding`
-- Summary: Work includes least-privilege delegated scopes required for file read/write and scopes in Entra app. It also covers consent and rationale.
+- Summary: Work includes least-privilege delegated scopes required for file read/write and scopes in Entra app. It also covers consent and rationale. Any Entra registration change in this issue must update `docs/auth/Entra-App-Registration.md` in the same PR.
 - Depends on: `M3-01`
 - GitHub: [#31](https://github.com/Jon2050/Conspectus-Mobile/issues/31)
 
@@ -240,7 +240,7 @@ An issue is only considered done when:
 
 - Label: `feature`
 - Milestone: `M3 - Auth + OneDrive Binding`
-- Summary: Work includes MSAL initialization with PKCE flow and token acquisition helper with silent-first strategy. It also covers account selection and active account restoration.
+- Summary: Work includes MSAL initialization with PKCE flow and token acquisition helper with silent-first strategy. It also covers account selection and active account restoration. If implementation requires Entra registration adjustments (redirect URIs, platform/account settings), update `docs/auth/Entra-App-Registration.md` in the same PR.
 - Depends on: `M3-01`
 - GitHub: [#33](https://github.com/Jon2050/Conspectus-Mobile/issues/33)
 


### PR DESCRIPTION
## Summary
- update M3-02 and M3-03 backlog summaries to require syncing docs/auth/Entra-App-Registration.md whenever Entra registration settings change
- aligns backlog text with updated issue bodies for #31, #33, and review scope in #109

## Verification
- npm run format
