### PR TITLE
feat: implement M3-05 Graph client wrapper

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -351,6 +351,13 @@ M3-04 implementation clarification:
 - E2E auth mocking is enabled only on localhost hosts (`127.0.0.1`/`localhost`) used by Playwright; production hosts always use the real auth client.
 - Platform verification is covered by Playwright Chromium + Pixel 5 by default, with optional iPhone WebKit runs enabled through `PLAYWRIGHT_INCLUDE_IOS_WEBKIT=1`.
 
+M3-05 implementation clarification:
+
+- Graph access is implemented in `src/graph/graphClient.ts` and exposed through `@graph` as `createGraphClient`.
+- The client centralizes the MVP Graph operations needed by upcoming milestones: file metadata, raw file download, and conditional full-file upload.
+- Every Graph request acquires a bearer token from `@auth` using `GRAPH_ONEDRIVE_FILE_SCOPES`, keeping MSAL details out of the graph module surface.
+- Graph/auth failures are normalized into stable app-level graph error codes (`unauthorized`, `forbidden`, `not_found`, `conflict`, `network_error`, `unknown`) for UI and sync-layer handling.
+
 Deliverables:
 
 - Stable login flow with persisted session where possible.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -252,7 +252,7 @@ An issue is only considered done when:
 - Depends on: `M3-03`
 - GitHub: [#35](https://github.com/Jon2050/Conspectus-Mobile/issues/35)
 
-### :green_circle: M3-05 Implement Graph client wrapper
+### :white_check_mark: M3-05 Implement Graph client wrapper
 
 - Label: `feature`
 - Milestone: `M3 - Auth + OneDrive Binding`

--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -17,6 +17,7 @@ Expected public interfaces (`src/graph/index.ts`):
 - `GraphFileMetadata`: eTag/size/modified metadata used by sync decisions.
 - `GraphUploadResult`: post-upload metadata returned from Graph.
 - `GraphClient`: metadata, download, and conditional-upload operations.
+- `createGraphClient`: factory that injects auth-backed bearer tokens into Graph requests.
 - `GraphErrorCode` and `GraphError`: normalized failure model for UI/services.
 
 M3 implementation target:

--- a/src/graph/graphClient.test.ts
+++ b/src/graph/graphClient.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createGraphClient } from './graphClient';
+
+const DRIVE_ITEM_BINDING = {
+  driveId: 'drive-123',
+  itemId: 'item-456',
+  name: 'conspectus.db',
+  parentPath: '/Apps/Conspectus',
+} as const;
+
+const createAuthClient = (accessTokenResult: string | Error = 'graph-token') => ({
+  initialize: vi.fn(async () => {}),
+  getSession: vi.fn(() => ({
+    isAuthenticated: true,
+    account: {
+      homeAccountId: 'home-account-id',
+      username: 'user@example.com',
+      displayName: 'Test User',
+    },
+  })),
+  signIn: vi.fn(async () => {}),
+  signOut: vi.fn(async () => {}),
+  getAccessToken: vi.fn(async () => {
+    if (accessTokenResult instanceof Error) {
+      throw accessTokenResult;
+    }
+
+    return accessTokenResult;
+  }),
+});
+
+const createJsonResponse = (payload: unknown, status = 200): Response =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+const getRequestHeaders = (call: readonly [string, RequestInit | undefined]): Headers =>
+  new Headers(call[1]?.headers);
+
+const getFetchCall = (
+  fetchFn: ReturnType<typeof vi.fn>,
+): readonly [string, RequestInit | undefined] =>
+  (fetchFn.mock.calls[0] as [string, RequestInit | undefined]) ?? ['', undefined];
+
+describe('createGraphClient', () => {
+  it('fetches file metadata with an auth-backed Graph request', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        eTag: '"etag-1"',
+        size: 2048,
+        lastModifiedDateTime: '2026-03-09T10:15:00Z',
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    const metadata = await client.getFileMetadata(DRIVE_ITEM_BINDING);
+
+    expect(metadata).toEqual({
+      eTag: '"etag-1"',
+      sizeBytes: 2048,
+      lastModifiedDateTime: '2026-03-09T10:15:00Z',
+    });
+    expect(authClient.getAccessToken).toHaveBeenCalledWith(['Files.ReadWrite']);
+
+    const [requestUrl, requestInit] = getFetchCall(fetchFn);
+    expect(requestUrl).toBeDefined();
+    expect(requestInit).toBeDefined();
+
+    const parsedUrl = new URL(requestUrl as string);
+    expect(parsedUrl.origin).toBe('https://graph.microsoft.com');
+    expect(parsedUrl.pathname).toBe('/v1.0/drives/drive-123/items/item-456');
+    expect(parsedUrl.searchParams.get('$select')).toBe('eTag,size,lastModifiedDateTime');
+
+    const requestHeaders = getRequestHeaders(getFetchCall(fetchFn));
+    expect(requestHeaders.get('Authorization')).toBe('Bearer graph-token');
+  });
+
+  it('downloads file bytes from the Graph content endpoint', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(
+      async () =>
+        new Response(Uint8Array.from([1, 2, 3, 4]), {
+          status: 200,
+        }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    const bytes = await client.downloadFile(DRIVE_ITEM_BINDING);
+
+    expect(Array.from(bytes)).toEqual([1, 2, 3, 4]);
+    const [requestUrl] = getFetchCall(fetchFn);
+    expect(requestUrl).toBe(
+      'https://graph.microsoft.com/v1.0/drives/drive-123/items/item-456/content',
+    );
+  });
+
+  it('uploads file bytes with If-Match and returns normalized metadata', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        eTag: '"etag-2"',
+        size: 4096,
+        lastModifiedDateTime: '2026-03-09T11:00:00Z',
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+    const bytes = Uint8Array.from([9, 8, 7]);
+
+    const uploadResult = await client.uploadFile(DRIVE_ITEM_BINDING, bytes, '"etag-1"');
+
+    expect(uploadResult).toEqual({
+      eTag: '"etag-2"',
+      sizeBytes: 4096,
+      lastModifiedDateTime: '2026-03-09T11:00:00Z',
+    });
+
+    const [requestUrl, requestInit] = getFetchCall(fetchFn);
+    expect(requestUrl).toBe(
+      'https://graph.microsoft.com/v1.0/drives/drive-123/items/item-456/content',
+    );
+    expect(requestInit).toMatchObject({
+      method: 'PUT',
+    });
+    expect(requestInit?.body).toBeInstanceOf(Blob);
+    await expect((requestInit?.body as Blob).arrayBuffer()).resolves.toEqual(bytes.buffer);
+
+    const requestHeaders = getRequestHeaders(getFetchCall(fetchFn));
+    expect(requestHeaders.get('Authorization')).toBe('Bearer graph-token');
+    expect(requestHeaders.get('Content-Type')).toBe('application/octet-stream');
+    expect(requestHeaders.get('If-Match')).toBe('"etag-1"');
+  });
+
+  it.each([
+    [401, 'unauthorized'],
+    [403, 'forbidden'],
+    [404, 'not_found'],
+    [409, 'conflict'],
+    [412, 'conflict'],
+    [429, 'network_error'],
+    [503, 'network_error'],
+  ] as const)('maps Graph HTTP %s responses to %s', async (status, expectedCode) => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse(
+        {
+          error: {
+            code: `status-${status}`,
+            message: `Graph failure ${status}`,
+          },
+        },
+        status,
+      ),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.getFileMetadata(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
+      code: expectedCode,
+      status,
+    });
+  });
+
+  it('maps auth failures to Graph error categories before any network request is made', async () => {
+    const authError = Object.assign(new Error('login required'), {
+      code: 'interaction_required',
+    });
+    const authClient = createAuthClient(authError);
+    const fetchFn = vi.fn(async () => createJsonResponse({}));
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.getFileMetadata(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
+      code: 'unauthorized',
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('maps auth network failures to network_error before any network request is made', async () => {
+    const authError = Object.assign(new Error('network unavailable'), {
+      code: 'network_error',
+    });
+    const authClient = createAuthClient(authError);
+    const fetchFn = vi.fn(async () => createJsonResponse({}));
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.getFileMetadata(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
+      code: 'network_error',
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('maps fetch rejections to network_error', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () => {
+      throw new TypeError('fetch failed');
+    });
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.getFileMetadata(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
+      code: 'network_error',
+    });
+  });
+
+  it('rejects invalid metadata payloads with an unknown Graph error', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        size: 2048,
+        lastModifiedDateTime: '2026-03-09T10:15:00Z',
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.getFileMetadata(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
+      code: 'unknown',
+      message: 'Microsoft Graph metadata response did not include the required file fields.',
+    });
+  });
+
+  it('normalizes malformed JSON metadata responses to an unknown Graph error', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(
+      async () =>
+        new Response('not-json', {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.getFileMetadata(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
+      code: 'unknown',
+      message: 'Microsoft Graph metadata response did not include the required file fields.',
+    });
+  });
+
+  it('rejects invalid upload payloads with an unknown Graph error', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        eTag: '"etag-2"',
+        lastModifiedDateTime: '2026-03-09T11:00:00Z',
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(
+      client.uploadFile(DRIVE_ITEM_BINDING, Uint8Array.from([9, 8, 7]), '"etag-1"'),
+    ).rejects.toMatchObject({
+      code: 'unknown',
+      message: 'Microsoft Graph upload response did not include the required file fields.',
+    });
+  });
+});

