### PR TITLE
feat(m3-07): persist OneDrive binding in versioned local storage

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -365,6 +365,13 @@ M3-06 implementation clarification:
 - The file browser surfaces folders plus `.db` files only, and validated selections return `driveId`, `itemId`, `name`, and `parentPath` for later persistence/recovery work.
 - File selection state is session-local in M3-06; durable storage of the selected binding remains scoped to `M3-07`.
 
+M3-07 implementation clarification:
+
+- Durable file binding persistence is implemented in `src/shared/state/selectedDriveItemBindingStore.ts` with schema-versioned local metadata payloads (`version` field).
+- Current payload schema stores bindings per authenticated account (`bindingsByAccountId`) so account switches do not overwrite previously persisted bindings for other accounts on the same device/profile.
+- Startup binding hydration is triggered at app initialization in `src/features/app-shell/AppShell.svelte` and synchronized through `src/features/app-shell/startupBindingSync.ts`, so the active account binding is resolved before entering Settings.
+- Legacy persisted payloads from pre-versioned and v1 single-binding formats are migrated on read into the current schema during hydration.
+
 Deliverables:
 
 - Stable login flow with persisted session where possible.

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import type { Readable } from 'svelte/store';
+  import { appSelectedDriveItemBindingStore } from '@shared';
   import LoadingPlaceholder from './components/LoadingPlaceholder.svelte';
   import AccountsRoute from './routes/AccountsRoute.svelte';
   import TransfersRoute from './routes/TransfersRoute.svelte';
   import AddRoute from './routes/AddRoute.svelte';
   import SettingsRoute from './routes/SettingsRoute.svelte';
-  import { initializeAppAuthClient } from './authClientResolver';
+  import { initializeAppAuthClient, resolveAppAuthClient } from './authClientResolver';
   import { APP_ROUTES, createHashRouteStore, DEFAULT_ROUTE, type AppRouteKey } from './hashRouting';
+  import { syncSelectedDriveItemBindingStoreAtStartup } from './startupBindingSync';
 
   export let routeStore: Readable<AppRouteKey> = createHashRouteStore();
   export let loadingDelayMs = 160;
