### PR TITLE
docs: improve prompt file guidance

### DIFF
--- a/docs/prompts/Local-CodeReview-Prompt-Template.md
+++ b/docs/prompts/Local-CodeReview-Prompt-Template.md
@@ -26,7 +26,7 @@ Resolves Issues / Description: {{ISSUE_NUMBERS_OR_DESCRIPTION}}
 - **Test Coverage:** Check if new tests were added or existing tests updated. Flag it if missing but reasonably required for the changes.
 - **Strictly Forbidden AI Anti-Patterns (Reject if found):**
   - Placeholder code (e.g., `TODO`, `pass`, `// implement here`) instead of actual logic.
-  - Improper Commenting: Code must be self-explanatory. Reject excessive/robotic comments and comments masking bad logic (request refactor). Complex logic, however, must include meaningful comments.
+  - Improper Commenting: Code must be self-explanatory. Reject excessive/robotic comments and comments masking bad logic (request refactor). Complex logic, however, must include meaningful comments. Every file should start with a short description of what the file does and why it is needed.
   - Unnecessary duplication, redundant fallbacks, over-complicated code, or hardcoded fallback values.
 
 # Code Quality & Architecture

--- a/docs/prompts/Task-Prompt-Template.md
+++ b/docs/prompts/Task-Prompt-Template.md
@@ -13,6 +13,8 @@ Task: Implement issue `M<milestone>-<issue-number>` end-to-end with full verific
 
 ## Execution workflow:
 
+Always print in which step you are!
+
 1. Load context from:
    - `README.md`
    - `docs/Architecture-and-Implementation-Plan.md`
@@ -65,6 +67,6 @@ Task: Implement issue `M<milestone>-<issue-number>` end-to-end with full verific
 1. **Clean Code & Architecture:** Enforce DRY (no duplication) and KISS (no over-engineering). Keep cyclomatic complexity low. Avoid deeply nested code (Arrow Anti-Pattern), spaghetti code, and excessively long methods. Use common libraries instead of reinventing the wheel.
 2. **UI/UX:** UI components must be fully responsive across screen sizes. The UI must communicate system status clearly. Always implement loading states for async actions, explicit error/success feedback, and prevent double-submissions. Good and simple but modern and beautiful UX is very important!
 3. **AI Anti-Patterns (STRICTLY FORBIDDEN):** Never implement "backup" solutions, redundant fallbacks, or placeholder code. Do not introduce technical debt.
-4. **Documentation:** Code must be self-explanatory. Add meaningful inline comments only for complex or non-obvious logic.
+4. **Documentation:** Code must be self-explanatory. Add meaningful inline comments only for complex or non-obvious logic. Every file should start with a short description of what the file does and why it is needed.
 5. **Testing:** All new or changed behavior must be accompanied by appropriate, passing tests.
 6. **Contextual Alignment:** Before coding, verify that prerequisites from previous tasks are complete. Ensure your implementation serves as a solid foundation for related upcoming issues in the backlog.


### PR DESCRIPTION
## Summary
- tighten the local code review prompt guidance
- add explicit step-progress output guidance to the task template
- require file-level purpose descriptions in the prompt templates

## Verification
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`