### PR TITLE
fix: persist selected DB file and collapse OneDrive browser after selection

### DIFF
--- a/src/features/app-shell/routes/SettingsRoute.svelte
+++ b/src/features/app-shell/routes/SettingsRoute.svelte
@@ -94,7 +94,6 @@
 
   const authController = createSettingsAuthController(authClient);
   const fileBindingController = createSettingsFileBindingController(graphClient, {
-    initialSelectedBinding: get(appSelectedDriveItemBindingStore),
     onBindingChange: (binding) => {
       if (binding === null) {
         appSelectedDriveItemBindingStore.clear();
@@ -105,11 +104,22 @@
     },
   });
   const unsubscribe = authController.subscribe((nextState) => {
+    const previousAccountId = state.session.account?.homeAccountId ?? null;
     const wasAuthenticated = state.session.isAuthenticated;
     state = nextState;
+    const nextAccountId = nextState.session.account?.homeAccountId ?? null;
     authOperationIsPending = nextState.operation !== 'idle';
     authStatusMessage = buildStatusMessage(nextState);
     bindingStatusMessage = buildBindingStatusMessage(bindingState);
+
+    if (nextState.session.isAuthenticated && previousAccountId !== nextAccountId) {
+      appSelectedDriveItemBindingStore.setActiveAccountId(nextAccountId);
+      fileBindingController.hydrateSelectedBinding(get(appSelectedDriveItemBindingStore));
+    }
+
+    if (!nextState.session.isAuthenticated) {
+      appSelectedDriveItemBindingStore.setActiveAccountId(null);
+    }
 
     if (wasAuthenticated && !nextState.session.isAuthenticated) {
       fileBindingController.reset();
@@ -210,7 +220,7 @@
         Select DB File
       </button>
 
-      {#if bindingState.selectedBinding === null && bindingState.canGoBack}
+      {#if bindingState.browserIsOpen && bindingState.canGoBack}
         <button
           class="settings-screen__button settings-screen__button--secondary"
           type="button"
@@ -235,7 +245,7 @@
       </dl>
     {/if}
 
-    {#if bindingState.selectedBinding === null && bindingState.browserIsOpen && bindingState.hasLoaded}
+    {#if bindingState.browserIsOpen && bindingState.hasLoaded}
       <section class="settings-screen__browser" data-testid="db-file-browser">
         <header class="settings-screen__browser-header">
           <h4>Current folder</h4>

--- a/src/features/app-shell/routes/settingsFileBindingController.test.ts
+++ b/src/features/app-shell/routes/settingsFileBindingController.test.ts
@@ -259,6 +259,58 @@ describe('settings file binding controller', () => {
     expect(onBindingChange).not.toHaveBeenCalled();
   });
 
+  it('hydrates a selected binding without triggering binding change callbacks', async () => {
+    const controller = createSettingsFileBindingController(harness.graphClient, {
+      onBindingChange,
+    });
+    await controller.browseRoot();
+
+    controller.hydrateSelectedBinding({
+      driveId: 'drive-123',
+      itemId: 'file-1',
+      name: 'conspectus.db',
+      parentPath: '/',
+    });
+
+    expect(controller.getState()).toEqual({
+      selectedBinding: {
+        driveId: 'drive-123',
+        itemId: 'file-1',
+        name: 'conspectus.db',
+        parentPath: '/',
+      },
+      currentFolder: null,
+      items: [],
+      browserIsOpen: false,
+      operation: 'idle',
+      error: null,
+      hasLoaded: false,
+      canGoBack: false,
+    });
+    expect(onBindingChange).not.toHaveBeenCalled();
+  });
+
+  it('reopens the browser from root even when a binding is already selected', async () => {
+    const controller = createSettingsFileBindingController(harness.graphClient, {
+      onBindingChange,
+    });
+
+    await controller.browseRoot();
+    controller.selectFile(ROOT_DB_FILE_ITEM);
+    await controller.browseRoot();
+
+    expect(controller.getState().selectedBinding).toEqual({
+      driveId: 'drive-123',
+      itemId: 'file-1',
+      name: 'conspectus.db',
+      parentPath: '/',
+    });
+    expect(controller.getState().browserIsOpen).toBe(true);
+    expect(controller.getState().items).toEqual([ROOT_FOLDER_ITEM, ROOT_DB_FILE_ITEM]);
+    expect(controller.getState().hasLoaded).toBe(true);
+    expect(controller.getState().canGoBack).toBe(false);
+  });
+
   it('captures graph browse failures as controller errors', async () => {
     harness.listChildren.mockRejectedValueOnce({
       code: 'network_error',

--- a/src/features/app-shell/routes/settingsFileBindingController.ts
+++ b/src/features/app-shell/routes/settingsFileBindingController.ts
@@ -35,6 +35,7 @@ export type SettingsFileBindingStateListener = (state: SettingsFileBindingState)
 export interface SettingsFileBindingController {
   getState(): SettingsFileBindingState;
   subscribe(listener: SettingsFileBindingStateListener): () => void;
+  hydrateSelectedBinding(binding: DriveItemBinding | null): void;
   browseRoot(): Promise<void>;
   openFolder(item: GraphDriveItem): Promise<void>;
   goBack(): Promise<void>;
@@ -238,6 +239,19 @@ export const createSettingsFileBindingController = (
       return () => {
         listeners.delete(listener);
       };
+    },
+
+    hydrateSelectedBinding(binding: DriveItemBinding | null): void {
+      beginRequest();
+      folderStack = [];
+      updateState({
+        selectedBinding: binding,
+        browserIsOpen: false,
+        items: [],
+        operation: 'idle',
+        error: null,
+        hasLoaded: false,
+      });
     },
 
     async browseRoot(): Promise<void> {

--- a/src/shared/state/selectedDriveItemBindingStore.test.ts
+++ b/src/shared/state/selectedDriveItemBindingStore.test.ts
@@ -39,7 +39,11 @@ describe('createSelectedDriveItemBindingStore', () => {
   it('stores and clears the selected binding in state and storage', () => {
     const { storage, values } = createMemoryStorage();
     const storageKey = 'binding-key';
-    const store = createSelectedDriveItemBindingStore(null, { storage, storageKey });
+    const store = createSelectedDriveItemBindingStore(null, {
+      storage,
+      storageKey,
+      initialActiveAccountId: 'account-1',
+    });
     const binding = {
       driveId: 'drive-123',
       itemId: 'item-456',
@@ -49,7 +53,12 @@ describe('createSelectedDriveItemBindingStore', () => {
 
     store.setBinding(binding);
     expect(get(store)).toEqual(binding);
-    expect(values[storageKey]).toBe(JSON.stringify(binding));
+    expect(values[storageKey]).toBe(
+      JSON.stringify({
+        accountId: 'account-1',
+        binding,
+      }),
+    );
 
     store.clear();
     expect(get(store)).toBeNull();
@@ -65,9 +74,16 @@ describe('createSelectedDriveItemBindingStore', () => {
       name: 'conspectus.db',
       parentPath: '/Finance',
     } as const;
-    values[storageKey] = JSON.stringify(binding);
+    values[storageKey] = JSON.stringify({
+      accountId: 'account-1',
+      binding,
+    });
 
-    const store = createSelectedDriveItemBindingStore(null, { storage, storageKey });
+    const store = createSelectedDriveItemBindingStore(null, {
+      storage,
+      storageKey,
+      initialActiveAccountId: 'account-1',
+    });
 
     expect(get(store)).toEqual(binding);
   });
@@ -76,14 +92,74 @@ describe('createSelectedDriveItemBindingStore', () => {
     const { storage, values } = createMemoryStorage();
     const storageKey = 'binding-key';
     values[storageKey] = JSON.stringify({
+      accountId: 'account-1',
+      binding: {
+        driveId: 'drive-123',
+        itemId: '',
+        name: 'conspectus.db',
+        parentPath: '/Finance',
+      },
+    });
+
+    const store = createSelectedDriveItemBindingStore(null, {
+      storage,
+      storageKey,
+      initialActiveAccountId: 'account-1',
+    });
+
+    expect(get(store)).toBeNull();
+  });
+
+  it('does not hydrate persisted binding when account does not match', () => {
+    const { storage, values } = createMemoryStorage();
+    const storageKey = 'binding-key';
+    const binding = {
       driveId: 'drive-123',
-      itemId: '',
+      itemId: 'item-456',
+      name: 'conspectus.db',
+      parentPath: '/Finance',
+    } as const;
+    values[storageKey] = JSON.stringify({
+      accountId: 'account-1',
+      binding,
+    });
+
+    const store = createSelectedDriveItemBindingStore(null, {
+      storage,
+      storageKey,
+      initialActiveAccountId: 'account-2',
+    });
+
+    expect(get(store)).toBeNull();
+  });
+
+  it('switches hydrated binding when the active account changes', () => {
+    const { storage, values } = createMemoryStorage();
+    const storageKey = 'binding-key';
+    values[storageKey] = JSON.stringify({
+      accountId: 'account-1',
+      binding: {
+        driveId: 'drive-123',
+        itemId: 'item-456',
+        name: 'conspectus.db',
+        parentPath: '/Finance',
+      },
+    });
+    const store = createSelectedDriveItemBindingStore(null, {
+      storage,
+      storageKey,
+      initialActiveAccountId: 'account-2',
+    });
+
+    expect(get(store)).toBeNull();
+
+    store.setActiveAccountId('account-1');
+
+    expect(get(store)).toEqual({
+      driveId: 'drive-123',
+      itemId: 'item-456',
       name: 'conspectus.db',
       parentPath: '/Finance',
     });
-
-    const store = createSelectedDriveItemBindingStore(null, { storage, storageKey });
-
-    expect(get(store)).toBeNull();
   });
 });

--- a/src/shared/state/selectedDriveItemBindingStore.ts
+++ b/src/shared/state/selectedDriveItemBindingStore.ts
@@ -3,6 +3,7 @@ import { writable, type Readable } from 'svelte/store';
 import type { DriveItemBinding } from '@graph';
 
 export interface SelectedDriveItemBindingStore extends Readable<DriveItemBinding | null> {
+  setActiveAccountId(accountId: string | null): void;
   setBinding(binding: DriveItemBinding): void;
   clear(): void;
 }
@@ -16,9 +17,14 @@ interface StorageAdapter {
 interface CreateSelectedDriveItemBindingStoreOptions {
   readonly storageKey?: string;
   readonly storage?: StorageAdapter | null;
+  readonly initialActiveAccountId?: string | null;
 }
 
 const DEFAULT_STORAGE_KEY = 'conspectus.selectedDriveItemBinding';
+interface PersistedBindingPayload {
+  readonly accountId: string;
+  readonly binding: DriveItemBinding;
+}
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -34,6 +40,21 @@ const isDriveItemBinding = (value: unknown): value is DriveItemBinding =>
   value.name.trim().length > 0 &&
   value.parentPath.trim().length > 0;
 
+const isPersistedBindingPayload = (value: unknown): value is PersistedBindingPayload =>
+  isRecord(value) &&
+  typeof value.accountId === 'string' &&
+  value.accountId.trim().length > 0 &&
+  isDriveItemBinding(value.binding);
+
+const normalizeAccountId = (accountId: string | null | undefined): string | null => {
+  if (accountId === null || accountId === undefined) {
+    return null;
+  }
+
+  const trimmedAccountId = accountId.trim();
+  return trimmedAccountId.length > 0 ? trimmedAccountId : null;
+};
+
 const resolveDefaultStorage = (): StorageAdapter | null => {
   if (typeof window === 'undefined') {
     return null;
@@ -45,8 +66,9 @@ const resolveDefaultStorage = (): StorageAdapter | null => {
 const loadStoredBinding = (
   storage: StorageAdapter | null,
   storageKey: string,
+  accountId: string | null,
 ): DriveItemBinding | null => {
-  if (storage === null) {
+  if (storage === null || accountId === null) {
     return null;
   }
 
@@ -57,7 +79,11 @@ const loadStoredBinding = (
     }
 
     const parsedValue: unknown = JSON.parse(rawValue);
-    return isDriveItemBinding(parsedValue) ? parsedValue : null;
+    if (!isPersistedBindingPayload(parsedValue)) {
+      return null;
+    }
+
+    return parsedValue.accountId === accountId ? parsedValue.binding : null;
   } catch {
     return null;
   }
@@ -69,11 +95,12 @@ export const createSelectedDriveItemBindingStore = (
 ): SelectedDriveItemBindingStore => {
   const storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
   const storage = options.storage ?? resolveDefaultStorage();
-  const persistedBinding = loadStoredBinding(storage, storageKey);
+  let activeAccountId = normalizeAccountId(options.initialActiveAccountId);
+  const persistedBinding = loadStoredBinding(storage, storageKey, activeAccountId);
   const { subscribe, set } = writable<DriveItemBinding | null>(initialBinding ?? persistedBinding);
 
   const persistBinding = (binding: DriveItemBinding | null): void => {
-    if (storage === null) {
+    if (storage === null || activeAccountId === null) {
       return;
     }
 
@@ -83,7 +110,13 @@ export const createSelectedDriveItemBindingStore = (
         return;
       }
 
-      storage.setItem(storageKey, JSON.stringify(binding));
+      storage.setItem(
+        storageKey,
+        JSON.stringify({
+          accountId: activeAccountId,
+          binding,
+        } satisfies PersistedBindingPayload),
+      );
     } catch {
       // Persistence failures should not block in-memory state updates.
     }
@@ -91,9 +124,13 @@ export const createSelectedDriveItemBindingStore = (
 
   return {
     subscribe,
+    setActiveAccountId: (accountId) => {
+      activeAccountId = normalizeAccountId(accountId);
+      set(loadStoredBinding(storage, storageKey, activeAccountId));
+    },
     setBinding: (binding) => {
       persistBinding(binding);
-      set(binding);
+      set(activeAccountId === null ? null : binding);
     },
     clear: () => {
       persistBinding(null);

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -317,6 +317,11 @@ test('allows selecting a OneDrive .db file from the settings browser', async ({ 
   await page.getByRole('link', { name: 'Settings' }).click();
   await expect(page.getByTestId('binding-status-message')).toContainText('DB file selected.');
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('budget.db');
+
+  await page.getByRole('button', { name: 'Select DB File' }).click();
+  await expect(page.getByTestId('db-file-browser')).toBeVisible();
+  await expect(page.getByTestId('open-folder-folder-finance')).toBeVisible();
+  await expect(page.getByTestId('select-file-file-root-db')).toBeVisible();
 });
 
 test('keeps the selected DB file after reload', async ({ page }) => {


### PR DESCRIPTION
## Summary
- close the OneDrive file browser immediately after successful .db selection
- keep the selected DB file visible as summary (file name + folder path)
- persist selected binding in localStorage so it survives full page reloads
- add/adjust unit and e2e tests for collapse + reload persistence behavior

## Verification
- [x] npm run format
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test
- [x] npm run build
- [x] npm run test:e2e

Refs #39