@@ -19,9 +21,16 @@
   });
 
   onMount(() => {
-    void initializeAppAuthClient().catch((error) => {
-      console.warn('Auth bootstrap initialization failed at app-shell startup.', error);
-    });
+    void (async () => {
+      try {
+        await initializeAppAuthClient();
+        const authSession = resolveAppAuthClient().getSession();
+        syncSelectedDriveItemBindingStoreAtStartup(authSession, appSelectedDriveItemBindingStore);
+      } catch (error) {
+        console.warn('Auth bootstrap initialization failed at app-shell startup.', error);
+        appSelectedDriveItemBindingStore.setActiveAccountId(null);
+      }
+    })();
 
     if (!showLoadingPlaceholder || loadingDelayMs <= 0) {
       showLoadingPlaceholder = false;

--- a/src/features/app-shell/startupBindingSync.test.ts
+++ b/src/features/app-shell/startupBindingSync.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { syncSelectedDriveItemBindingStoreAtStartup } from './startupBindingSync';
+
+describe('syncSelectedDriveItemBindingStoreAtStartup', () => {
+  it('hydrates binding store for the active authenticated account', () => {
+    const setActiveAccountId = vi.fn<(accountId: string | null) => void>();
+
+    syncSelectedDriveItemBindingStoreAtStartup(
+      {
+        isAuthenticated: true,
+        account: {
+          homeAccountId: 'account-1',
+          username: 'user@example.com',
+          displayName: 'User',
+        },
+      },
+      { setActiveAccountId },
+    );
+
+    expect(setActiveAccountId).toHaveBeenCalledWith('account-1');
+  });
+
+  it('clears binding store account context when signed out', () => {
+    const setActiveAccountId = vi.fn<(accountId: string | null) => void>();
+
+    syncSelectedDriveItemBindingStoreAtStartup(
+      {
+        isAuthenticated: false,
+        account: null,
+      },
+      { setActiveAccountId },
+    );
+
+    expect(setActiveAccountId).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/features/app-shell/startupBindingSync.ts
+++ b/src/features/app-shell/startupBindingSync.ts
@@ -1,0 +1,18 @@
+// Synchronizes the selected OneDrive binding store with the active authenticated account at app startup.
+import type { AuthSession } from '@auth';
+import type { SelectedDriveItemBindingStore } from '@shared';
+
+const resolveActiveAccountId = (session: AuthSession): string | null => {
+  if (!session.isAuthenticated) {
+    return null;
+  }
+
+  return session.account?.homeAccountId ?? null;
+};
+
+export const syncSelectedDriveItemBindingStoreAtStartup = (
+  session: AuthSession,
+  selectedDriveItemBindingStore: Pick<SelectedDriveItemBindingStore, 'setActiveAccountId'>,
+): void => {
+  selectedDriveItemBindingStore.setActiveAccountId(resolveActiveAccountId(session));
+};

--- a/src/shared/state/selectedDriveItemBindingStore.test.ts
+++ b/src/shared/state/selectedDriveItemBindingStore.test.ts
@@ -55,8 +55,10 @@ describe('createSelectedDriveItemBindingStore', () => {
     expect(get(store)).toEqual(binding);
     expect(values[storageKey]).toBe(
       JSON.stringify({
-        accountId: 'account-1',
-        binding,
+        version: 2,
+        bindingsByAccountId: {
+          'account-1': binding,
+        },
       }),
     );
 
@@ -75,8 +77,10 @@ describe('createSelectedDriveItemBindingStore', () => {
       parentPath: '/Finance',
     } as const;
     values[storageKey] = JSON.stringify({
-      accountId: 'account-1',
-      binding,
+      version: 2,
+      bindingsByAccountId: {
+        'account-1': binding,
+      },
     });
 
     const store = createSelectedDriveItemBindingStore(null, {
@@ -92,12 +96,14 @@ describe('createSelectedDriveItemBindingStore', () => {
     const { storage, values } = createMemoryStorage();
     const storageKey = 'binding-key';
     values[storageKey] = JSON.stringify({
-      accountId: 'account-1',
-      binding: {
-        driveId: 'drive-123',
-        itemId: '',
-        name: 'conspectus.db',
-        parentPath: '/Finance',
+      version: 2,
+      bindingsByAccountId: {
+        'account-1': {
+          driveId: 'drive-123',
+          itemId: '',
+          name: 'conspectus.db',
+          parentPath: '/Finance',
+        },
       },
     });
 
@@ -120,8 +126,10 @@ describe('createSelectedDriveItemBindingStore', () => {
       parentPath: '/Finance',
     } as const;
     values[storageKey] = JSON.stringify({
-      accountId: 'account-1',
-      binding,
+      version: 2,
+      bindingsByAccountId: {
+        'account-1': binding,
+      },
     });
 
     const store = createSelectedDriveItemBindingStore(null, {
@@ -137,12 +145,14 @@ describe('createSelectedDriveItemBindingStore', () => {
     const { storage, values } = createMemoryStorage();
     const storageKey = 'binding-key';
     values[storageKey] = JSON.stringify({
-      accountId: 'account-1',
-      binding: {
-        driveId: 'drive-123',
-        itemId: 'item-456',
-        name: 'conspectus.db',
-        parentPath: '/Finance',
+      version: 2,
+      bindingsByAccountId: {
+        'account-1': {
+          driveId: 'drive-123',
+          itemId: 'item-456',
+          name: 'conspectus.db',
+          parentPath: '/Finance',
+        },
       },
     });
     const store = createSelectedDriveItemBindingStore(null, {
@@ -161,5 +171,125 @@ describe('createSelectedDriveItemBindingStore', () => {
       name: 'conspectus.db',
       parentPath: '/Finance',
     });
+  });
+
+  it('hydrates legacy unversioned payloads to preserve existing local bindings', () => {
+    const { storage, values } = createMemoryStorage();
+    const storageKey = 'binding-key';
+    values[storageKey] = JSON.stringify({
+      accountId: 'account-1',
+      binding: {
+        driveId: 'drive-123',
+        itemId: 'item-456',
+        name: 'conspectus.db',
+        parentPath: '/Finance',
+      },
+    });
+
+    const store = createSelectedDriveItemBindingStore(null, {
+      storage,
+      storageKey,
+      initialActiveAccountId: 'account-1',
+    });
+
+    expect(get(store)).toEqual({
+      driveId: 'drive-123',
+      itemId: 'item-456',
+      name: 'conspectus.db',
+      parentPath: '/Finance',
+    });
+  });
+
+  it('hydrates legacy v1 payloads to preserve existing local bindings', () => {
+    const { storage, values } = createMemoryStorage();
+    const storageKey = 'binding-key';
+    values[storageKey] = JSON.stringify({
+      version: 1,
+      accountId: 'account-1',
+      binding: {
+        driveId: 'drive-123',
+        itemId: 'item-456',
+        name: 'conspectus.db',
+        parentPath: '/Finance',
+      },
+    });
+
+    const store = createSelectedDriveItemBindingStore(null, {
+      storage,
+      storageKey,
+      initialActiveAccountId: 'account-1',
+    });
+
+    expect(get(store)).toEqual({
+      driveId: 'drive-123',
+      itemId: 'item-456',
+      name: 'conspectus.db',
+      parentPath: '/Finance',
+    });
+  });
+
+  it('ignores persisted payloads with unsupported schema versions', () => {
+    const { storage, values } = createMemoryStorage();
+    const storageKey = 'binding-key';
+    values[storageKey] = JSON.stringify({
+      version: 99,
+      bindingsByAccountId: {
+        'account-1': {
+          driveId: 'drive-123',
+          itemId: 'item-456',
+          name: 'conspectus.db',
+          parentPath: '/Finance',
+        },
+      },
+    });
+
+    const store = createSelectedDriveItemBindingStore(null, {
+      storage,
+      storageKey,
+      initialActiveAccountId: 'account-1',
+    });
+
+    expect(get(store)).toBeNull();
+  });
+
+  it('keeps separate bindings per account in storage', () => {
+    const { storage, values } = createMemoryStorage();
+    const storageKey = 'binding-key';
+    const store = createSelectedDriveItemBindingStore(null, {
+      storage,
+      storageKey,
+      initialActiveAccountId: 'account-1',
+    });
+    const bindingOne = {
+      driveId: 'drive-123',
+      itemId: 'item-1',
+      name: 'first.db',
+      parentPath: '/Finance',
+    } as const;
+    const bindingTwo = {
+      driveId: 'drive-123',
+      itemId: 'item-2',
+      name: 'second.db',
+      parentPath: '/Private',
+    } as const;
+
+    store.setBinding(bindingOne);
+    store.setActiveAccountId('account-2');
+    store.setBinding(bindingTwo);
+
+    expect(get(store)).toEqual(bindingTwo);
+
+    store.setActiveAccountId('account-1');
+    expect(get(store)).toEqual(bindingOne);
+
+    expect(values[storageKey]).toBe(
+      JSON.stringify({
+        version: 2,
+        bindingsByAccountId: {
+          'account-1': bindingOne,
+          'account-2': bindingTwo,
+        },
+      }),
+    );
   });
 });

--- a/src/shared/state/selectedDriveItemBindingStore.ts
+++ b/src/shared/state/selectedDriveItemBindingStore.ts
@@ -21,7 +21,15 @@ interface CreateSelectedDriveItemBindingStoreOptions {
 }
 
 const DEFAULT_STORAGE_KEY = 'conspectus.selectedDriveItemBinding';
+const LEGACY_PERSISTED_BINDING_SCHEMA_VERSION = 1;
+const PERSISTED_BINDING_SCHEMA_VERSION = 2;
+
 interface PersistedBindingPayload {
+  readonly version: typeof PERSISTED_BINDING_SCHEMA_VERSION;
+  readonly bindingsByAccountId: Record<string, DriveItemBinding>;
+}
+
+interface LegacyPersistedBindingPayload {
   readonly accountId: string;
   readonly binding: DriveItemBinding;
 }
@@ -40,11 +48,58 @@ const isDriveItemBinding = (value: unknown): value is DriveItemBinding =>
   value.name.trim().length > 0 &&
   value.parentPath.trim().length > 0;
 
-const isPersistedBindingPayload = (value: unknown): value is PersistedBindingPayload =>
+const isLegacyPersistedBindingPayload = (value: unknown): value is LegacyPersistedBindingPayload =>
   isRecord(value) &&
   typeof value.accountId === 'string' &&
   value.accountId.trim().length > 0 &&
   isDriveItemBinding(value.binding);
+
+const isBindingsByAccountIdRecord = (value: unknown): value is Record<string, DriveItemBinding> => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return Object.entries(value).every(([accountId, binding]) => {
+    return accountId.trim().length > 0 && isDriveItemBinding(binding);
+  });
+};
+
+const parsePersistedBindingPayload = (value: unknown): PersistedBindingPayload | null => {
+  if (isRecord(value) && value.version === PERSISTED_BINDING_SCHEMA_VERSION) {
+    if (!isBindingsByAccountIdRecord(value.bindingsByAccountId)) {
+      return null;
+    }
+
+    return {
+      version: PERSISTED_BINDING_SCHEMA_VERSION,
+      bindingsByAccountId: value.bindingsByAccountId,
+    };
+  }
+
+  if (isRecord(value) && value.version === LEGACY_PERSISTED_BINDING_SCHEMA_VERSION) {
+    if (!isLegacyPersistedBindingPayload(value)) {
+      return null;
+    }
+
+    return {
+      version: PERSISTED_BINDING_SCHEMA_VERSION,
+      bindingsByAccountId: {
+        [value.accountId]: value.binding,
+      },
+    };
+  }
+
+  if (isLegacyPersistedBindingPayload(value)) {
+    return {
+      version: PERSISTED_BINDING_SCHEMA_VERSION,
+      bindingsByAccountId: {
+        [value.accountId]: value.binding,
+      },
+    };
+  }
+
+  return null;
+};
 
 const normalizeAccountId = (accountId: string | null | undefined): string | null => {
   if (accountId === null || accountId === undefined) {
@@ -78,12 +133,12 @@ const loadStoredBinding = (
       return null;
     }
 
-    const parsedValue: unknown = JSON.parse(rawValue);
-    if (!isPersistedBindingPayload(parsedValue)) {
+    const parsedValue = parsePersistedBindingPayload(JSON.parse(rawValue));
+    if (parsedValue === null) {
       return null;
     }
 
-    return parsedValue.accountId === accountId ? parsedValue.binding : null;
+    return parsedValue.bindingsByAccountId[accountId] ?? null;
   } catch {
     return null;
   }
@@ -99,13 +154,24 @@ export const createSelectedDriveItemBindingStore = (
   const persistedBinding = loadStoredBinding(storage, storageKey, activeAccountId);
   const { subscribe, set } = writable<DriveItemBinding | null>(initialBinding ?? persistedBinding);
 
-  const persistBinding = (binding: DriveItemBinding | null): void => {
+  const persistActiveAccountBinding = (binding: DriveItemBinding | null): void => {
     if (storage === null || activeAccountId === null) {
       return;
     }
 
     try {
+      const existingPayload = parsePersistedBindingPayload(
+        JSON.parse(storage.getItem(storageKey) ?? 'null'),
+      );
+      const bindingsByAccountId = { ...(existingPayload?.bindingsByAccountId ?? {}) };
+
       if (binding === null) {
+        delete bindingsByAccountId[activeAccountId];
+      } else {
+        bindingsByAccountId[activeAccountId] = binding;
+      }
+
+      if (Object.keys(bindingsByAccountId).length === 0) {
         storage.removeItem(storageKey);
         return;
       }
@@ -113,8 +179,8 @@ export const createSelectedDriveItemBindingStore = (
       storage.setItem(
         storageKey,
         JSON.stringify({
-          accountId: activeAccountId,
-          binding,
+          version: PERSISTED_BINDING_SCHEMA_VERSION,
+          bindingsByAccountId,
         } satisfies PersistedBindingPayload),
       );
     } catch {
@@ -129,11 +195,11 @@ export const createSelectedDriveItemBindingStore = (
       set(loadStoredBinding(storage, storageKey, activeAccountId));
     },
     setBinding: (binding) => {
-      persistBinding(binding);
+      persistActiveAccountBinding(binding);
       set(activeAccountId === null ? null : binding);
     },
     clear: () => {
-      persistBinding(null);
+      persistActiveAccountBinding(null);
       set(null);
     },
   };

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -131,6 +131,7 @@ const installMockGraphClient = async (
   options: MockGraphClientOptions = {},
 ): Promise<void> => {
   await page.addInitScript((mockOptions: MockGraphClientOptions) => {
+    let listChildrenCallCount = 0;
     const rootItems = [
       {
         driveId: 'drive-123',
@@ -167,6 +168,10 @@ const installMockGraphClient = async (
 
     (window as Window & { __CONSPECTUS_GRAPH_CLIENT__?: unknown }).__CONSPECTUS_GRAPH_CLIENT__ = {
       async listChildren(folder?: { itemId?: string }) {
+        listChildrenCallCount += 1;
+        (
+          window as Window & { __CONSPECTUS_GRAPH_LIST_CHILDREN_CALL_COUNT__?: number }
+        ).__CONSPECTUS_GRAPH_LIST_CHILDREN_CALL_COUNT__ = listChildrenCallCount;
         if (mockOptions.failListChildren) {
           throw {
             code: 'network_error',
@@ -198,8 +203,23 @@ const installMockGraphClient = async (
         };
       },
     };
+    (
+      window as Window & { __CONSPECTUS_GRAPH_LIST_CHILDREN_CALL_COUNT__?: number }
+    ).__CONSPECTUS_GRAPH_LIST_CHILDREN_CALL_COUNT__ = listChildrenCallCount;
   }, options);
 };
+
+const getGraphListChildrenCallCount = async (
+  page: import('@playwright/test').Page,
+): Promise<number> =>
+  page.evaluate(() => {
+    const value = (
+      window as Window & {
+        __CONSPECTUS_GRAPH_LIST_CHILDREN_CALL_COUNT__?: unknown;
+      }
+    ).__CONSPECTUS_GRAPH_LIST_CHILDREN_CALL_COUNT__;
+    return typeof value === 'number' ? value : 0;
+  });
 
 test('shows startup configuration error when required runtime env is missing', async ({ page }) => {
   await page.route('**/*.js', async (route) => {
@@ -333,6 +353,7 @@ test('keeps the selected DB file after reload', async ({ page }) => {
   await page.goto(appPath('#/settings'));
   await page.getByRole('button', { name: 'Select DB File' }).click();
   await page.getByTestId('select-file-file-root-db').click();
+  expect(await getGraphListChildrenCallCount(page)).toBe(1);
 
   await expect(page.getByTestId('binding-status-message')).toContainText('DB file selected.');
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('conspectus.db');
@@ -344,6 +365,29 @@ test('keeps the selected DB file after reload', async ({ page }) => {
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('conspectus.db');
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('/');
   await expect(page.getByTestId('db-file-browser')).toHaveCount(0);
+  expect(await getGraphListChildrenCallCount(page)).toBe(0);
+});
+
+test('restores selected DB file after startup on a non-settings route', async ({ page }) => {
+  await installMockAuthClient(page, {
+    startAuthenticated: true,
+  });
+  await installMockGraphClient(page);
+
+  await page.goto(appPath('#/settings'));
+  await page.getByRole('button', { name: 'Select DB File' }).click();
+  await page.getByTestId('select-file-file-root-db').click();
+
+  await page.getByRole('link', { name: 'Accounts' }).click();
+  await expect(page.getByRole('heading', { level: 2, name: 'Accounts' })).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByRole('heading', { level: 2, name: 'Accounts' })).toBeVisible();
+  expect(await getGraphListChildrenCallCount(page)).toBe(0);
+
+  await page.getByRole('link', { name: 'Settings' }).click();
+  await expect(page.getByTestId('binding-status-message')).toContainText('DB file selected.');
+  await expect(page.getByTestId('selected-db-file-summary')).toContainText('conspectus.db');
 });
 
 test('shows browse errors without pretending the OneDrive folder is empty', async ({ page }) => {


### PR DESCRIPTION
## Summary\n- implement M3-07 local binding persistence with schema-versioned metadata payloads\n- persist selected OneDrive bindings per authenticated account (indingsByAccountId) with legacy read migration support\n- hydrate active-account binding at app startup (not only when Settings route mounts)\n- extend unit and e2e coverage for restart persistence and non-settings startup behavior\n\n## Acceptance Criteria Mapping\n- Binding survives app restart: covered by persisted store hydration + Playwright reload tests (keeps the selected DB file after reload, estores selected DB file after startup on a non-settings route).\n- Binding can be read without extra network calls: on reload, binding summary is restored before any browse call; e2e asserts no Graph browse calls unless user explicitly opens file browser.\n\n## Verification\n- npm run format\n- npm run lint\n- npm run typecheck\n- npm run test\n- npm run build\n- npm run test:e2e\n\nCloses #41