### PR TITLE
feat(auth): implement M3-03 MSAL bootstrap module

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -335,6 +335,16 @@ M3 sequencing note:
 
 - `M3-01` defines the app registration contract (`docs/auth/Entra-App-Registration.md`) and is required before `M3-02` (Graph scopes) and `M3-03` (MSAL bootstrap implementation).
 
+M3-03 implementation clarification:
+
+- Auth bootstrap is implemented in `src/auth/msalAuthClient.ts` and exposed through `@auth` as `createAuthClient`.
+- Login/logout interactive actions use MSAL redirect flow (`loginRedirect`/`logoutRedirect`) with personal-account authority (`https://login.microsoftonline.com/consumers`).
+- Startup initialization restores active account in deterministic order:
+  1. account returned by `handleRedirectPromise()`
+  2. currently active account in MSAL cache
+  3. deterministic fallback from cached accounts (username + homeAccountId sort)
+- Access token acquisition uses a silent-first strategy (`acquireTokenSilent`) and normalizes failures into stable app-level auth error codes (`interaction_required`, `network_error`, `no_active_account`, etc.).
+
 Deliverables:
 
 - Stable login flow with persisted session where possible.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -236,7 +236,7 @@ An issue is only considered done when:
 - Depends on: `M3-01`
 - GitHub: [#31](https://github.com/Jon2050/Conspectus-Mobile/issues/31)
 
-### :green_circle: M3-03 Implement MSAL bootstrap module
+### :white_check_mark: M3-03 Implement MSAL bootstrap module
 
 - Label: `feature`
 - Milestone: `M3 - Auth + OneDrive Binding`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.0.0",
+      "version": "0.2.0",
+      "dependencies": {
+        "@azure/msal-browser": "^5.4.0"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.58.2",
@@ -28,6 +31,30 @@
         "vite": "^7.3.1",
         "vite-plugin-pwa": "^1.2.0",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.4.0.tgz",
+      "integrity": "sha512-GvRbLNk26oPOPpnry4Ym8wtXrmdozGm2Sry5EKfui0siwnEuAKWEeMLLyosDo5nVEIIDO1C2t/+HpVzqqCWlfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.2.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.2.0.tgz",
+      "integrity": "sha512-ge0nGzTLmEE5lg7tSCbTBrYqMGkpFQeQEtqfcKPuGJn/FPFf8Xz51uDfZsm5xpstNZGMYPhHvnYbL8OeNp/aLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   },
   "engines": {
     "node": ">=22"
+  },
+  "dependencies": {
+    "@azure/msal-browser": "^5.4.0"
   }
 }

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -16,9 +16,12 @@ Expected public interfaces (`src/auth/index.ts`):
 - `AuthAccount`: signed-in account identity surfaced to UI/state layers.
 - `AuthSession`: deterministic auth state snapshot (`isAuthenticated` + account).
 - `AuthClient`: bootstrap/login/logout/token API used by higher-level modules.
+- `createAuthClient`: factory that hides MSAL details behind the `AuthClient` interface.
 - `AuthErrorCode` and `AuthError`: normalized, provider-agnostic auth failure model.
 
 M3 implementation target:
 
 - Keep MSAL-specific details behind `AuthClient`.
+- Use silent-first token acquisition (`acquireTokenSilent`) and return `interaction_required` when user re-auth is needed.
+- Restore active account in deterministic order: redirect result account, current active account, then cached account fallback.
 - Return stable session and error shapes so feature code does not depend on MSAL internals.

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AccountInfo } from '@azure/msal-browser';
+
+import { AUTH_REQUEST_SCOPES, createAuthClient } from './index';
+
+type CreateAuthClientArg = NonNullable<Parameters<typeof createAuthClient>[0]>;
+type MsalInstance = NonNullable<CreateAuthClientArg['msalInstance']>;
+
+const createMinimalMsalInstance = (): MsalInstance => {
+  let activeAccount: AccountInfo | null = null;
+
+  return {
+    initialize: vi.fn(async () => {}),
+    handleRedirectPromise: vi.fn(async () => null),
+    getActiveAccount: vi.fn(() => activeAccount),
+    setActiveAccount: vi.fn((account: AccountInfo | null) => {
+      activeAccount = account;
+    }),
+    getAllAccounts: vi.fn(() => []),
+    loginRedirect: vi.fn(async () => {}),
+    logoutRedirect: vi.fn(async () => {}),
+    acquireTokenSilent: vi.fn(async () => ({
+      authority: 'https://login.microsoftonline.com/consumers',
+      uniqueId: 'unique-id',
+      tenantId: 'tenant-id',
+      scopes: ['Files.ReadWrite'],
+      account:
+        activeAccount ??
+        ({
+          homeAccountId: 'fallback-home',
+          environment: 'login.microsoftonline.com',
+          tenantId: 'tenant-id',
+          username: 'fallback@example.com',
+          localAccountId: 'fallback-local',
+          name: 'Fallback User',
+        } as AccountInfo),
+      idToken: 'id-token',
+      idTokenClaims: {},
+      accessToken: 'token-value',
+      fromCache: true,
+      expiresOn: new Date('2099-01-01T00:00:00.000Z'),
+      tokenType: 'Bearer',
+      correlationId: 'correlation-id',
+    })),
+  };
+};
+
+describe('auth barrel contract', () => {
+  it('exports an auth client factory with the stable method surface', () => {
+    const client = createAuthClient({ msalInstance: createMinimalMsalInstance() });
+
+    expect(client).toEqual(
+      expect.objectContaining({
+        initialize: expect.any(Function),
+        getSession: expect.any(Function),
+        signIn: expect.any(Function),
+        signOut: expect.any(Function),
+        getAccessToken: expect.any(Function),
+      }),
+    );
+  });
+
+  it('keeps the approved auth request scopes available to callers', () => {
+    expect(AUTH_REQUEST_SCOPES).toEqual(['openid', 'profile', 'offline_access', 'Files.ReadWrite']);
+  });
+});

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -30,5 +30,6 @@ export interface AuthError {
   readonly cause?: unknown;
 }
 
