### PR TITLE
feat: implement M3-06 OneDrive file selection flow

### DIFF
--- a/src/features/app-shell/routes/SettingsRoute.svelte
+++ b/src/features/app-shell/routes/SettingsRoute.svelte
@@ -1,8 +1,10 @@
 <!-- Renders settings auth controls and the OneDrive DB file selection flow for the current session. -->
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import type { AuthClient } from '@auth';
   import type { GraphClient, GraphDriveItem } from '@graph';
+  import { appSelectedDriveItemBindingStore } from '@shared';
 
   import {
     createSettingsAuthController,
@@ -90,7 +92,17 @@
     items.filter((item) => item.kind === 'file');
 
   const authController = createSettingsAuthController(authClient);
-  const fileBindingController = createSettingsFileBindingController(graphClient);
+  const fileBindingController = createSettingsFileBindingController(graphClient, {
+    initialSelectedBinding: get(appSelectedDriveItemBindingStore),
+    onBindingChange: (binding) => {
+      if (binding === null) {
+        appSelectedDriveItemBindingStore.clear();
+        return;
+      }
+
+      appSelectedDriveItemBindingStore.setBinding(binding);
+    },
+  });
   const unsubscribe = authController.subscribe((nextState) => {
     const wasAuthenticated = state.session.isAuthenticated;
     state = nextState;
@@ -239,7 +251,7 @@
           <p>{bindingState.currentFolder?.path ?? '/'}</p>
         </header>
 
-        {#if bindingState.items.length === 0}
+        {#if bindingState.error === null && bindingState.items.length === 0}
           <p class="settings-screen__browser-empty">No folders or .db files found here.</p>
         {:else}
           {#if folderItems(bindingState.items).length > 0}

--- a/src/features/app-shell/routes/settingsFileBindingController.test.ts
+++ b/src/features/app-shell/routes/settingsFileBindingController.test.ts
@@ -1,6 +1,6 @@
 // Tests the settings-route file browser controller for browse, navigation, selection, and errors.
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { GraphClient, GraphDriveItem } from '@graph';
+import type { DriveItemBinding, GraphClient, GraphDriveItem } from '@graph';
 
 import { createSettingsFileBindingController } from './settingsFileBindingController';
 
@@ -44,6 +44,19 @@ const FINANCE_ITEMS: readonly GraphDriveItem[] = [
   },
 ];
 
+const createDeferred = <T>(): { promise: Promise<T>; resolve(value: T): void } => {
+  let resolvePromise: (value: T) => void = () => {};
+
+  return {
+    promise: new Promise<T>((resolve) => {
+      resolvePromise = resolve;
+    }),
+    resolve: (value: T) => {
+      resolvePromise(value);
+    },
+  };
+};
+
 const createGraphClientHarness = (): {
   readonly graphClient: GraphClient;
   readonly listChildren: ReturnType<typeof vi.fn>;
@@ -81,9 +94,11 @@ const createGraphClientHarness = (): {
 
 describe('settings file binding controller', () => {
   let harness: ReturnType<typeof createGraphClientHarness>;
+  let onBindingChange: ReturnType<typeof vi.fn<(binding: DriveItemBinding | null) => void>>;
 
   beforeEach(() => {
     harness = createGraphClientHarness();
+    onBindingChange = vi.fn<(binding: DriveItemBinding | null) => void>();
   });
 
   it('loads root items and keeps only folders and .db files', async () => {
@@ -124,7 +139,9 @@ describe('settings file binding controller', () => {
   });
 
   it('stores a validated file binding when a .db file is selected', async () => {
-    const controller = createSettingsFileBindingController(harness.graphClient);
+    const controller = createSettingsFileBindingController(harness.graphClient, {
+      onBindingChange,
+    });
     await controller.browseRoot();
 
     controller.selectFile(ROOT_DB_FILE_ITEM);
@@ -136,10 +153,18 @@ describe('settings file binding controller', () => {
       parentPath: '/',
     });
     expect(controller.getState().error).toBeNull();
+    expect(onBindingChange).toHaveBeenCalledWith({
+      driveId: 'drive-123',
+      itemId: 'file-1',
+      name: 'conspectus.db',
+      parentPath: '/',
+    });
   });
 
   it('rejects invalid non-database file selections', () => {
-    const controller = createSettingsFileBindingController(harness.graphClient);
+    const controller = createSettingsFileBindingController(harness.graphClient, {
+      onBindingChange,
+    });
 
     controller.selectFile(ROOT_NON_DB_FILE_ITEM);
 
@@ -152,10 +177,13 @@ describe('settings file binding controller', () => {
         message: 'Selected file must use the .db extension.',
       },
     });
+    expect(onBindingChange).not.toHaveBeenCalled();
   });
 
   it('rejects file selections that are missing required binding identifiers', () => {
-    const controller = createSettingsFileBindingController(harness.graphClient);
+    const controller = createSettingsFileBindingController(harness.graphClient, {
+      onBindingChange,
+    });
 
     controller.selectFile({
       driveId: '',
@@ -174,6 +202,55 @@ describe('settings file binding controller', () => {
         message: 'Selected file did not include the required OneDrive identifiers.',
       },
     });
+    expect(onBindingChange).not.toHaveBeenCalled();
+  });
+
+  it('preserves a previous valid binding when a later invalid selection is made', async () => {
+    const controller = createSettingsFileBindingController(harness.graphClient, {
+      onBindingChange,
+    });
+    await controller.browseRoot();
+
+    controller.selectFile(ROOT_DB_FILE_ITEM);
+    controller.selectFile(ROOT_NON_DB_FILE_ITEM);
+
+    expect(controller.getState().selectedBinding).toEqual({
+      driveId: 'drive-123',
+      itemId: 'file-1',
+      name: 'conspectus.db',
+      parentPath: '/',
+    });
+    expect(controller.getState().error).toEqual({
+      code: 'invalid_selection',
+      message: 'Selected file must use the .db extension.',
+      cause: {
+        code: 'invalid_selection',
+        message: 'Selected file must use the .db extension.',
+      },
+    });
+    expect(onBindingChange).toHaveBeenNthCalledWith(1, {
+      driveId: 'drive-123',
+      itemId: 'file-1',
+      name: 'conspectus.db',
+      parentPath: '/',
+    });
+    expect(onBindingChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('hydrates the initial selected binding from controller options', () => {
+    const initialSelectedBinding = {
+      driveId: 'drive-123',
+      itemId: 'file-1',
+      name: 'conspectus.db',
+      parentPath: '/Finance',
+    } as const;
+    const controller = createSettingsFileBindingController(harness.graphClient, {
+      initialSelectedBinding,
+      onBindingChange,
+    });
+
+    expect(controller.getState().selectedBinding).toEqual(initialSelectedBinding);
+    expect(onBindingChange).not.toHaveBeenCalled();
   });
 
   it('captures graph browse failures as controller errors', async () => {
@@ -195,8 +272,36 @@ describe('settings file binding controller', () => {
     expect(controller.getState().operation).toBe('idle');
   });
 
+  it('ignores stale browse results that resolve after reset', async () => {
+    const browseDeferred = createDeferred<readonly GraphDriveItem[]>();
+    harness.listChildren.mockImplementationOnce(async () => browseDeferred.promise);
+    const controller = createSettingsFileBindingController(harness.graphClient, {
+      onBindingChange,
+    });
+
+    const browsePromise = controller.browseRoot();
+    expect(controller.getState().operation).toBe('loading');
+
+    controller.reset();
+    browseDeferred.resolve(ROOT_ITEMS);
+    await browsePromise;
+
+    expect(controller.getState()).toEqual({
+      selectedBinding: null,
+      currentFolder: null,
+      items: [],
+      operation: 'idle',
+      error: null,
+      hasLoaded: false,
+      canGoBack: false,
+    });
+    expect(onBindingChange).toHaveBeenCalledWith(null);
+  });
+
   it('resets the current browse and selected binding state', async () => {
-    const controller = createSettingsFileBindingController(harness.graphClient);
+    const controller = createSettingsFileBindingController(harness.graphClient, {
+      onBindingChange,
+    });
     await controller.browseRoot();
     controller.selectFile(ROOT_DB_FILE_ITEM);
 
@@ -211,5 +316,6 @@ describe('settings file binding controller', () => {
       hasLoaded: false,
       canGoBack: false,
     });
+    expect(onBindingChange).toHaveBeenLastCalledWith(null);
   });
 });

--- a/src/features/app-shell/routes/settingsFileBindingController.ts
+++ b/src/features/app-shell/routes/settingsFileBindingController.ts
@@ -41,6 +41,11 @@ export interface SettingsFileBindingController {
   reset(): void;
 }
 
+interface CreateSettingsFileBindingControllerOptions {
+  readonly initialSelectedBinding?: DriveItemBinding | null;
+  readonly onBindingChange?: (binding: DriveItemBinding | null) => void;
+}
+
 const INITIAL_STATE: SettingsFileBindingState = {
   selectedBinding: null,
   currentFolder: null,
@@ -150,9 +155,14 @@ const validateSelectedBinding = (item: GraphDriveItem): DriveItemBinding => {
 
 export const createSettingsFileBindingController = (
   graphClient: GraphClient,
+  options: CreateSettingsFileBindingControllerOptions = {},
 ): SettingsFileBindingController => {
-  let state: SettingsFileBindingState = INITIAL_STATE;
+  let state: SettingsFileBindingState = {
+    ...INITIAL_STATE,
+    selectedBinding: options.initialSelectedBinding ?? null,
+  };
   let folderStack: readonly DriveFolderReference[] = [];
+  let activeRequestId = 0;
   const listeners = new Set<SettingsFileBindingStateListener>();
 
   const emitState = (): void => {
@@ -171,7 +181,15 @@ export const createSettingsFileBindingController = (
     emitState();
   };
 
+  const beginRequest = (): number => {
+    activeRequestId += 1;
+    return activeRequestId;
+  };
+
+  const isStaleRequest = (requestId: number): boolean => requestId !== activeRequestId;
+
   const loadItems = async (folder?: DriveFolderReference): Promise<void> => {
+    const requestId = beginRequest();
     updateState({
       operation: 'loading',
       error: null,
@@ -179,6 +197,10 @@ export const createSettingsFileBindingController = (
 
     try {
       const items = await graphClient.listChildren(folder);
+      if (isStaleRequest(requestId)) {
+        return;
+      }
+
       updateState({
         items: items.filter(isSelectableDatabaseFile),
         operation: 'idle',
@@ -186,6 +208,10 @@ export const createSettingsFileBindingController = (
         hasLoaded: true,
       });
     } catch (error) {
+      if (isStaleRequest(requestId)) {
+        return;
+      }
+
       updateState({
         items: [],
         operation: 'idle',
@@ -245,10 +271,12 @@ export const createSettingsFileBindingController = (
 
     selectFile(item: GraphDriveItem): void {
       try {
+        const selectedBinding = validateSelectedBinding(item);
         updateState({
-          selectedBinding: validateSelectedBinding(item),
+          selectedBinding,
           error: null,
         });
+        options.onBindingChange?.(selectedBinding);
       } catch (error) {
         updateState({
           error: toBindingError(error, 'Failed to validate the selected OneDrive file.'),
@@ -257,8 +285,10 @@ export const createSettingsFileBindingController = (
     },
 
     reset(): void {
+      beginRequest();
       folderStack = [];
       state = INITIAL_STATE;
+      options.onBindingChange?.(null);
       emitState();
     },
   };

--- a/src/graph/graphClient.test.ts
+++ b/src/graph/graphClient.test.ts
@@ -156,6 +156,74 @@ describe('createGraphClient', () => {
     );
   });
 
+  it('follows paginated children responses until all browse items are loaded', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi
+      .fn<(_: string) => Promise<Response>>()
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          value: [
+            {
+              id: 'folder-1',
+              name: 'Finance',
+              parentReference: {
+                driveId: 'drive-123',
+                path: '/drive/root:',
+              },
+              folder: {},
+            },
+          ],
+          '@odata.nextLink':
+            'https://graph.microsoft.com/v1.0/me/drive/root/children?$skiptoken=abc',
+        }),
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          value: [
+            {
+              id: 'file-1',
+              name: 'conspectus.db',
+              parentReference: {
+                driveId: 'drive-123',
+                path: '/drive/root:/Finance',
+              },
+              file: {},
+            },
+          ],
+        }),
+      );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    const items = await client.listChildren();
+
+    expect(items).toEqual([
+      {
+        driveId: 'drive-123',
+        itemId: 'folder-1',
+        name: 'Finance',
+        parentPath: '/',
+        kind: 'folder',
+      },
+      {
+        driveId: 'drive-123',
+        itemId: 'file-1',
+        name: 'conspectus.db',
+        parentPath: '/Finance',
+        kind: 'file',
+      },
+    ]);
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      1,
+      'https://graph.microsoft.com/v1.0/me/drive/root/children?$select=id%2Cname%2CparentReference%2Cfile%2Cfolder',
+      expect.any(Object),
+    );
+    expect(fetchFn).toHaveBeenNthCalledWith(
+      2,
+      'https://graph.microsoft.com/v1.0/me/drive/root/children?$skiptoken=abc',
+      expect.any(Object),
+    );
+  });
+
   it('fetches file metadata with an auth-backed Graph request', async () => {
     const authClient = createAuthClient();
     const fetchFn = vi.fn(async () =>
@@ -421,6 +489,22 @@ describe('createGraphClient', () => {
             file: {},
           },
         ],
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.listChildren()).rejects.toMatchObject({
+      code: 'unknown',
+      message: 'Microsoft Graph children response did not include the required file fields.',
+    });
+  });
+
+  it('rejects invalid paginated children payloads with an unknown Graph error', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        value: [],
+        '@odata.nextLink': 123,
       }),
     );
     const client = createGraphClient({ authClient, fetchFn });

--- a/src/graph/graphClient.ts
+++ b/src/graph/graphClient.ts
@@ -35,6 +35,7 @@ interface GraphItemPayload {
 
 interface GraphChildrenPayload {
   readonly value?: unknown;
+  readonly '@odata.nextLink'?: unknown;
 }
 
 interface GraphErrorPayload {
@@ -299,21 +300,29 @@ const normalizeGraphItem = (
 const normalizeChildrenPayload = (
   payload: unknown,
   invalidResponseMessage: string,
-): readonly GraphDriveItem[] => {
+): {
+  readonly items: readonly GraphDriveItem[];
+  readonly nextLink: string | null;
+} => {
   if (!isGraphChildrenPayload(payload) || !Array.isArray(payload.value)) {
     throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
   }
 
-  return payload.value
-    .map((childPayload) => normalizeDriveItem(childPayload, invalidResponseMessage))
-    .filter((child): child is GraphDriveItem => child !== null)
-    .sort((left, right) => {
-      if (left.kind !== right.kind) {
-        return left.kind === 'folder' ? -1 : 1;
-      }
+  const nextLink =
+    payload['@odata.nextLink'] === undefined
+      ? null
+      : typeof payload['@odata.nextLink'] === 'string'
+        ? payload['@odata.nextLink']
+        : (() => {
+            throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
+          })();
 
-      return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
-    });
+  return {
+    items: payload.value
+      .map((childPayload) => normalizeDriveItem(childPayload, invalidResponseMessage))
+      .filter((child): child is GraphDriveItem => child !== null),
+    nextLink,
+  };
 };
 
 export const createGraphClient = (options: CreateGraphClientOptions): GraphClient => {
@@ -352,17 +361,27 @@ export const createGraphClient = (options: CreateGraphClientOptions): GraphClien
 
   return {
     async listChildren(folder): Promise<readonly GraphDriveItem[]> {
-      const childrenUrl = `${buildFolderChildrenUrl(folder)}?$select=${encodeURIComponent(CHILDREN_FIELDS)}`;
-      const response = await executeRequest(childrenUrl);
-      const payload = await readJsonPayload(
-        response,
-        'Microsoft Graph children response did not include the required file fields.',
-      );
+      const invalidChildrenResponseMessage =
+        'Microsoft Graph children response did not include the required file fields.';
+      const items: GraphDriveItem[] = [];
+      let nextUrl: string | null =
+        `${buildFolderChildrenUrl(folder)}?$select=${encodeURIComponent(CHILDREN_FIELDS)}`;
 
-      return normalizeChildrenPayload(
-        payload,
-        'Microsoft Graph children response did not include the required file fields.',
-      );
+      while (nextUrl !== null) {
+        const response = await executeRequest(nextUrl);
+        const payload = await readJsonPayload(response, invalidChildrenResponseMessage);
+        const page = normalizeChildrenPayload(payload, invalidChildrenResponseMessage);
+        items.push(...page.items);
+        nextUrl = page.nextLink;
+      }
+
+      return items.sort((left, right) => {
+        if (left.kind !== right.kind) {
+          return left.kind === 'folder' ? -1 : 1;
+        }
+
+        return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
+      });
     },
 
     async getFileMetadata(binding): Promise<GraphFileMetadata> {

--- a/src/shared/state/index.ts
+++ b/src/shared/state/index.ts
@@ -1,1 +1,2 @@
 export * from './syncStateStore';
+export * from './selectedDriveItemBindingStore';

--- a/src/shared/state/selectedDriveItemBindingStore.test.ts
+++ b/src/shared/state/selectedDriveItemBindingStore.test.ts
@@ -1,0 +1,29 @@
+// Verifies the app-level selected OneDrive binding store can set and clear bindings predictably.
+import { get } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+
+import { createSelectedDriveItemBindingStore } from './selectedDriveItemBindingStore';
+
+describe('createSelectedDriveItemBindingStore', () => {
+  it('starts empty by default', () => {
+    const store = createSelectedDriveItemBindingStore();
+
+    expect(get(store)).toBeNull();
+  });
+
+  it('stores and clears the selected binding', () => {
+    const store = createSelectedDriveItemBindingStore();
+    const binding = {
+      driveId: 'drive-123',
+      itemId: 'item-456',
+      name: 'conspectus.db',
+      parentPath: '/Finance',
+    } as const;
+
+    store.setBinding(binding);
+    expect(get(store)).toEqual(binding);
+
+    store.clear();
+    expect(get(store)).toBeNull();
+  });
+});

--- a/src/shared/state/selectedDriveItemBindingStore.ts
+++ b/src/shared/state/selectedDriveItemBindingStore.ts
@@ -1,0 +1,22 @@
+// Provides an app-level in-memory store for the currently selected OneDrive database binding.
+import { writable, type Readable } from 'svelte/store';
+import type { DriveItemBinding } from '@graph';
+
+export interface SelectedDriveItemBindingStore extends Readable<DriveItemBinding | null> {
+  setBinding(binding: DriveItemBinding): void;
+  clear(): void;
+}
+
+export const createSelectedDriveItemBindingStore = (
+  initialBinding: DriveItemBinding | null = null,
+): SelectedDriveItemBindingStore => {
+  const { subscribe, set } = writable<DriveItemBinding | null>(initialBinding);
+
+  return {
+    subscribe,
+    setBinding: (binding) => set(binding),
+    clear: () => set(null),
+  };
+};
+
+export const appSelectedDriveItemBindingStore = createSelectedDriveItemBindingStore();

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -313,6 +313,34 @@ test('allows selecting a OneDrive .db file from the settings browser', async ({ 
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('/Finance');
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('drive-123');
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('file-finance-db');
+
+  await page.getByRole('link', { name: 'Accounts' }).click();
+  await expect(page.getByRole('heading', { level: 2, name: 'Accounts' })).toBeVisible();
+
+  await page.getByRole('link', { name: 'Settings' }).click();
+  await expect(page.getByTestId('binding-status-message')).toContainText(
+    'DB file selected for this session.',
+  );
+  await expect(page.getByTestId('selected-db-file-summary')).toContainText('budget.db');
+});
+
+test('shows browse errors without pretending the OneDrive folder is empty', async ({ page }) => {
+  await installMockAuthClient(page, {
+    startAuthenticated: true,
+  });
+  await installMockGraphClient(page, {
+    failListChildren: true,
+  });
+
+  await page.goto(appPath('#/settings'));
+
+  await page.getByRole('button', { name: 'Choose OneDrive DB file' }).click();
+
+  await expect(page.getByRole('alert')).toContainText('Mock OneDrive browse failure.');
+  await expect(page.getByTestId('binding-status-message')).toContainText(
+    'File selection error. Mock OneDrive browse failure.',
+  );
+  await expect(page.getByText('No folders or .db files found here.')).toHaveCount(0);
 });
 
 test('processes redirect auth hash before route navigation and keeps signed-in status', async ({


### PR DESCRIPTION
## Summary
- add a OneDrive file browser in Settings for selecting .db files and surfacing the selected binding details
- extend the Graph client to browse paginated OneDrive folder contents and normalize selectable items
- keep the selected binding in app state for the current session and cover the flow with unit and e2e tests

## Acceptance Criteria
- [x] User can select a DB file once
- [x] Selection returns driveId, itemId, 
ame, and folder path for self-healing fallback

## Verification
- [x] npm run format
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test
- [x] npm run build
- [x] npm run test:e2e

Refs #39