### PR TITLE
docs: mark M3-06 done in backlog

### DIFF
--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -260,7 +260,7 @@ An issue is only considered done when:
 - Depends on: `M3-03`
 - GitHub: [#37](https://github.com/Jon2050/Conspectus-Mobile/issues/37)
 
-### :green_circle: M3-06 Implement OneDrive file selection flow
+### :white_check_mark: M3-06 Implement OneDrive file selection flow
 
 - Label: `feature`
 - Milestone: `M3 - Auth + OneDrive Binding`


### PR DESCRIPTION
## Summary
- update the backlog marker for M3-06 after the merged delivery of PR #138

## Verification
- [x] npm run format
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test
- [x] npm run build
- [x] npm run test:e2e