### PR TITLE
feat: implement OneDrive DB file selection flow

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -358,6 +358,13 @@ M3-05 implementation clarification:
 - Every Graph request acquires a bearer token from `@auth` using `GRAPH_ONEDRIVE_FILE_SCOPES`, keeping MSAL details out of the graph module surface.
 - Graph/auth failures are normalized into stable app-level graph error codes (`unauthorized`, `forbidden`, `not_found`, `conflict`, `network_error`, `unknown`) for UI and sync-layer handling.
 
+M3-06 implementation clarification:
+
+- OneDrive DB file browsing/selection is implemented in `src/features/app-shell/routes/settingsFileBindingController.ts` and `src/features/app-shell/routes/SettingsRoute.svelte`.
+- The Settings flow uses the Graph client browse surface (`listChildren`) to open the root folder and navigate child folders without adding an external picker dependency.
+- The file browser surfaces folders plus `.db` files only, and validated selections return `driveId`, `itemId`, `name`, and `parentPath` for later persistence/recovery work.
+- File selection state is session-local in M3-06; durable storage of the selected binding remains scoped to `M3-07`.
+
 Deliverables:
 
 - Stable login flow with persisted session where possible.

--- a/src/features/app-shell/graphClientResolver.test.ts
+++ b/src/features/app-shell/graphClientResolver.test.ts
@@ -1,0 +1,92 @@
+// Verifies the shared Graph client resolver keeps one instance and honors localhost test overrides.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthClient } from '@auth';
+import type { GraphClient } from '@graph';
+
+const { createGraphClientMock, resolveAppAuthClientMock } = vi.hoisted(() => ({
+  createGraphClientMock: vi.fn(),
+  resolveAppAuthClientMock: vi.fn(),
+}));
+
+vi.mock('@graph', () => ({
+  createGraphClient: createGraphClientMock,
+}));
+
+vi.mock('./authClientResolver', () => ({
+  resolveAppAuthClient: resolveAppAuthClientMock,
+}));
+
+const createStubAuthClient = (): AuthClient => ({
+  initialize: vi.fn(async () => {}),
+  getSession: vi.fn(() => ({
+    isAuthenticated: false,
+    account: null,
+  })),
+  signIn: vi.fn(async () => {}),
+  signOut: vi.fn(async () => {}),
+  getAccessToken: vi.fn(async () => 'token'),
+});
+
+const createStubGraphClient = (): GraphClient => ({
+  listChildren: vi.fn(async () => []),
+  getFileMetadata: vi.fn(async () => ({
+    eTag: '"etag-1"',
+    sizeBytes: 1,
+    lastModifiedDateTime: '2026-03-09T10:15:00Z',
+  })),
+  downloadFile: vi.fn(async () => Uint8Array.from([1])),
+  uploadFile: vi.fn(async () => ({
+    eTag: '"etag-2"',
+    sizeBytes: 1,
+    lastModifiedDateTime: '2026-03-09T10:15:00Z',
+  })),
+});
+
+describe('app graph client resolver', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    createGraphClientMock.mockReset();
+    resolveAppAuthClientMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns one shared graph client instance for non-localhost environments', async () => {
+    const stubAuthClient = createStubAuthClient();
+    const stubGraphClient = createStubGraphClient();
+    resolveAppAuthClientMock.mockReturnValue(stubAuthClient);
+    createGraphClientMock.mockReturnValue(stubGraphClient);
+
+    const { resolveAppGraphClient } = await import('./graphClientResolver');
+
+    const firstClient = resolveAppGraphClient();
+    const secondClient = resolveAppGraphClient();
+
+    expect(firstClient).toBe(stubGraphClient);
+    expect(secondClient).toBe(stubGraphClient);
+    expect(resolveAppAuthClientMock).toHaveBeenCalledTimes(1);
+    expect(createGraphClientMock).toHaveBeenCalledTimes(1);
+    expect(createGraphClientMock).toHaveBeenCalledWith({
+      authClient: stubAuthClient,
+    });
+  });
+
+  it('uses localhost test override graph client when available', async () => {
+    const overrideClient = createStubGraphClient();
+    createGraphClientMock.mockReturnValue(createStubGraphClient());
+
+    vi.stubGlobal('window', {
+      location: { hostname: 'localhost' },
+      __CONSPECTUS_GRAPH_CLIENT__: overrideClient,
+    });
+
+    const { resolveAppGraphClient } = await import('./graphClientResolver');
+
+    expect(resolveAppGraphClient()).toBe(overrideClient);
+    expect(createGraphClientMock).not.toHaveBeenCalled();
+    expect(resolveAppAuthClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/app-shell/graphClientResolver.ts
+++ b/src/features/app-shell/graphClientResolver.ts
@@ -1,0 +1,34 @@
+/** Resolves a shared Graph client instance and supports localhost test overrides for UI flows. */
+import { createGraphClient, type GraphClient } from '@graph';
+
+import { resolveAppAuthClient } from './authClientResolver';
+
+declare global {
+  interface Window {
+    __CONSPECTUS_GRAPH_CLIENT__?: GraphClient;
+  }
+}
+
+let sharedGraphClient: GraphClient | null = null;
+
+const isLocalGraphMockHost = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.location.hostname === '127.0.0.1' || window.location.hostname === 'localhost';
+};
+
+export const resolveAppGraphClient = (): GraphClient => {
+  if (isLocalGraphMockHost() && window.__CONSPECTUS_GRAPH_CLIENT__ !== undefined) {
+    return window.__CONSPECTUS_GRAPH_CLIENT__;
+  }
+
+  if (sharedGraphClient === null) {
+    sharedGraphClient = createGraphClient({
+      authClient: resolveAppAuthClient(),
+    });
+  }
+
+  return sharedGraphClient;
+};

--- a/src/features/app-shell/routes/SettingsRoute.svelte
+++ b/src/features/app-shell/routes/SettingsRoute.svelte
@@ -1,15 +1,23 @@
+<!-- Renders settings auth controls and the OneDrive DB file selection flow for the current session. -->
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import type { AuthClient } from '@auth';
+  import type { GraphClient, GraphDriveItem } from '@graph';
 
   import {
     createSettingsAuthController,
     type SettingsAuthOperation,
     type SettingsAuthState,
   } from './settingsAuthController';
+  import {
+    createSettingsFileBindingController,
+    type SettingsFileBindingState,
+  } from './settingsFileBindingController';
   import { resolveSettingsAuthClient } from './settingsAuthClientResolver';
+  import { resolveSettingsGraphClient } from './settingsGraphClientResolver';
 
   export let authClient: AuthClient = resolveSettingsAuthClient();
+  export let graphClient: GraphClient = resolveSettingsGraphClient();
 
   let state: SettingsAuthState = {
     session: {
@@ -21,6 +29,16 @@
   };
   let authOperationIsPending = false;
   let authStatusMessage = 'Signed out.';
+  let bindingState: SettingsFileBindingState = {
+    selectedBinding: null,
+    currentFolder: null,
+    items: [],
+    operation: 'idle',
+    error: null,
+    hasLoaded: false,
+    canGoBack: false,
+  };
+  let bindingStatusMessage = 'Sign in to browse and choose a .db file.';
 
   const statusMessageByOperation: Record<SettingsAuthOperation, string> = {
     initializing: 'Checking authentication status...',
@@ -41,11 +59,52 @@
     return nextState.session.isAuthenticated ? 'Signed in.' : 'Signed out.';
   };
 
+  const buildBindingStatusMessage = (nextState: SettingsFileBindingState): string => {
+    if (!state.session.isAuthenticated) {
+      return 'Sign in to browse and choose a .db file.';
+    }
+
+    if (nextState.operation === 'loading') {
+      return 'Loading OneDrive files...';
+    }
+
+    if (nextState.error !== null) {
+      return `File selection error. ${nextState.error.message}`;
+    }
+
+    if (nextState.selectedBinding !== null) {
+      return 'DB file selected for this session.';
+    }
+
+    if (nextState.hasLoaded) {
+      return 'Choose a .db file from the current OneDrive folder.';
+    }
+
+    return 'No DB file selected yet.';
+  };
+
+  const folderItems = (items: readonly GraphDriveItem[]): readonly GraphDriveItem[] =>
+    items.filter((item) => item.kind === 'folder');
+
+  const selectableFileItems = (items: readonly GraphDriveItem[]): readonly GraphDriveItem[] =>
+    items.filter((item) => item.kind === 'file');
+
   const authController = createSettingsAuthController(authClient);
+  const fileBindingController = createSettingsFileBindingController(graphClient);
   const unsubscribe = authController.subscribe((nextState) => {
+    const wasAuthenticated = state.session.isAuthenticated;
     state = nextState;
     authOperationIsPending = nextState.operation !== 'idle';
     authStatusMessage = buildStatusMessage(nextState);
+    bindingStatusMessage = buildBindingStatusMessage(bindingState);
+
+    if (wasAuthenticated && !nextState.session.isAuthenticated) {
+      fileBindingController.reset();
+    }
+  });
+  const unsubscribeFileBinding = fileBindingController.subscribe((nextState) => {
+    bindingState = nextState;
+    bindingStatusMessage = buildBindingStatusMessage(nextState);
   });
 
   const handleSignInClick = (): void => {
@@ -56,12 +115,29 @@
     void authController.signOut();
   };
 
+  const handleBrowseClick = (): void => {
+    void fileBindingController.browseRoot();
+  };
+
+  const handleBackClick = (): void => {
+    void fileBindingController.goBack();
+  };
+
+  const handleOpenFolderClick = (item: GraphDriveItem): void => {
+    void fileBindingController.openFolder(item);
+  };
+
+  const handleSelectFileClick = (item: GraphDriveItem): void => {
+    fileBindingController.selectFile(item);
+  };
+
   onMount(() => {
     void authController.initialize();
   });
 
   onDestroy(() => {
     unsubscribe();
+    unsubscribeFileBinding();
   });
 </script>
 
@@ -95,6 +171,123 @@
         <dd>{state.session.account.homeAccountId}</dd>
       </div>
     </dl>
+
+    <h3 class="settings-screen__subheading">DB file</h3>
+    <p
+      class="settings-screen__binding-status"
+      data-testid="binding-status-message"
+      aria-live="polite"
+    >
+      {bindingStatusMessage}
+    </p>
+
+    {#if bindingState.error !== null}
+      <p class="settings-screen__binding-error" role="alert">
+        {bindingState.error.message}
+      </p>
+    {/if}
+
+    <div class="settings-screen__actions">
+      <button
+        class="settings-screen__button settings-screen__button--primary"
+        type="button"
+        on:click={handleBrowseClick}
+        disabled={authOperationIsPending || bindingState.operation !== 'idle'}
+      >
+        {bindingState.selectedBinding === null
+          ? 'Choose OneDrive DB file'
+          : 'Choose another DB file'}
+      </button>
+
+      {#if bindingState.canGoBack}
+        <button
+          class="settings-screen__button settings-screen__button--secondary"
+          type="button"
+          on:click={handleBackClick}
+          disabled={bindingState.operation !== 'idle'}
+        >
+          Back to parent folder
+        </button>
+      {/if}
+    </div>
+
+    {#if bindingState.selectedBinding !== null}
+      <dl class="settings-screen__binding-summary" data-testid="selected-db-file-summary">
+        <div>
+          <dt>File name</dt>
+          <dd>{bindingState.selectedBinding.name}</dd>
+        </div>
+        <div>
+          <dt>Folder path</dt>
+          <dd>{bindingState.selectedBinding.parentPath}</dd>
+        </div>
+        <div>
+          <dt>Drive ID</dt>
+          <dd>{bindingState.selectedBinding.driveId}</dd>
+        </div>
+        <div>
+          <dt>Item ID</dt>
+          <dd>{bindingState.selectedBinding.itemId}</dd>
+        </div>
+      </dl>
+    {/if}
+
+    {#if bindingState.hasLoaded}
+      <section class="settings-screen__browser" data-testid="db-file-browser">
+        <header class="settings-screen__browser-header">
+          <h4>Current folder</h4>
+          <p>{bindingState.currentFolder?.path ?? '/'}</p>
+        </header>
+
+        {#if bindingState.items.length === 0}
+          <p class="settings-screen__browser-empty">No folders or .db files found here.</p>
+        {:else}
+          {#if folderItems(bindingState.items).length > 0}
+            <div class="settings-screen__browser-group">
+              <h4>Folders</h4>
+              <ul class="settings-screen__browser-list">
+                {#each folderItems(bindingState.items) as item (item.itemId)}
+                  <li>
+                    <button
+                      class="settings-screen__browser-item settings-screen__browser-item--folder"
+                      type="button"
+                      data-testid={`open-folder-${item.itemId}`}
+                      on:click={() => handleOpenFolderClick(item)}
+                      disabled={bindingState.operation !== 'idle'}
+                    >
+                      <span>{item.name}</span>
+                      <span>Open folder</span>
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+
+          {#if selectableFileItems(bindingState.items).length > 0}
+            <div class="settings-screen__browser-group">
+              <h4>Database files</h4>
+              <ul class="settings-screen__browser-list">
+                {#each selectableFileItems(bindingState.items) as item (item.itemId)}
+                  <li>
+                    <button
+                      class="settings-screen__browser-item settings-screen__browser-item--file"
+                      type="button"
+                      data-testid={`select-file-${item.itemId}`}
+                      on:click={() => handleSelectFileClick(item)}
+                      disabled={bindingState.operation !== 'idle'}
+                    >
+                      <span>{item.name}</span>
+                      <span>Select file</span>
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+        {/if}
+      </section>
+    {/if}
   {/if}
 
   <div class="settings-screen__actions">
@@ -141,18 +334,34 @@
     background: #ffe9e9;
   }
 
+  .settings-screen__binding-status {
+    margin: 0;
+    color: var(--text-secondary);
+  }
+
+  .settings-screen__binding-error {
+    margin: 0;
+    padding: 0.65rem;
+    border: 1px solid color-mix(in srgb, var(--error) 40%, var(--border));
+    border-radius: 0.75rem;
+    color: #7d1111;
+    background: #ffe9e9;
+  }
+
   .settings-screen__subheading {
     margin: 0;
     font-size: 0.98rem;
   }
 
-  .settings-screen__account-summary {
+  .settings-screen__account-summary,
+  .settings-screen__binding-summary {
     margin: 0;
     display: grid;
     gap: 0.55rem;
   }
 
-  .settings-screen__account-summary div {
+  .settings-screen__account-summary div,
+  .settings-screen__binding-summary div {
     display: grid;
     gap: 0.2rem;
     padding: 0.65rem;
@@ -161,13 +370,15 @@
     background: color-mix(in srgb, var(--surface) 94%, white);
   }
 
-  .settings-screen__account-summary dt {
+  .settings-screen__account-summary dt,
+  .settings-screen__binding-summary dt {
     margin: 0;
     font-size: 0.8rem;
     color: var(--text-secondary);
   }
 
-  .settings-screen__account-summary dd {
+  .settings-screen__account-summary dd,
+  .settings-screen__binding-summary dd {
     margin: 0;
     font-size: 0.95rem;
     color: var(--text-primary);
@@ -208,5 +419,70 @@
     color: var(--text-primary);
     background: var(--surface);
     border-color: var(--border);
+  }
+
+  .settings-screen__browser {
+    display: grid;
+    gap: 0.85rem;
+    padding: 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    background: color-mix(in srgb, var(--surface) 95%, white);
+  }
+
+  .settings-screen__browser-header {
+    display: grid;
+    gap: 0.2rem;
+  }
+
+  .settings-screen__browser-header h4,
+  .settings-screen__browser-group h4 {
+    margin: 0;
+    font-size: 0.88rem;
+  }
+
+  .settings-screen__browser-header p,
+  .settings-screen__browser-empty {
+    margin: 0;
+    color: var(--text-secondary);
+    word-break: break-word;
+  }
+
+  .settings-screen__browser-group {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .settings-screen__browser-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.45rem;
+  }
+
+  .settings-screen__browser-item {
+    width: 100%;
+    min-height: 3rem;
+    padding: 0.7rem 0.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.8rem;
+    border: 1px solid var(--border);
+    border-radius: 0.85rem;
+    background: #ffffff;
+    color: var(--text-primary);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .settings-screen__browser-item--folder {
+    border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+  }
+
+  .settings-screen__browser-item--file {
+    border-color: color-mix(in srgb, var(--success) 35%, var(--border));
   }
 </style>

--- a/src/features/app-shell/routes/settingsFileBindingController.test.ts
+++ b/src/features/app-shell/routes/settingsFileBindingController.test.ts
@@ -1,0 +1,215 @@
+// Tests the settings-route file browser controller for browse, navigation, selection, and errors.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GraphClient, GraphDriveItem } from '@graph';
+
+import { createSettingsFileBindingController } from './settingsFileBindingController';
+
+const ROOT_FOLDER_ITEM: GraphDriveItem = {
+  driveId: 'drive-123',
+  itemId: 'folder-1',
+  name: 'Finance',
+  parentPath: '/',
+  kind: 'folder',
+};
+
+const ROOT_DB_FILE_ITEM: GraphDriveItem = {
+  driveId: 'drive-123',
+  itemId: 'file-1',
+  name: 'conspectus.db',
+  parentPath: '/',
+  kind: 'file',
+};
+
+const ROOT_NON_DB_FILE_ITEM: GraphDriveItem = {
+  driveId: 'drive-123',
+  itemId: 'file-2',
+  name: 'notes.txt',
+  parentPath: '/',
+  kind: 'file',
+};
+
+const ROOT_ITEMS: readonly GraphDriveItem[] = [
+  ROOT_FOLDER_ITEM,
+  ROOT_DB_FILE_ITEM,
+  ROOT_NON_DB_FILE_ITEM,
+];
+
+const FINANCE_ITEMS: readonly GraphDriveItem[] = [
+  {
+    driveId: 'drive-123',
+    itemId: 'file-3',
+    name: 'budget.db',
+    parentPath: '/Finance',
+    kind: 'file',
+  },
+];
+
+const createGraphClientHarness = (): {
+  readonly graphClient: GraphClient;
+  readonly listChildren: ReturnType<typeof vi.fn>;
+} => {
+  const listChildren = vi.fn(async (folder) => {
+    if (folder === undefined) {
+      return ROOT_ITEMS;
+    }
+
+    if (folder.itemId === 'folder-1') {
+      return FINANCE_ITEMS;
+    }
+
+    return [];
+  });
+
+  return {
+    graphClient: {
+      listChildren,
+      getFileMetadata: vi.fn(async () => ({
+        eTag: '"etag-1"',
+        sizeBytes: 2048,
+        lastModifiedDateTime: '2026-03-09T10:15:00Z',
+      })),
+      downloadFile: vi.fn(async () => Uint8Array.from([1, 2, 3])),
+      uploadFile: vi.fn(async () => ({
+        eTag: '"etag-2"',
+        sizeBytes: 2048,
+        lastModifiedDateTime: '2026-03-09T11:15:00Z',
+      })),
+    },
+    listChildren,
+  };
+};
+
+describe('settings file binding controller', () => {
+  let harness: ReturnType<typeof createGraphClientHarness>;
+
+  beforeEach(() => {
+    harness = createGraphClientHarness();
+  });
+
+  it('loads root items and keeps only folders and .db files', async () => {
+    const controller = createSettingsFileBindingController(harness.graphClient);
+
+    await controller.browseRoot();
+
+    expect(controller.getState()).toEqual({
+      selectedBinding: null,
+      currentFolder: null,
+      items: [ROOT_FOLDER_ITEM, ROOT_DB_FILE_ITEM],
+      operation: 'idle',
+      error: null,
+      hasLoaded: true,
+      canGoBack: false,
+    });
+  });
+
+  it('navigates into a folder and back to the root listing', async () => {
+    const controller = createSettingsFileBindingController(harness.graphClient);
+    await controller.browseRoot();
+
+    await controller.openFolder(ROOT_FOLDER_ITEM);
+
+    expect(controller.getState().currentFolder).toEqual({
+      driveId: 'drive-123',
+      itemId: 'folder-1',
+      path: '/Finance',
+    });
+    expect(controller.getState().items).toEqual(FINANCE_ITEMS);
+    expect(controller.getState().canGoBack).toBe(true);
+
+    await controller.goBack();
+
+    expect(controller.getState().currentFolder).toBeNull();
+    expect(controller.getState().items).toEqual([ROOT_FOLDER_ITEM, ROOT_DB_FILE_ITEM]);
+    expect(controller.getState().canGoBack).toBe(false);
+  });
+
+  it('stores a validated file binding when a .db file is selected', async () => {
+    const controller = createSettingsFileBindingController(harness.graphClient);
+    await controller.browseRoot();
+
+    controller.selectFile(ROOT_DB_FILE_ITEM);
+
+    expect(controller.getState().selectedBinding).toEqual({
+      driveId: 'drive-123',
+      itemId: 'file-1',
+      name: 'conspectus.db',
+      parentPath: '/',
+    });
+    expect(controller.getState().error).toBeNull();
+  });
+
+  it('rejects invalid non-database file selections', () => {
+    const controller = createSettingsFileBindingController(harness.graphClient);
+
+    controller.selectFile(ROOT_NON_DB_FILE_ITEM);
+
+    expect(controller.getState().selectedBinding).toBeNull();
+    expect(controller.getState().error).toEqual({
+      code: 'invalid_selection',
+      message: 'Selected file must use the .db extension.',
+      cause: {
+        code: 'invalid_selection',
+        message: 'Selected file must use the .db extension.',
+      },
+    });
+  });
+
+  it('rejects file selections that are missing required binding identifiers', () => {
+    const controller = createSettingsFileBindingController(harness.graphClient);
+
+    controller.selectFile({
+      driveId: '',
+      itemId: 'file-4',
+      name: 'broken.db',
+      parentPath: '/',
+      kind: 'file',
+    });
+
+    expect(controller.getState().selectedBinding).toBeNull();
+    expect(controller.getState().error).toEqual({
+      code: 'invalid_selection',
+      message: 'Selected file did not include the required OneDrive identifiers.',
+      cause: {
+        code: 'invalid_selection',
+        message: 'Selected file did not include the required OneDrive identifiers.',
+      },
+    });
+  });
+
+  it('captures graph browse failures as controller errors', async () => {
+    harness.listChildren.mockRejectedValueOnce({
+      code: 'network_error',
+      message: 'OneDrive is unavailable.',
+    });
+    const controller = createSettingsFileBindingController(harness.graphClient);
+
+    await controller.browseRoot();
+
+    expect(controller.getState().error).toEqual({
+      code: 'network_error',
+      message: 'OneDrive is unavailable.',
+      status: undefined,
+      cause: undefined,
+    });
+    expect(controller.getState().items).toEqual([]);
+    expect(controller.getState().operation).toBe('idle');
+  });
+
+  it('resets the current browse and selected binding state', async () => {
+    const controller = createSettingsFileBindingController(harness.graphClient);
+    await controller.browseRoot();
+    controller.selectFile(ROOT_DB_FILE_ITEM);
+
+    controller.reset();
+
+    expect(controller.getState()).toEqual({
+      selectedBinding: null,
+      currentFolder: null,
+      items: [],
+      operation: 'idle',
+      error: null,
+      hasLoaded: false,
+      canGoBack: false,
+    });
+  });
+});

--- a/src/features/app-shell/routes/settingsFileBindingController.ts
+++ b/src/features/app-shell/routes/settingsFileBindingController.ts
@@ -1,0 +1,265 @@
+// Manages the settings-route OneDrive file browser and validates selected database bindings.
+import type {
+  DriveFolderReference,
+  DriveItemBinding,
+  GraphClient,
+  GraphDriveItem,
+  GraphError,
+  GraphErrorCode,
+} from '@graph';
+
+export type SettingsFileBindingOperation = 'idle' | 'loading';
+
+export type SettingsFileBindingErrorCode = GraphErrorCode | 'invalid_selection';
+
+export interface SettingsFileBindingError {
+  readonly code: SettingsFileBindingErrorCode;
+  readonly message: string;
+  readonly status?: number;
+  readonly cause?: unknown;
+}
+
+export interface SettingsFileBindingState {
+  readonly selectedBinding: DriveItemBinding | null;
+  readonly currentFolder: DriveFolderReference | null;
+  readonly items: readonly GraphDriveItem[];
+  readonly operation: SettingsFileBindingOperation;
+  readonly error: SettingsFileBindingError | null;
+  readonly hasLoaded: boolean;
+  readonly canGoBack: boolean;
+}
+
+export type SettingsFileBindingStateListener = (state: SettingsFileBindingState) => void;
+
+export interface SettingsFileBindingController {
+  getState(): SettingsFileBindingState;
+  subscribe(listener: SettingsFileBindingStateListener): () => void;
+  browseRoot(): Promise<void>;
+  openFolder(item: GraphDriveItem): Promise<void>;
+  goBack(): Promise<void>;
+  selectFile(item: GraphDriveItem): void;
+  reset(): void;
+}
+
+const INITIAL_STATE: SettingsFileBindingState = {
+  selectedBinding: null,
+  currentFolder: null,
+  items: [],
+  operation: 'idle',
+  error: null,
+  hasLoaded: false,
+  canGoBack: false,
+};
+
+const isGraphError = (value: unknown): value is GraphError => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const graphError = value as Partial<GraphError>;
+  return typeof graphError.code === 'string' && typeof graphError.message === 'string';
+};
+
+const createGraphBindingError = (error: GraphError): SettingsFileBindingError => {
+  return {
+    code: error.code,
+    message: error.message,
+    cause: error.cause,
+    ...(error.status !== undefined ? { status: error.status } : {}),
+  };
+};
+
+const toBindingError = (error: unknown, fallbackMessage: string): SettingsFileBindingError => {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { code?: unknown }).code === 'invalid_selection' &&
+    typeof (error as { message?: unknown }).message === 'string'
+  ) {
+    return {
+      code: 'invalid_selection',
+      message: (error as { message: string }).message,
+      cause: error,
+    };
+  }
+
+  if (isGraphError(error)) {
+    return createGraphBindingError(error);
+  }
+
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return {
+      code: 'unknown',
+      message: error.message,
+      cause: error,
+    };
+  }
+
+  return {
+    code: 'unknown',
+    message: fallbackMessage,
+    cause: error,
+  };
+};
+
+const joinFolderPath = (parentPath: string, name: string): string => {
+  if (parentPath === '/') {
+    return `/${name}`;
+  }
+
+  return `${parentPath}/${name}`;
+};
+
+const isSelectableDatabaseFile = (item: GraphDriveItem): boolean =>
+  item.kind === 'folder' || item.name.toLowerCase().endsWith('.db');
+
+const validateSelectedBinding = (item: GraphDriveItem): DriveItemBinding => {
+  if (item.kind !== 'file') {
+    throw {
+      code: 'invalid_selection',
+      message: 'Only database files can be selected.',
+    } satisfies SettingsFileBindingError;
+  }
+
+  if (!item.name.toLowerCase().endsWith('.db')) {
+    throw {
+      code: 'invalid_selection',
+      message: 'Selected file must use the .db extension.',
+    } satisfies SettingsFileBindingError;
+  }
+
+  if (
+    item.driveId.trim().length === 0 ||
+    item.itemId.trim().length === 0 ||
+    item.name.trim().length === 0 ||
+    item.parentPath.trim().length === 0
+  ) {
+    throw {
+      code: 'invalid_selection',
+      message: 'Selected file did not include the required OneDrive identifiers.',
+    } satisfies SettingsFileBindingError;
+  }
+
+  return {
+    driveId: item.driveId,
+    itemId: item.itemId,
+    name: item.name,
+    parentPath: item.parentPath,
+  };
+};
+
+export const createSettingsFileBindingController = (
+  graphClient: GraphClient,
+): SettingsFileBindingController => {
+  let state: SettingsFileBindingState = INITIAL_STATE;
+  let folderStack: readonly DriveFolderReference[] = [];
+  const listeners = new Set<SettingsFileBindingStateListener>();
+
+  const emitState = (): void => {
+    for (const listener of listeners) {
+      listener(state);
+    }
+  };
+
+  const updateState = (patch: Partial<SettingsFileBindingState>): void => {
+    state = {
+      ...state,
+      ...patch,
+      currentFolder: folderStack.at(-1) ?? null,
+      canGoBack: folderStack.length > 0,
+    };
+    emitState();
+  };
+
+  const loadItems = async (folder?: DriveFolderReference): Promise<void> => {
+    updateState({
+      operation: 'loading',
+      error: null,
+    });
+
+    try {
+      const items = await graphClient.listChildren(folder);
+      updateState({
+        items: items.filter(isSelectableDatabaseFile),
+        operation: 'idle',
+        error: null,
+        hasLoaded: true,
+      });
+    } catch (error) {
+      updateState({
+        items: [],
+        operation: 'idle',
+        error: toBindingError(error, 'Failed to load OneDrive files.'),
+        hasLoaded: true,
+      });
+    }
+  };
+
+  return {
+    getState(): SettingsFileBindingState {
+      return state;
+    },
+
+    subscribe(listener: SettingsFileBindingStateListener): () => void {
+      listeners.add(listener);
+      listener(state);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    async browseRoot(): Promise<void> {
+      if (state.operation !== 'idle') {
+        return;
+      }
+
+      folderStack = [];
+      await loadItems();
+    },
+
+    async openFolder(item: GraphDriveItem): Promise<void> {
+      if (state.operation !== 'idle' || item.kind !== 'folder') {
+        return;
+      }
+
+      folderStack = [
+        ...folderStack,
+        {
+          driveId: item.driveId,
+          itemId: item.itemId,
+          path: joinFolderPath(item.parentPath, item.name),
+        },
+      ];
+      await loadItems(folderStack.at(-1));
+    },
+
+    async goBack(): Promise<void> {
+      if (state.operation !== 'idle' || folderStack.length === 0) {
+        return;
+      }
+
+      folderStack = folderStack.slice(0, -1);
+      await loadItems(folderStack.at(-1));
+    },
+
+    selectFile(item: GraphDriveItem): void {
+      try {
+        updateState({
+          selectedBinding: validateSelectedBinding(item),
+          error: null,
+        });
+      } catch (error) {
+        updateState({
+          error: toBindingError(error, 'Failed to validate the selected OneDrive file.'),
+        });
+      }
+    },
+
+    reset(): void {
+      folderStack = [];
+      state = INITIAL_STATE;
+      emitState();
+    },
+  };
+};

--- a/src/features/app-shell/routes/settingsGraphClientResolver.ts
+++ b/src/features/app-shell/routes/settingsGraphClientResolver.ts
@@ -1,0 +1,4 @@
+// Re-exports the shared app Graph client resolver for the Settings route.
+import { resolveAppGraphClient } from '../graphClientResolver';
+
+export const resolveSettingsGraphClient = resolveAppGraphClient;

--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -14,9 +14,10 @@ Dependency boundaries:
 Expected public interfaces (`src/graph/index.ts`):
 
 - `DriveItemBinding`: stored identity for the selected OneDrive database file.
+- `DriveFolderReference` and `GraphDriveItem`: typed OneDrive browse models for folder/file selection.
 - `GraphFileMetadata`: eTag/size/modified metadata used by sync decisions.
 - `GraphUploadResult`: post-upload metadata returned from Graph.
-- `GraphClient`: metadata, download, and conditional-upload operations.
+- `GraphClient`: browse, metadata, download, and conditional-upload operations.
 - `createGraphClient`: factory that injects auth-backed bearer tokens into Graph requests.
 - `GraphErrorCode` and `GraphError`: normalized failure model for UI/services.
 

--- a/src/graph/graphClient.test.ts
+++ b/src/graph/graphClient.test.ts
@@ -1,3 +1,4 @@
+// Tests the Microsoft Graph client browse/read/upload behavior and error normalization.
 import { describe, expect, it, vi } from 'vitest';
 
 import { createGraphClient } from './graphClient';
@@ -47,6 +48,114 @@ const getFetchCall = (
   (fetchFn.mock.calls[0] as [string, RequestInit | undefined]) ?? ['', undefined];
 
 describe('createGraphClient', () => {
+  it('lists root drive children with normalized browse item details', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        value: [
+          {
+            id: 'file-2',
+            name: 'zeta.db',
+            parentReference: {
+              driveId: 'drive-123',
+              path: '/drive/root:/Finance',
+            },
+            file: {},
+          },
+          {
+            id: 'folder-1',
+            name: 'Archives',
+            parentReference: {
+              driveId: 'drive-123',
+              path: '/drive/root:',
+            },
+            folder: {},
+          },
+          {
+            id: 'file-1',
+            name: 'alpha.db',
+            parentReference: {
+              driveId: 'drive-123',
+              path: '/drive/root:/Finance',
+            },
+            file: {},
+          },
+          {
+            id: 'ignored-package',
+            name: 'Package',
+            parentReference: {
+              driveId: 'drive-123',
+              path: '/drive/root:',
+            },
+          },
+        ],
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    const items = await client.listChildren();
+
+    expect(items).toEqual([
+      {
+        driveId: 'drive-123',
+        itemId: 'folder-1',
+        name: 'Archives',
+        parentPath: '/',
+        kind: 'folder',
+      },
+      {
+        driveId: 'drive-123',
+        itemId: 'file-1',
+        name: 'alpha.db',
+        parentPath: '/Finance',
+        kind: 'file',
+      },
+      {
+        driveId: 'drive-123',
+        itemId: 'file-2',
+        name: 'zeta.db',
+        parentPath: '/Finance',
+        kind: 'file',
+      },
+    ]);
+
+    const [requestUrl] = getFetchCall(fetchFn);
+    expect(requestUrl).toBe(
+      'https://graph.microsoft.com/v1.0/me/drive/root/children?$select=id%2Cname%2CparentReference%2Cfile%2Cfolder',
+    );
+  });
+
+  it('lists folder children from a selected folder reference', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        value: [
+          {
+            id: 'file-1',
+            name: 'conspectus.db',
+            parentReference: {
+              driveId: 'drive-123',
+              path: '/drive/root:/Finance',
+            },
+            file: {},
+          },
+        ],
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await client.listChildren({
+      driveId: 'drive-123',
+      itemId: 'folder-456',
+      path: '/Finance',
+    });
+
+    const [requestUrl] = getFetchCall(fetchFn);
+    expect(requestUrl).toBe(
+      'https://graph.microsoft.com/v1.0/drives/drive-123/items/folder-456/children?$select=id%2Cname%2CparentReference%2Cfile%2Cfolder',
+    );
+  });
+
   it('fetches file metadata with an auth-backed Graph request', async () => {
     const authClient = createAuthClient();
     const fetchFn = vi.fn(async () =>
@@ -295,6 +404,30 @@ describe('createGraphClient', () => {
     ).rejects.toMatchObject({
       code: 'unknown',
       message: 'Microsoft Graph upload response did not include the required file fields.',
+    });
+  });
+
+  it('rejects invalid children payloads with an unknown Graph error', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        value: [
+          {
+            id: 'file-1',
+            name: 'conspectus.db',
+            parentReference: {
+              path: '/drive/root:/Finance',
+            },
+            file: {},
+          },
+        ],
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.listChildren()).rejects.toMatchObject({
+      code: 'unknown',
+      message: 'Microsoft Graph children response did not include the required file fields.',
     });
   });
 });

--- a/src/graph/graphClient.ts
+++ b/src/graph/graphClient.ts
@@ -1,22 +1,40 @@
+// Implements the typed Microsoft Graph client used for OneDrive browse, read, and upload flows.
 import { GRAPH_ONEDRIVE_FILE_SCOPES, type AuthClient } from '@auth';
 
 import type {
   DriveItemBinding,
+  DriveFolderReference,
   GraphClient,
+  GraphDriveItem,
   GraphErrorCode,
   GraphFileMetadata,
   GraphUploadResult,
 } from './index';
 
 const GRAPH_API_BASE_URL = 'https://graph.microsoft.com/v1.0';
+const CHILDREN_FIELDS = 'id,name,parentReference,file,folder';
 const METADATA_FIELDS = 'eTag,size,lastModifiedDateTime';
 
 type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
 
+interface GraphParentReferencePayload {
+  readonly driveId?: unknown;
+  readonly path?: unknown;
+}
+
 interface GraphItemPayload {
+  readonly id?: unknown;
+  readonly name?: unknown;
+  readonly parentReference?: unknown;
+  readonly file?: unknown;
+  readonly folder?: unknown;
   readonly eTag?: unknown;
   readonly size?: unknown;
   readonly lastModifiedDateTime?: unknown;
+}
+
+interface GraphChildrenPayload {
+  readonly value?: unknown;
 }
 
 interface GraphErrorPayload {
@@ -54,6 +72,8 @@ const isObject = (value: unknown): value is Record<string, unknown> =>
 
 const isGraphItemPayload = (value: unknown): value is GraphItemPayload => isObject(value);
 
+const isGraphChildrenPayload = (value: unknown): value is GraphChildrenPayload => isObject(value);
+
 const isGraphErrorPayload = (value: unknown): value is GraphErrorPayload => isObject(value);
 
 const getGraphErrorMessage = (payload: unknown): string | null => {
@@ -76,6 +96,27 @@ const buildDriveItemUrl = (binding: DriveItemBinding, suffix = ''): string => {
   const driveId = encodeURIComponent(binding.driveId);
   const itemId = encodeURIComponent(binding.itemId);
   return `${GRAPH_API_BASE_URL}/drives/${driveId}/items/${itemId}${suffix}`;
+};
+
+const buildFolderChildrenUrl = (folder?: DriveFolderReference): string => {
+  if (folder === undefined) {
+    return `${GRAPH_API_BASE_URL}/me/drive/root/children`;
+  }
+
+  const driveId = encodeURIComponent(folder.driveId);
+  const itemId = encodeURIComponent(folder.itemId);
+  return `${GRAPH_API_BASE_URL}/drives/${driveId}/items/${itemId}/children`;
+};
+
+const normalizeParentPath = (value: string): string => {
+  const trimmedValue = value.trim();
+  const delimiterIndex = trimmedValue.indexOf(':');
+  const graphPath = delimiterIndex >= 0 ? trimmedValue.slice(delimiterIndex + 1) : trimmedValue;
+  const decodedPath = decodeURIComponent(graphPath);
+  const normalizedPath = decodedPath.length > 0 ? decodedPath : '/';
+  const withLeadingSlash = normalizedPath.startsWith('/') ? normalizedPath : `/${normalizedPath}`;
+  const withoutTrailingSlash = withLeadingSlash.replace(/\/+$/g, '');
+  return withoutTrailingSlash.length > 0 ? withoutTrailingSlash : '/';
 };
 
 const createAuthorizedHeaders = (accessToken: string, headers?: HeadersInit): Headers => {
@@ -196,6 +237,41 @@ const readJsonPayload = async (
   }
 };
 
+const normalizeDriveItem = (
+  payload: unknown,
+  invalidResponseMessage: string,
+): GraphDriveItem | null => {
+  if (!isGraphItemPayload(payload)) {
+    throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
+  }
+
+  if (
+    typeof payload.id !== 'string' ||
+    typeof payload.name !== 'string' ||
+    !isObject(payload.parentReference) ||
+    typeof (payload.parentReference as GraphParentReferencePayload).driveId !== 'string' ||
+    typeof (payload.parentReference as GraphParentReferencePayload).path !== 'string'
+  ) {
+    throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
+  }
+
+  const kind = isObject(payload.folder) ? 'folder' : isObject(payload.file) ? 'file' : null;
+
+  if (kind === null) {
+    return null;
+  }
+
+  return {
+    driveId: (payload.parentReference as GraphParentReferencePayload).driveId as string,
+    itemId: payload.id,
+    name: payload.name,
+    parentPath: normalizeParentPath(
+      (payload.parentReference as GraphParentReferencePayload).path as string,
+    ),
+    kind,
+  };
+};
+
 const normalizeGraphItem = (
   payload: unknown,
   invalidResponseMessage: string,
@@ -218,6 +294,26 @@ const normalizeGraphItem = (
     sizeBytes: payload.size,
     lastModifiedDateTime: payload.lastModifiedDateTime,
   };
+};
+
+const normalizeChildrenPayload = (
+  payload: unknown,
+  invalidResponseMessage: string,
+): readonly GraphDriveItem[] => {
+  if (!isGraphChildrenPayload(payload) || !Array.isArray(payload.value)) {
+    throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
+  }
+
+  return payload.value
+    .map((childPayload) => normalizeDriveItem(childPayload, invalidResponseMessage))
+    .filter((child): child is GraphDriveItem => child !== null)
+    .sort((left, right) => {
+      if (left.kind !== right.kind) {
+        return left.kind === 'folder' ? -1 : 1;
+      }
+
+      return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
+    });
 };
 
 export const createGraphClient = (options: CreateGraphClientOptions): GraphClient => {
@@ -255,6 +351,20 @@ export const createGraphClient = (options: CreateGraphClientOptions): GraphClien
   };
 
   return {
+    async listChildren(folder): Promise<readonly GraphDriveItem[]> {
+      const childrenUrl = `${buildFolderChildrenUrl(folder)}?$select=${encodeURIComponent(CHILDREN_FIELDS)}`;
+      const response = await executeRequest(childrenUrl);
+      const payload = await readJsonPayload(
+        response,
+        'Microsoft Graph children response did not include the required file fields.',
+      );
+
+      return normalizeChildrenPayload(
+        payload,
+        'Microsoft Graph children response did not include the required file fields.',
+      );
+    },
+
     async getFileMetadata(binding): Promise<GraphFileMetadata> {
       const metadataUrl = `${buildDriveItemUrl(binding)}?$select=${encodeURIComponent(METADATA_FIELDS)}`;
       const response = await executeRequest(metadataUrl);

--- a/src/graph/index.test.ts
+++ b/src/graph/index.test.ts
@@ -1,3 +1,4 @@
+// Verifies the public graph barrel keeps the stable browse/read/upload client contract.
 import { describe, expect, it, vi } from 'vitest';
 
 import { createGraphClient } from './index';
@@ -29,6 +30,7 @@ describe('graph barrel contract', () => {
 
     expect(client).toEqual(
       expect.objectContaining({
+        listChildren: expect.any(Function),
         getFileMetadata: expect.any(Function),
         downloadFile: expect.any(Function),
         uploadFile: expect.any(Function),

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,8 +1,25 @@
+// Defines the public Microsoft Graph types and client contract used by app features.
 export interface DriveItemBinding {
   readonly driveId: string;
   readonly itemId: string;
   readonly name: string;
   readonly parentPath: string;
+}
+
+export interface DriveFolderReference {
+  readonly driveId: string;
+  readonly itemId: string;
+  readonly path: string;
+}
+
+export type GraphDriveItemKind = 'file' | 'folder';
+
+export interface GraphDriveItem {
+  readonly driveId: string;
+  readonly itemId: string;
+  readonly name: string;
+  readonly parentPath: string;
+  readonly kind: GraphDriveItemKind;
 }
 
 export interface GraphFileMetadata {
@@ -33,6 +50,7 @@ export interface GraphError {
 }
 
 export interface GraphClient {
+  listChildren(folder?: DriveFolderReference): Promise<readonly GraphDriveItem[]>;
   getFileMetadata(binding: DriveItemBinding): Promise<GraphFileMetadata>;
   downloadFile(binding: DriveItemBinding): Promise<Uint8Array>;
   uploadFile(

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -1,3 +1,4 @@
+// Covers the app-shell navigation, auth mock flow, and OneDrive file selection behavior in a browser.
 import { expect, test } from '@playwright/test';
 
 test.use({ viewport: { width: 390, height: 844 } });
@@ -38,6 +39,10 @@ type MockAuthClientOptions = {
   readonly failSignIn?: boolean;
   readonly failSignOut?: boolean;
   readonly startAuthenticated?: boolean;
+};
+
+type MockGraphClientOptions = {
+  readonly failListChildren?: boolean;
 };
 
 const installMockAuthClient = async (
@@ -121,6 +126,81 @@ const installMockAuthClient = async (
   }, options);
 };
 
+const installMockGraphClient = async (
+  page: import('@playwright/test').Page,
+  options: MockGraphClientOptions = {},
+): Promise<void> => {
+  await page.addInitScript((mockOptions: MockGraphClientOptions) => {
+    const rootItems = [
+      {
+        driveId: 'drive-123',
+        itemId: 'folder-finance',
+        name: 'Finance',
+        parentPath: '/',
+        kind: 'folder',
+      },
+      {
+        driveId: 'drive-123',
+        itemId: 'file-root-db',
+        name: 'conspectus.db',
+        parentPath: '/',
+        kind: 'file',
+      },
+      {
+        driveId: 'drive-123',
+        itemId: 'file-root-text',
+        name: 'notes.txt',
+        parentPath: '/',
+        kind: 'file',
+      },
+    ];
+
+    const financeItems = [
+      {
+        driveId: 'drive-123',
+        itemId: 'file-finance-db',
+        name: 'budget.db',
+        parentPath: '/Finance',
+        kind: 'file',
+      },
+    ];
+
+    (window as Window & { __CONSPECTUS_GRAPH_CLIENT__?: unknown }).__CONSPECTUS_GRAPH_CLIENT__ = {
+      async listChildren(folder?: { itemId?: string }) {
+        if (mockOptions.failListChildren) {
+          throw {
+            code: 'network_error',
+            message: 'Mock OneDrive browse failure.',
+          };
+        }
+
+        if (folder?.itemId === 'folder-finance') {
+          return financeItems;
+        }
+
+        return rootItems;
+      },
+      async getFileMetadata() {
+        return {
+          eTag: '"etag-1"',
+          sizeBytes: 2048,
+          lastModifiedDateTime: '2026-03-09T10:15:00Z',
+        };
+      },
+      async downloadFile() {
+        return new Uint8Array([1, 2, 3]);
+      },
+      async uploadFile() {
+        return {
+          eTag: '"etag-2"',
+          sizeBytes: 2048,
+          lastModifiedDateTime: '2026-03-09T11:15:00Z',
+        };
+      },
+    };
+  }, options);
+};
+
 test('shows startup configuration error when required runtime env is missing', async ({ page }) => {
   await page.route('**/*.js', async (route) => {
     const response = await route.fetch();
@@ -198,6 +278,41 @@ test('supports sign-in and sign-out auth UX states in settings', async ({ page }
   await expect(signOutButton).toBeDisabled();
   await expect(page.getByRole('button', { name: 'Sign in with Microsoft' })).toBeVisible();
   await expect(statusMessage).toContainText('Signed out.');
+});
+
+test('allows selecting a OneDrive .db file from the settings browser', async ({ page }) => {
+  await installMockAuthClient(page, {
+    startAuthenticated: true,
+  });
+  await installMockGraphClient(page);
+
+  await page.goto(appPath('#/settings'));
+
+  await expect(page.getByTestId('signed-in-account-summary')).toBeVisible();
+  await expect(page.getByTestId('binding-status-message')).toContainText(
+    'No DB file selected yet.',
+  );
+
+  await page.getByRole('button', { name: 'Choose OneDrive DB file' }).click();
+
+  await expect(page.getByTestId('db-file-browser')).toBeVisible();
+  await expect(page.getByText('Finance')).toBeVisible();
+  await expect(page.getByText('conspectus.db')).toBeVisible();
+  await expect(page.getByText('notes.txt')).toHaveCount(0);
+
+  await page.getByTestId('open-folder-folder-finance').click();
+  await expect(page.getByText('/Finance')).toBeVisible();
+  await expect(page.getByText('budget.db')).toBeVisible();
+
+  await page.getByTestId('select-file-file-finance-db').click();
+
+  await expect(page.getByTestId('binding-status-message')).toContainText(
+    'DB file selected for this session.',
+  );
+  await expect(page.getByTestId('selected-db-file-summary')).toContainText('budget.db');
+  await expect(page.getByTestId('selected-db-file-summary')).toContainText('/Finance');
+  await expect(page.getByTestId('selected-db-file-summary')).toContainText('drive-123');
+  await expect(page.getByTestId('selected-db-file-summary')).toContainText('file-finance-db');
 });
 
 test('processes redirect auth hash before route navigation and keeps signed-in status', async ({


### PR DESCRIPTION
## Summary
- add Graph browse support for OneDrive root/folder child listing
- add the Settings file-binding controller and resolver-backed OneDrive browser UI
- cover the flow with graph, controller, resolver, and Playwright tests

## Acceptance Criteria
- [x] User can select a DB file once.
- [x] Selection returns driveId, itemId, 
ame, and parentPath for fallback recovery.
- [x] Selection data is validated before it is handed off for later persistence.

## Verification
- [x] npm run format
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test
- [x] npm run build
- [x] npm run test:e2e

Closes #39