--- a/src/graph/graphClient.ts
+++ b/src/graph/graphClient.ts
@@ -1,0 +1,290 @@
+import { GRAPH_ONEDRIVE_FILE_SCOPES, type AuthClient } from '@auth';
+
+import type {
+  DriveItemBinding,
+  GraphClient,
+  GraphErrorCode,
+  GraphFileMetadata,
+  GraphUploadResult,
+} from './index';
+
+const GRAPH_API_BASE_URL = 'https://graph.microsoft.com/v1.0';
+const METADATA_FIELDS = 'eTag,size,lastModifiedDateTime';
+
+type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
+
+interface GraphItemPayload {
+  readonly eTag?: unknown;
+  readonly size?: unknown;
+  readonly lastModifiedDateTime?: unknown;
+}
+
+interface GraphErrorPayload {
+  readonly error?: {
+    readonly code?: unknown;
+    readonly message?: unknown;
+  };
+}
+
+interface CreateGraphClientOptions {
+  readonly authClient: AuthClient;
+  readonly fetchFn?: FetchFn;
+}
+
+class GraphClientError extends Error {
+  readonly code: GraphErrorCode;
+  readonly status?: number;
+  readonly cause?: unknown;
+
+  constructor(code: GraphErrorCode, message: string, status?: number, cause?: unknown) {
+    super(message);
+    this.name = 'GraphClientError';
+    this.code = code;
+    if (status !== undefined) {
+      this.status = status;
+    }
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isGraphItemPayload = (value: unknown): value is GraphItemPayload => isObject(value);
+
+const isGraphErrorPayload = (value: unknown): value is GraphErrorPayload => isObject(value);
+
+const getGraphErrorMessage = (payload: unknown): string | null => {
+  if (!isGraphErrorPayload(payload) || !isObject(payload.error)) {
+    return null;
+  }
+
+  return typeof payload.error.message === 'string' ? payload.error.message : null;
+};
+
+const getErrorCode = (error: unknown): string | null => {
+  if (!isObject(error) || typeof error.code !== 'string') {
+    return null;
+  }
+
+  return error.code;
+};
+
+const buildDriveItemUrl = (binding: DriveItemBinding, suffix = ''): string => {
+  const driveId = encodeURIComponent(binding.driveId);
+  const itemId = encodeURIComponent(binding.itemId);
+  return `${GRAPH_API_BASE_URL}/drives/${driveId}/items/${itemId}${suffix}`;
+};
+
+const createAuthorizedHeaders = (accessToken: string, headers?: HeadersInit): Headers => {
+  const authorizedHeaders = new Headers(headers);
+  authorizedHeaders.set('Authorization', `Bearer ${accessToken}`);
+  return authorizedHeaders;
+};
+
+const mapStatusToErrorCode = (status: number): GraphErrorCode => {
+  if (status === 401) {
+    return 'unauthorized';
+  }
+
+  if (status === 403) {
+    return 'forbidden';
+  }
+
+  if (status === 404) {
+    return 'not_found';
+  }
+
+  if (status === 409 || status === 412) {
+    return 'conflict';
+  }
+
+  if (status === 408 || status === 429 || status >= 500) {
+    return 'network_error';
+  }
+
+  return 'unknown';
+};
+
+const getDefaultErrorMessage = (code: GraphErrorCode): string => {
+  switch (code) {
+    case 'unauthorized':
+      return 'Authentication is required to access the selected OneDrive file.';
+    case 'forbidden':
+      return 'The app does not have permission to access the selected OneDrive file.';
+    case 'not_found':
+      return 'The selected OneDrive file could not be found.';
+    case 'conflict':
+      return 'The selected OneDrive file changed on OneDrive. Refresh and try again.';
+    case 'network_error':
+      return 'The request to OneDrive failed because of a temporary network or service problem. Try again.';
+    case 'unknown':
+      return 'Microsoft Graph request failed.';
+  }
+};
+
+const normalizeAuthError = (error: unknown): GraphClientError => {
+  const code = getErrorCode(error);
+
+  if (
+    code === 'interaction_required' ||
+    code === 'no_active_account' ||
+    code === 'not_initialized'
+  ) {
+    return new GraphClientError(
+      'unauthorized',
+      getDefaultErrorMessage('unauthorized'),
+      undefined,
+      error,
+    );
+  }
+
+  if (code === 'network_error') {
+    return new GraphClientError(
+      'network_error',
+      getDefaultErrorMessage('network_error'),
+      undefined,
+      error,
+    );
+  }
+
+  return new GraphClientError('unknown', getDefaultErrorMessage('unknown'), undefined, error);
+};
+
+const normalizeNetworkError = (error: unknown): GraphClientError =>
+  new GraphClientError('network_error', getDefaultErrorMessage('network_error'), undefined, error);
+
+const normalizeHttpError = async (response: Response): Promise<GraphClientError> => {
+  let payload: unknown = null;
+
+  try {
+    const bodyText = await response.text();
+    if (bodyText.trim().length > 0) {
+      payload = JSON.parse(bodyText);
+    }
+  } catch {
+    payload = null;
+  }
+
+  const code = mapStatusToErrorCode(response.status);
+  const message =
+    code === 'unknown'
+      ? (getGraphErrorMessage(payload) ?? getDefaultErrorMessage(code))
+      : getDefaultErrorMessage(code);
+
+  return new GraphClientError(code, message, response.status, payload);
+};
+
+const readJsonPayload = async (
+  response: Response,
+  invalidResponseMessage: string,
+): Promise<unknown> => {
+  try {
+    return await response.json();
+  } catch (error) {
+    throw new GraphClientError('unknown', invalidResponseMessage, response.status, error);
+  }
+};
+
+const normalizeGraphItem = (
+  payload: unknown,
+  invalidResponseMessage: string,
+): GraphFileMetadata | GraphUploadResult => {
+  if (!isGraphItemPayload(payload)) {
+    throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
+  }
+
+  if (
+    typeof payload.eTag !== 'string' ||
+    typeof payload.size !== 'number' ||
+    !Number.isFinite(payload.size) ||
+    typeof payload.lastModifiedDateTime !== 'string'
+  ) {
+    throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
+  }
+
+  return {
+    eTag: payload.eTag,
+    sizeBytes: payload.size,
+    lastModifiedDateTime: payload.lastModifiedDateTime,
+  };
+};
+
+export const createGraphClient = (options: CreateGraphClientOptions): GraphClient => {
+  const fetchFn = options.fetchFn ?? fetch;
+  const toRequestBody = (bytes: Uint8Array): Blob =>
+    new Blob([Uint8Array.from(bytes).buffer], { type: 'application/octet-stream' });
+
+  const executeRequest = async (url: string, init?: RequestInit): Promise<Response> => {
+    let accessToken: string;
+
+    try {
+      accessToken = await options.authClient.getAccessToken(GRAPH_ONEDRIVE_FILE_SCOPES);
+    } catch (error) {
+      throw normalizeAuthError(error);
+    }
+
+    const requestInit: RequestInit = {
+      ...init,
+      headers: createAuthorizedHeaders(accessToken, init?.headers),
+    };
+
+    let response: Response;
+
+    try {
+      response = await fetchFn(url, requestInit);
+    } catch (error) {
+      throw normalizeNetworkError(error);
+    }
+
+    if (!response.ok) {
+      throw await normalizeHttpError(response);
+    }
+
+    return response;
+  };
+
+  return {
+    async getFileMetadata(binding): Promise<GraphFileMetadata> {
+      const metadataUrl = `${buildDriveItemUrl(binding)}?$select=${encodeURIComponent(METADATA_FIELDS)}`;
+      const response = await executeRequest(metadataUrl);
+      const payload = await readJsonPayload(
+        response,
+        'Microsoft Graph metadata response did not include the required file fields.',
+      );
+
+      return normalizeGraphItem(
+        payload,
+        'Microsoft Graph metadata response did not include the required file fields.',
+      );
+    },
+
+    async downloadFile(binding): Promise<Uint8Array> {
+      const response = await executeRequest(buildDriveItemUrl(binding, '/content'));
+      const arrayBuffer = await response.arrayBuffer();
+      return new Uint8Array(arrayBuffer);
+    },
+
+    async uploadFile(binding, bytes, expectedETag): Promise<GraphUploadResult> {
+      const response = await executeRequest(buildDriveItemUrl(binding, '/content'), {
+        method: 'PUT',
+        body: toRequestBody(bytes),
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'If-Match': expectedETag,
+        },
+      });
+      const payload = await readJsonPayload(
+        response,
+        'Microsoft Graph upload response did not include the required file fields.',
+      );
+
+      return normalizeGraphItem(
+        payload,
+        'Microsoft Graph upload response did not include the required file fields.',
+      );
+    },
+  };
+};

--- a/src/graph/index.test.ts
+++ b/src/graph/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createGraphClient } from './index';
+
+type CreateGraphClientArg = Parameters<typeof createGraphClient>[0];
+type AuthClient = CreateGraphClientArg['authClient'];
+
+const createMinimalAuthClient = (): AuthClient => ({
+  initialize: vi.fn(async () => {}),
+  getSession: vi.fn(() => ({
+    isAuthenticated: true,
+    account: {
+      homeAccountId: 'home-account-id',
+      username: 'user@example.com',
+      displayName: 'Test User',
+    },
+  })),
+  signIn: vi.fn(async () => {}),
+  signOut: vi.fn(async () => {}),
+  getAccessToken: vi.fn(async () => 'graph-access-token'),
+});
+
+describe('graph barrel contract', () => {
+  it('exports a graph client factory with the stable method surface', () => {
+    const client = createGraphClient({
+      authClient: createMinimalAuthClient(),
+      fetchFn: vi.fn(async () => new Response(null, { status: 200 })),
+    });
+
+    expect(client).toEqual(
+      expect.objectContaining({
+        getFileMetadata: expect.any(Function),
+        downloadFile: expect.any(Function),
+        uploadFile: expect.any(Function),
+      }),
+    );
+  });
+});

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -41,3 +41,5 @@ export interface GraphClient {
     expectedETag: string,
   ): Promise<GraphUploadResult>;
 }
+
+export { createGraphClient } from './graphClient';


### PR DESCRIPTION
## Summary
- add createGraphClient as the centralized Graph wrapper for metadata, download, and conditional upload operations
- inject bearer tokens from @auth and normalize auth, HTTP, and network failures into stable graph error categories
- add Graph module tests plus the M3 architecture/backlog updates for issue delivery

## Acceptance Criteria
- [x] Graph calls are centralized behind one client interface.
- [x] Common Graph errors are mapped to user-facing categories.

## Verification
- 
pm run format
- 
pm run lint
- 
pm run typecheck
- 
pm run test
- 
pm run build
- 
pm run test:e2e not run; M3-05 is service-layer only with no user-visible flow changes

Closes #37