+export { createAuthClient } from './msalAuthClient';
 export { AUTH_OIDC_SCOPES, GRAPH_ONEDRIVE_FILE_SCOPES, AUTH_REQUEST_SCOPES } from './scopes';
 export type { AuthRequestScope } from './scopes';

--- a/src/auth/msalAuthClient.test.ts
+++ b/src/auth/msalAuthClient.test.ts
@@ -1,0 +1,292 @@
+import {
+  BrowserAuthErrorCodes,
+  InteractionRequiredAuthError,
+  InteractionRequiredAuthErrorCodes,
+  type AccountInfo,
+  type AuthenticationResult,
+} from '@azure/msal-browser';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAuthClient } from './index';
+import { AUTH_REQUEST_SCOPES } from './scopes';
+
+type CreateAuthClientArg = NonNullable<Parameters<typeof createAuthClient>[0]>;
+type MsalInstance = NonNullable<CreateAuthClientArg['msalInstance']>;
+
+interface MockMsalOptions {
+  readonly redirectResult?: AuthenticationResult | null;
+  readonly initialActiveAccount?: AccountInfo | null;
+  readonly cachedAccounts?: AccountInfo[];
+  readonly silentResult?: AuthenticationResult;
+  readonly silentError?: unknown;
+  readonly logoutError?: unknown;
+}
+
+const createAccount = (username: string, homeAccountId: string): AccountInfo => ({
+  homeAccountId,
+  environment: 'login.microsoftonline.com',
+  tenantId: 'tenant-id',
+  username,
+  localAccountId: `${homeAccountId}-local`,
+  name: `Name ${username}`,
+});
+
+const createAuthenticationResult = (
+  account: AccountInfo,
+  accessToken = 'token-value',
+): AuthenticationResult => ({
+  authority: 'https://login.microsoftonline.com/consumers',
+  uniqueId: account?.localAccountId ?? 'unique-id',
+  tenantId: account?.tenantId ?? 'tenant-id',
+  scopes: ['Files.ReadWrite'],
+  account,
+  idToken: 'id-token',
+  idTokenClaims: {},
+  accessToken,
+  fromCache: true,
+  expiresOn: new Date('2099-01-01T00:00:00.000Z'),
+  tokenType: 'Bearer',
+  correlationId: 'correlation-id',
+});
+
+const createMockMsalInstance = (options: MockMsalOptions = {}) => {
+  let activeAccount = options.initialActiveAccount ?? null;
+  const cachedAccounts = options.cachedAccounts ?? [];
+
+  const initialize = vi.fn(async () => {});
+  const handleRedirectPromise = vi.fn(async () => options.redirectResult ?? null);
+  const getActiveAccount = vi.fn(() => activeAccount);
+  const setActiveAccount = vi.fn((account: AccountInfo | null) => {
+    activeAccount = account;
+  });
+  const getAllAccounts = vi.fn(() => [...cachedAccounts]);
+  const loginRedirect = vi.fn(async () => {});
+  const logoutRedirect = vi.fn(async () => {
+    if (options.logoutError !== undefined) {
+      throw options.logoutError;
+    }
+  });
+  const acquireTokenSilent = vi.fn(async () => {
+    if (options.silentError !== undefined) {
+      throw options.silentError;
+    }
+
+    return (
+      options.silentResult ??
+      createAuthenticationResult(
+        activeAccount ?? createAccount('fallback@example.com', 'fallback-home'),
+        'silent-token',
+      )
+    );
+  });
+
+  const instance: MsalInstance = {
+    initialize,
+    handleRedirectPromise,
+    getActiveAccount,
+    setActiveAccount,
+    getAllAccounts,
+    loginRedirect,
+    logoutRedirect,
+    acquireTokenSilent,
+  };
+
+  return {
+    instance,
+    handleRedirectPromise,
+    setActiveAccount,
+    loginRedirect,
+    logoutRedirect,
+    acquireTokenSilent,
+    getActiveAccountValue: (): AccountInfo | null => activeAccount,
+  };
+};
+
+describe('createAuthClient', () => {
+  it('returns an unauthenticated session before initialization', () => {
+    const mockMsal = createMockMsalInstance();
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    expect(client.getSession()).toEqual({
+      isAuthenticated: false,
+      account: null,
+    });
+  });
+
+  it('restores active account from redirect result during initialization', async () => {
+    const redirectAccount = createAccount('redirect@example.com', 'redirect-home');
+    const existingAccount = createAccount('existing@example.com', 'existing-home');
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: existingAccount,
+      redirectResult: createAuthenticationResult(redirectAccount),
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+
+    expect(mockMsal.handleRedirectPromise).toHaveBeenCalledTimes(1);
+    expect(mockMsal.setActiveAccount).toHaveBeenCalledWith(redirectAccount);
+    expect(client.getSession()).toEqual({
+      isAuthenticated: true,
+      account: {
+        homeAccountId: redirectAccount.homeAccountId,
+        username: redirectAccount.username,
+        displayName: redirectAccount.name ?? null,
+      },
+    });
+  });
+
+  it('restores deterministic cached account when no active account exists', async () => {
+    const accountZ = createAccount('zeta@example.com', 'zeta-home');
+    const accountA = createAccount('alpha@example.com', 'alpha-home');
+    const mockMsal = createMockMsalInstance({
+      cachedAccounts: [accountZ, accountA],
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+
+    expect(mockMsal.getActiveAccountValue()).toEqual(accountA);
+  });
+
+  it('acquires token silently when a session exists', async () => {
+    const activeAccount = createAccount('active@example.com', 'active-home');
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: activeAccount,
+      silentResult: createAuthenticationResult(activeAccount, 'graph-token'),
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+    const token = await client.getAccessToken(['Files.ReadWrite', 'Files.ReadWrite']);
+
+    expect(token).toBe('graph-token');
+    expect(mockMsal.acquireTokenSilent).toHaveBeenCalledWith({
+      account: activeAccount,
+      scopes: ['Files.ReadWrite'],
+    });
+    expect(mockMsal.loginRedirect).not.toHaveBeenCalled();
+  });
+
+  it('maps interaction-required token failures to the stable interaction_required code', async () => {
+    const activeAccount = createAccount('active@example.com', 'active-home');
+    const interactionError = new InteractionRequiredAuthError(
+      InteractionRequiredAuthErrorCodes.loginRequired,
+      'login required',
+    );
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: activeAccount,
+      silentError: interactionError,
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+
+    await expect(client.getAccessToken(['Files.ReadWrite'])).rejects.toMatchObject({
+      code: 'interaction_required',
+    });
+  });
+
+  it('maps network token failures to the stable network_error code', async () => {
+    const activeAccount = createAccount('active@example.com', 'active-home');
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: activeAccount,
+      silentError: {
+        errorCode: BrowserAuthErrorCodes.noNetworkConnectivity,
+        errorMessage: 'Network unavailable',
+      },
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+
+    await expect(client.getAccessToken(['Files.ReadWrite'])).rejects.toMatchObject({
+      code: 'network_error',
+    });
+  });
+
+  it('maps unexpected token failures to unknown and preserves message text', async () => {
+    const activeAccount = createAccount('active@example.com', 'active-home');
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: activeAccount,
+      silentError: new Error('unexpected token failure'),
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+
+    await expect(client.getAccessToken(['Files.ReadWrite'])).rejects.toMatchObject({
+      code: 'unknown',
+      message: 'unexpected token failure',
+    });
+  });
+
+  it('returns no_active_account when token is requested without an active session', async () => {
+    const mockMsal = createMockMsalInstance();
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+
+    await expect(client.getAccessToken(['Files.ReadWrite'])).rejects.toMatchObject({
+      code: 'no_active_account',
+    });
+  });
+
+  it('throws not_initialized before interactive auth operations are used', async () => {
+    const mockMsal = createMockMsalInstance();
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await expect(client.signIn()).rejects.toMatchObject({ code: 'not_initialized' });
+    await expect(client.signOut()).rejects.toMatchObject({ code: 'not_initialized' });
+    await expect(client.getAccessToken(['Files.ReadWrite'])).rejects.toMatchObject({
+      code: 'not_initialized',
+    });
+  });
+
+  it('uses approved scopes and account picker prompt for sign-in', async () => {
+    const activeAccount = createAccount('active@example.com', 'active-home');
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: activeAccount,
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+    await client.signIn();
+
+    expect(mockMsal.loginRedirect).toHaveBeenCalledWith({
+      scopes: [...AUTH_REQUEST_SCOPES],
+      prompt: 'select_account',
+    });
+  });
+
+  it('clears active account and logs out against the active account context', async () => {
+    const activeAccount = createAccount('active@example.com', 'active-home');
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: activeAccount,
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+    await client.signOut();
+
+    expect(mockMsal.setActiveAccount).toHaveBeenLastCalledWith(null);
+    expect(mockMsal.logoutRedirect).toHaveBeenCalledWith({ account: activeAccount });
+  });
+
+  it('restores the prior active account when sign-out fails', async () => {
+    const activeAccount = createAccount('active@example.com', 'active-home');
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: activeAccount,
+      logoutError: new Error('logout failed'),
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+
+    await expect(client.signOut()).rejects.toMatchObject({
+      code: 'unknown',
+      message: 'logout failed',
+    });
+    expect(mockMsal.setActiveAccount).toHaveBeenLastCalledWith(activeAccount);
+  });
+});

--- a/src/auth/msalAuthClient.ts
+++ b/src/auth/msalAuthClient.ts
@@ -1,0 +1,333 @@
+import {
+  BrowserAuthErrorCodes,
+  BrowserCacheLocation,
+  InteractionRequiredAuthError,
+  InteractionRequiredAuthErrorCodes,
+  PublicClientApplication,
+  type AccountInfo,
+  type AuthenticationResult,
+  type Configuration,
+  type EndSessionRequest,
+  type RedirectRequest,
+  type SilentRequest,
+} from '@azure/msal-browser';
+import { loadRuntimeEnv } from '@shared';
+
+import type { AuthAccount, AuthClient, AuthErrorCode, AuthSession } from './index';
+import { AUTH_REQUEST_SCOPES } from './scopes';
+
+const MSAL_CONSUMERS_AUTHORITY = 'https://login.microsoftonline.com/consumers';
+
+type MsalInstance = {
+  initialize(): Promise<void>;
+  handleRedirectPromise(): Promise<AuthenticationResult | null>;
+  getActiveAccount(): AccountInfo | null;
+  setActiveAccount(account: AccountInfo | null): void;
+  getAllAccounts(): AccountInfo[];
+  loginRedirect(request?: RedirectRequest): Promise<void>;
+  logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void>;
+  acquireTokenSilent(request: SilentRequest): Promise<AuthenticationResult>;
+};
+
+export interface CreateAuthClientOptions {
+  readonly msalInstance?: MsalInstance;
+}
+
+class AuthClientError extends Error {
+  readonly code: AuthErrorCode;
+  readonly cause?: unknown;
+
+  constructor(code: AuthErrorCode, message: string, cause?: unknown) {
+    super(message);
+    this.name = 'AuthClientError';
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+const INTERACTION_REQUIRED_CODES = new Set<string>([
+  InteractionRequiredAuthErrorCodes.badToken,
+  InteractionRequiredAuthErrorCodes.consentRequired,
+  InteractionRequiredAuthErrorCodes.interactionRequired,
+  InteractionRequiredAuthErrorCodes.interruptedUser,
+  InteractionRequiredAuthErrorCodes.loginRequired,
+  InteractionRequiredAuthErrorCodes.nativeAccountUnavailable,
+  InteractionRequiredAuthErrorCodes.noTokensFound,
+  InteractionRequiredAuthErrorCodes.refreshTokenExpired,
+  InteractionRequiredAuthErrorCodes.uxNotAllowed,
+]);
+
+const NETWORK_ERROR_CODES = new Set<string>([
+  BrowserAuthErrorCodes.getRequestFailed,
+  BrowserAuthErrorCodes.noNetworkConnectivity,
+  BrowserAuthErrorCodes.postRequestFailed,
+]);
+
+const extractErrorCode = (error: unknown): string | null => {
+  if (typeof error !== 'object' || error === null) {
+    return null;
+  }
+
+  const errorCode = (error as { errorCode?: unknown }).errorCode;
+  return typeof errorCode === 'string' ? errorCode : null;
+};
+
+const extractErrorMessage = (error: unknown): string | null => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (typeof error !== 'object' || error === null) {
+    return null;
+  }
+
+  const errorMessage = (error as { errorMessage?: unknown }).errorMessage;
+  return typeof errorMessage === 'string' ? errorMessage : null;
+};
+
+const normalizeAuthError = (error: unknown, fallbackMessage: string): AuthClientError => {
+  if (error instanceof AuthClientError) {
+    return error;
+  }
+
+  const errorCode = extractErrorCode(error);
+
+  if (
+    error instanceof InteractionRequiredAuthError ||
+    (errorCode !== null && INTERACTION_REQUIRED_CODES.has(errorCode))
+  ) {
+    return new AuthClientError(
+      'interaction_required',
+      'User interaction is required to continue authentication.',
+      error,
+    );
+  }
+
+  if (errorCode === BrowserAuthErrorCodes.uninitializedPublicClientApplication) {
+    return new AuthClientError(
+      'not_initialized',
+      'Auth client is not initialized. Call initialize() before using auth operations.',
+      error,
+    );
+  }
+
+  if (errorCode === BrowserAuthErrorCodes.noAccountError) {
+    return new AuthClientError(
+      'no_active_account',
+      'No active account is available. Sign in and try again.',
+      error,
+    );
+  }
+
+  if (errorCode !== null && NETWORK_ERROR_CODES.has(errorCode)) {
+    return new AuthClientError(
+      'network_error',
+      'Authentication network request failed. Check your connection and try again.',
+      error,
+    );
+  }
+
+  return new AuthClientError('unknown', extractErrorMessage(error) ?? fallbackMessage, error);
+};
+
+const normalizeTokenScopes = (scopes: readonly string[]): string[] => [
+  ...new Set(scopes.map((scope) => scope.trim()).filter((scope) => scope.length > 0)),
+];
+
+const compareAccounts = (left: AccountInfo, right: AccountInfo): number => {
+  const usernameComparison = left.username.localeCompare(right.username);
+  if (usernameComparison !== 0) {
+    return usernameComparison;
+  }
+
+  return left.homeAccountId.localeCompare(right.homeAccountId);
+};
+
+const resolvePreferredAccount = (
+  msalInstance: MsalInstance,
+  redirectResult: AuthenticationResult | null,
+): AccountInfo | null => {
+  if (redirectResult?.account !== null && redirectResult?.account !== undefined) {
+    return redirectResult.account;
+  }
+
+  const activeAccount = msalInstance.getActiveAccount();
+  if (activeAccount !== null) {
+    return activeAccount;
+  }
+
+  const allAccounts = msalInstance.getAllAccounts();
+  if (allAccounts.length === 0) {
+    return null;
+  }
+
+  return [...allAccounts].sort(compareAccounts)[0] ?? null;
+};
+
+const toAuthAccount = (account: AccountInfo | null): AuthAccount | null => {
+  if (account === null) {
+    return null;
+  }
+
+  return {
+    homeAccountId: account.homeAccountId,
+    username: account.username,
+    displayName: account.name ?? null,
+  };
+};
+
+const createMsalConfiguration = (clientId: string): Configuration => ({
+  auth: {
+    clientId,
+    authority: MSAL_CONSUMERS_AUTHORITY,
+  },
+  cache: {
+    cacheLocation: BrowserCacheLocation.LocalStorage,
+  },
+});
+
+const createDefaultMsalInstance = (): MsalInstance => {
+  const { VITE_AZURE_CLIENT_ID } = loadRuntimeEnv();
+  return new PublicClientApplication(createMsalConfiguration(VITE_AZURE_CLIENT_ID));
+};
+
+const notInitializedError = (): AuthClientError =>
+  new AuthClientError(
+    'not_initialized',
+    'Auth client is not initialized. Call initialize() before using auth operations.',
+  );
+
+const ensureActiveAccount = (msalInstance: MsalInstance): AccountInfo => {
+  const activeAccount = msalInstance.getActiveAccount();
+  if (activeAccount === null) {
+    throw new AuthClientError(
+      'no_active_account',
+      'No active account is available. Sign in and try again.',
+    );
+  }
+
+  return activeAccount;
+};
+
+export const createAuthClient = (options: CreateAuthClientOptions = {}): AuthClient => {
+  let msalInstance: MsalInstance | null = options.msalInstance ?? null;
+  let isInitialized = false;
+
+  const resolveMsalInstance = (): MsalInstance => {
+    if (msalInstance !== null) {
+      return msalInstance;
+    }
+
+    msalInstance = createDefaultMsalInstance();
+    return msalInstance;
+  };
+
+  const assertInitialized = (): void => {
+    if (!isInitialized) {
+      throw notInitializedError();
+    }
+  };
+
+  return {
+    async initialize(): Promise<void> {
+      if (isInitialized) {
+        return;
+      }
+
+      try {
+        const resolvedMsalInstance = resolveMsalInstance();
+        await resolvedMsalInstance.initialize();
+        const redirectResult = await resolvedMsalInstance.handleRedirectPromise();
+        const preferredAccount = resolvePreferredAccount(resolvedMsalInstance, redirectResult);
+        if (preferredAccount !== null) {
+          resolvedMsalInstance.setActiveAccount(preferredAccount);
+        }
+        isInitialized = true;
+      } catch (error) {
+        throw normalizeAuthError(error, 'Failed to initialize authentication.');
+      }
+    },
+
+    getSession(): AuthSession {
+      if (!isInitialized) {
+        return {
+          isAuthenticated: false,
+          account: null,
+        };
+      }
+
+      const activeAccount = resolveMsalInstance().getActiveAccount();
+      return {
+        isAuthenticated: activeAccount !== null,
+        account: toAuthAccount(activeAccount),
+      };
+    },
+
+    async signIn(): Promise<void> {
+      assertInitialized();
+
+      const signInRequest: RedirectRequest = {
+        scopes: [...AUTH_REQUEST_SCOPES],
+        prompt: 'select_account',
+      };
+
+      try {
+        await resolveMsalInstance().loginRedirect(signInRequest);
+      } catch (error) {
+        throw normalizeAuthError(error, 'Sign-in failed.');
+      }
+    },
+
+    async signOut(): Promise<void> {
+      assertInitialized();
+
+      const resolvedMsalInstance = resolveMsalInstance();
+      const activeAccount = resolvedMsalInstance.getActiveAccount();
+      const logoutRequest = activeAccount !== null ? { account: activeAccount } : undefined;
+
+      resolvedMsalInstance.setActiveAccount(null);
+
+      try {
+        await resolvedMsalInstance.logoutRedirect(logoutRequest);
+      } catch (error) {
+        if (activeAccount !== null) {
+          resolvedMsalInstance.setActiveAccount(activeAccount);
+        }
+        throw normalizeAuthError(error, 'Sign-out failed.');
+      }
+    },
+
+    async getAccessToken(scopes: readonly string[]): Promise<string> {
+      assertInitialized();
+
+      const resolvedMsalInstance = resolveMsalInstance();
+      const activeAccount = ensureActiveAccount(resolvedMsalInstance);
+      const normalizedScopes = normalizeTokenScopes(scopes);
+      if (normalizedScopes.length === 0) {
+        throw new AuthClientError(
+          'unknown',
+          'At least one scope must be provided for token acquisition.',
+        );
+      }
+
+      const tokenRequest: SilentRequest = {
+        account: activeAccount,
+        scopes: normalizedScopes,
+      };
+
+      try {
+        const tokenResult = await resolvedMsalInstance.acquireTokenSilent(tokenRequest);
+        if (tokenResult.account !== null) {
+          resolvedMsalInstance.setActiveAccount(tokenResult.account);
+        }
+        return tokenResult.accessToken;
+      } catch (error) {
+        throw normalizeAuthError(error, 'Access token acquisition failed.');
+      }
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- add createAuthClient MSAL bootstrap implementation with redirect-based sign-in/sign-out and deterministic active-account restoration
- add silent-first access-token acquisition with normalized auth error codes for upper layers
- add focused auth unit tests covering initialization/session restore plus interaction/network/unknown/logout-failure branches
- update architecture source-of-truth notes for M3-03 behavior and mark backlog item M3-03 done

## Acceptance Criteria Mapping
- AC1: tokens are acquired silently when a session exists (cquireTokenSilent path + tests)
- AC2: auth module exposes stable API through @auth (createAuthClient + AuthClient contract)
- AC3: no Entra registration contract value changed; docs/auth/Entra-App-Registration.md remains valid without modification

## Validation
- 
pm run format
- 
pm run lint
- 
pm run typecheck
- 
pm run test
- 
pm run build
- 
pm run test:e2e

Closes #33