### PR TITLE
feat(m3-08): add settings rebind and local reset actions

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -372,6 +372,13 @@ M3-07 implementation clarification:
 - Startup binding hydration is triggered at app initialization in `src/features/app-shell/AppShell.svelte` and synchronized through `src/features/app-shell/startupBindingSync.ts`, so the active account binding is resolved before entering Settings.
 - Legacy persisted payloads from pre-versioned and v1 single-binding formats are migrated on read into the current schema during hydration.
 
+M3-08 implementation clarification:
+
+- Settings now exposes explicit DB rebind and local reset actions in `src/features/app-shell/routes/SettingsRoute.svelte`: `Change DB file` (when a binding exists) and `Reset local app data`.
+- Destructive local reset behavior is orchestrated by `src/features/app-shell/routes/settingsLocalDataController.ts` with explicit confirmation state, in-flight protection, and surfaced failure messaging.
+- Reset execution is wired through `src/features/app-shell/routes/settingsCacheStoreResolver.ts`, which clears app-owned local storage/session storage keys, service-worker cache entries with `conspectus` naming, and IndexedDB databases matching `conspectus` before binding removal completes.
+- The reset confirmation is rendered as a modal `dialog` and blocks sign-out/reset/rebind controls while confirmation or reset is active to prevent account-context race conditions during binding clearance.
+
 Deliverables:
 
 - Stable login flow with persisted session where possible.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -276,7 +276,7 @@ An issue is only considered done when:
 - Depends on: `M3-06`
 - GitHub: [#41](https://github.com/Jon2050/Conspectus-Mobile/issues/41)
 
-### :green_circle: M3-08 Add settings actions for rebind and local reset
+### :white_check_mark: M3-08 Add settings actions for rebind and local reset
 
 - Label: `feature`
 - Milestone: `M3 - Auth + OneDrive Binding`

--- a/docs/prompts/Task-Prompt-Template.md
+++ b/docs/prompts/Task-Prompt-Template.md
@@ -42,7 +42,7 @@ Always print in which step you are!
 8. CI gate: wait for required GitHub checks to pass. If any check fails, fix and repeat from step 4.
 9. Completion:
    - Merge the PR to `main`, then delete the head branch.
-   - Mark issue done in GitHub.
+   - Mark issue done in GitHub. Also add a brief comment with a summary of what you did and why. Also mention if you made any assumptions or any problems you encountered. Comment must be well formatted.
    - Update `docs/GitHub-Issues-MVP-Backlog.md` status marker to done.
    - Update docs/Architecture-and-Implementation-Plan.md: Append something or modify ONLY the specific section relevant to this issue to reflect implementation realities if something changed, got redefined or became clearer during this task. STRICTLY FORBIDDEN: Do not reformat, summarize, or alter any unrelated parts of this document.
    - Provide final report with changed files, commands/results, CI status, acceptance criteria checklist, and assumptions.

--- a/src/features/app-shell/routes/SettingsRoute.svelte
+++ b/src/features/app-shell/routes/SettingsRoute.svelte
@@ -3,6 +3,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { get } from 'svelte/store';
   import type { AuthClient } from '@auth';
+  import type { CacheStore } from '@cache';
   import type { GraphClient, GraphDriveItem } from '@graph';
   import { appSelectedDriveItemBindingStore } from '@shared';
 
@@ -15,10 +16,16 @@
     createSettingsFileBindingController,
     type SettingsFileBindingState,
   } from './settingsFileBindingController';
+  import {
+    createSettingsLocalDataController,
+    type SettingsLocalDataResetState,
+  } from './settingsLocalDataController';
   import { resolveSettingsAuthClient } from './settingsAuthClientResolver';
+  import { resolveSettingsCacheStore } from './settingsCacheStoreResolver';
   import { resolveSettingsGraphClient } from './settingsGraphClientResolver';
 
   export let authClient: AuthClient = resolveSettingsAuthClient();
+  export let cacheStore: Pick<CacheStore, 'clearAll'> = resolveSettingsCacheStore();
   export let graphClient: GraphClient = resolveSettingsGraphClient();
 
   let state: SettingsAuthState = {
@@ -42,6 +49,11 @@
     canGoBack: false,
   };
   let bindingStatusMessage = 'Sign in to browse and choose a .db file.';
+  let localDataResetState: SettingsLocalDataResetState = {
+    operation: 'idle',
+    error: null,
+  };
+  let localDataResetDialogElement: HTMLDialogElement | null = null;
 
   const statusMessageByOperation: Record<SettingsAuthOperation, string> = {
     initializing: 'Checking authentication status...',
@@ -103,6 +115,12 @@
       appSelectedDriveItemBindingStore.setBinding(binding);
     },
   });
+  const localDataController = createSettingsLocalDataController(cacheStore, {
+    onLocalDataReset: () => {
+      appSelectedDriveItemBindingStore.clear();
+      fileBindingController.reset();
+    },
+  });
   const unsubscribe = authController.subscribe((nextState) => {
     const previousAccountId = state.session.account?.homeAccountId ?? null;
     const wasAuthenticated = state.session.isAuthenticated;
@@ -119,6 +137,7 @@
 
     if (!nextState.session.isAuthenticated) {
       appSelectedDriveItemBindingStore.setActiveAccountId(null);
+      localDataController.cancelReset();
     }
 
     if (wasAuthenticated && !nextState.session.isAuthenticated) {
@@ -128,6 +147,9 @@
   const unsubscribeFileBinding = fileBindingController.subscribe((nextState) => {
     bindingState = nextState;
     bindingStatusMessage = buildBindingStatusMessage(nextState);
+  });
+  const unsubscribeLocalDataReset = localDataController.subscribe((nextState) => {
+    localDataResetState = nextState;
   });
 
   const handleSignInClick = (): void => {
@@ -140,6 +162,22 @@
 
   const handleBrowseClick = (): void => {
     void fileBindingController.browseRoot();
+  };
+  const handleRequestLocalResetClick = (): void => {
+    localDataController.requestReset();
+  };
+
+  const handleCancelLocalResetClick = (): void => {
+    localDataController.cancelReset();
+  };
+
+  const handleConfirmLocalResetClick = (): void => {
+    void localDataController.confirmReset();
+  };
+
+  const handleLocalResetDialogCancel = (event: Event): void => {
+    event.preventDefault();
+    localDataController.cancelReset();
   };
 
   const handleBackClick = (): void => {
@@ -154,6 +192,16 @@
     fileBindingController.selectFile(item);
   };
 
+  $: if (localDataResetDialogElement !== null) {
+    if (localDataResetState.operation === 'idle') {
+      if (localDataResetDialogElement.open) {
+        localDataResetDialogElement.close();
+      }
+    } else if (!localDataResetDialogElement.open) {
+      localDataResetDialogElement.showModal();
+    }
+  }
+
   onMount(() => {
     void authController.initialize();
   });
@@ -161,6 +209,7 @@
   onDestroy(() => {
     unsubscribe();
     unsubscribeFileBinding();
+    unsubscribeLocalDataReset();
   });
 </script>
 
@@ -215,9 +264,11 @@
         class="settings-screen__button settings-screen__button--primary"
         type="button"
         on:click={handleBrowseClick}
-        disabled={authOperationIsPending || bindingState.operation !== 'idle'}
+        disabled={authOperationIsPending ||
+          bindingState.operation !== 'idle' ||
+          localDataResetState.operation !== 'idle'}
       >
-        Select DB File
+        {bindingState.selectedBinding === null ? 'Select DB File' : 'Change DB file'}
       </button>
 
       {#if bindingState.browserIsOpen && bindingState.canGoBack}
@@ -231,6 +282,66 @@
         </button>
       {/if}
     </div>
+
+    <div class="settings-screen__actions">
+      <button
+        class="settings-screen__button settings-screen__button--danger"
+        type="button"
+        data-testid="reset-local-app-data-button"
+        on:click={handleRequestLocalResetClick}
+        disabled={authOperationIsPending ||
+          bindingState.operation !== 'idle' ||
+          localDataResetState.operation !== 'idle'}
+      >
+        Reset local app data
+      </button>
+    </div>
+
+    <dialog
+      bind:this={localDataResetDialogElement}
+      class="settings-screen__confirmation"
+      aria-labelledby="reset-local-data-title"
+      data-testid="reset-local-app-data-confirmation"
+      on:cancel={handleLocalResetDialogCancel}
+    >
+      <h4 id="reset-local-data-title">Reset local app data?</h4>
+      <p>
+        This clears local DB file binding and cached app data on this device for the signed-in
+        account.
+      </p>
+
+      {#if localDataResetState.error !== null}
+        <p class="settings-screen__confirmation-error" role="alert">
+          {localDataResetState.error.message}
+        </p>
+      {/if}
+
+      {#if localDataResetState.operation === 'resetting'}
+        <p class="settings-screen__confirmation-status" aria-live="polite">
+          Resetting local app data...
+        </p>
+      {/if}
+
+      <div class="settings-screen__actions">
+        <button
+          class="settings-screen__button settings-screen__button--secondary"
+          type="button"
+          on:click={handleCancelLocalResetClick}
+          disabled={localDataResetState.operation === 'resetting'}
+        >
+          Cancel
+        </button>
+        <button
+          class="settings-screen__button settings-screen__button--danger"
+          type="button"
+          data-testid="confirm-reset-local-app-data-button"
+          on:click={handleConfirmLocalResetClick}
+          disabled={localDataResetState.operation === 'resetting'}
+        >
+          Confirm reset
+        </button>
+      </div>
+    </dialog>
 
     {#if bindingState.selectedBinding !== null}
       <dl class="settings-screen__binding-summary" data-testid="selected-db-file-summary">
@@ -309,7 +420,7 @@
         class="settings-screen__button settings-screen__button--secondary"
         type="button"
         on:click={handleSignOutClick}
-        disabled={authOperationIsPending}
+        disabled={authOperationIsPending || localDataResetState.operation !== 'idle'}
       >
         Sign out
       </button>
@@ -432,6 +543,45 @@
     color: var(--text-primary);
     background: var(--surface);
     border-color: var(--border);
+  }
+
+  .settings-screen__button--danger {
+    color: #ffffff;
+    background: color-mix(in srgb, var(--error) 92%, black);
+    border-color: color-mix(in srgb, var(--error) 55%, black);
+  }
+
+  .settings-screen__confirmation {
+    display: grid;
+    gap: 0.65rem;
+    width: min(32rem, calc(100vw - 2rem));
+    max-width: 100%;
+    margin: auto;
+    padding: 0.8rem;
+    border: 1px solid color-mix(in srgb, var(--error) 40%, var(--border));
+    border-radius: 0.9rem;
+    background: #fff2f2;
+  }
+
+  .settings-screen__confirmation:not([open]) {
+    display: none;
+  }
+
+  .settings-screen__confirmation::backdrop {
+    background: color-mix(in srgb, black 40%, transparent);
+  }
+
+  .settings-screen__confirmation h4,
+  .settings-screen__confirmation p {
+    margin: 0;
+  }
+
+  .settings-screen__confirmation-status {
+    color: var(--text-secondary);
+  }
+
+  .settings-screen__confirmation-error {
+    color: #7d1111;
   }
 
   .settings-screen__browser {

--- a/src/features/app-shell/routes/settingsCacheStoreResolver.test.ts
+++ b/src/features/app-shell/routes/settingsCacheStoreResolver.test.ts
@@ -1,0 +1,90 @@
+// Verifies the Settings cache resolver uses localhost overrides and clears app-owned local caches by default.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface MemoryStorageLike {
+  getItem(key: string): string | null;
+  key(index: number): string | null;
+  readonly length: number;
+  removeItem(key: string): void;
+  setItem(key: string, value: string): void;
+}
+
+const createMemoryStorage = (initialValues: Record<string, string>): MemoryStorageLike => {
+  const values = new Map(Object.entries(initialValues));
+
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() {
+      return values.size;
+    },
+    removeItem: (key) => {
+      values.delete(key);
+    },
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+  };
+};
+
+describe('settings cache store resolver', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('uses localhost test override cache store when available', async () => {
+    const overrideClearAll = vi.fn(async () => {});
+    vi.stubGlobal('window', {
+      location: { hostname: '127.0.0.1' },
+      __CONSPECTUS_CACHE_STORE__: { clearAll: overrideClearAll },
+    });
+
+    const { resolveSettingsCacheStore } = await import('./settingsCacheStoreResolver');
+    await resolveSettingsCacheStore().clearAll();
+
+    expect(overrideClearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears app-owned storage, CacheStorage, and IndexedDB entries by default', async () => {
+    const localStorage = createMemoryStorage({
+      'conspectus.selectedDriveItemBinding': '{"value":1}',
+      'other-app-key': 'keep',
+    });
+    const sessionStorage = createMemoryStorage({
+      'conspectus.session': 'temp',
+      untouched: 'keep',
+    });
+    const cacheDelete = vi.fn(async () => true);
+    const indexedDbDeleteDatabase = vi.fn();
+    vi.stubGlobal('window', {
+      location: { hostname: 'jon2050.de' },
+      localStorage,
+      sessionStorage,
+      caches: {
+        keys: vi.fn(async () => ['conspectus-mobile-precache-v1', 'unrelated-cache']),
+        delete: cacheDelete,
+      },
+      indexedDB: {
+        databases: vi.fn(async () => [{ name: 'conspectus-mobile-cache' }, { name: 'other-db' }]),
+        deleteDatabase: indexedDbDeleteDatabase,
+      },
+    });
+
+    const { resolveSettingsCacheStore } = await import('./settingsCacheStoreResolver');
+    await resolveSettingsCacheStore().clearAll();
+
+    expect(localStorage.getItem('conspectus.selectedDriveItemBinding')).toBeNull();
+    expect(localStorage.getItem('other-app-key')).toBe('keep');
+    expect(sessionStorage.getItem('conspectus.session')).toBeNull();
+    expect(sessionStorage.getItem('untouched')).toBe('keep');
+    expect(cacheDelete).toHaveBeenCalledTimes(1);
+    expect(cacheDelete).toHaveBeenCalledWith('conspectus-mobile-precache-v1');
+    expect(indexedDbDeleteDatabase).toHaveBeenCalledTimes(1);
+    expect(indexedDbDeleteDatabase).toHaveBeenCalledWith('conspectus-mobile-cache');
+  });
+});

--- a/src/features/app-shell/routes/settingsCacheStoreResolver.ts
+++ b/src/features/app-shell/routes/settingsCacheStoreResolver.ts
@@ -1,0 +1,115 @@
+// Resolves the cache store used by Settings local-reset actions, with localhost-only test override support.
+import type { CacheStore } from '@cache';
+
+declare global {
+  interface Window {
+    __CONSPECTUS_CACHE_STORE__?: Pick<CacheStore, 'clearAll'>;
+  }
+}
+
+const defaultCacheStore: Pick<CacheStore, 'clearAll'> = {
+  async clearAll(): Promise<void> {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const errors: unknown[] = [];
+
+    const clearConspectusStorageKeys = (storage: Storage): void => {
+      for (let index = storage.length - 1; index >= 0; index -= 1) {
+        const key = storage.key(index);
+        if (key !== null && key.startsWith('conspectus.')) {
+          storage.removeItem(key);
+        }
+      }
+    };
+
+    try {
+      clearConspectusStorageKeys(window.localStorage);
+    } catch (error) {
+      errors.push(error);
+    }
+
+    try {
+      clearConspectusStorageKeys(window.sessionStorage);
+    } catch (error) {
+      errors.push(error);
+    }
+
+    try {
+      if ('caches' in window) {
+        const cacheKeys = await window.caches.keys();
+        await Promise.all(
+          cacheKeys
+            .filter((cacheKey) => cacheKey.toLowerCase().includes('conspectus'))
+            .map((cacheKey) => window.caches.delete(cacheKey)),
+        );
+      }
+    } catch (error) {
+      errors.push(error);
+    }
+
+    try {
+      const indexedDbApi = window.indexedDB;
+      if (typeof indexedDbApi !== 'undefined') {
+        const deleteIndexedDatabase = async (databaseName: string): Promise<void> => {
+          const request = indexedDbApi.deleteDatabase(databaseName);
+          if (request === undefined || typeof request !== 'object' || !('onsuccess' in request)) {
+            return;
+          }
+
+          await new Promise<void>((resolve, reject) => {
+            request.onsuccess = () => {
+              resolve();
+            };
+            request.onerror = () => {
+              reject(request.error ?? new Error(`Failed to delete IndexedDB "${databaseName}".`));
+            };
+            request.onblocked = () => {
+              reject(new Error(`IndexedDB "${databaseName}" deletion was blocked.`));
+            };
+          });
+        };
+
+        const resolvedDatabaseNames =
+          typeof indexedDbApi.databases === 'function'
+            ? (await indexedDbApi.databases())
+                .map((database) => database.name?.trim() ?? '')
+                .filter(
+                  (databaseName) =>
+                    databaseName.length > 0 && databaseName.toLowerCase().includes('conspectus'),
+                )
+            : ['conspectus-mobile-cache', 'conspectus-cache'];
+        const uniqueDatabaseNames = [...new Set(resolvedDatabaseNames)];
+
+        for (const databaseName of uniqueDatabaseNames) {
+          await deleteIndexedDatabase(databaseName);
+        }
+      }
+    } catch (error) {
+      errors.push(error);
+    }
+
+    if (errors.length > 0) {
+      throw new Error('Failed to clear all local app cache data.', {
+        cause: errors[0],
+      });
+    }
+  },
+};
+
+const isLocalCacheMockHost = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.location.hostname === '127.0.0.1' || window.location.hostname === 'localhost';
+};
+
+export const resolveSettingsCacheStore = (): Pick<CacheStore, 'clearAll'> => {
+  if (isLocalCacheMockHost() && window.__CONSPECTUS_CACHE_STORE__ !== undefined) {
+    return window.__CONSPECTUS_CACHE_STORE__;
+  }
+
+  return defaultCacheStore;
+};

--- a/src/features/app-shell/routes/settingsFileBindingController.test.ts
+++ b/src/features/app-shell/routes/settingsFileBindingController.test.ts
@@ -34,15 +34,15 @@ const ROOT_ITEMS: readonly GraphDriveItem[] = [
   ROOT_NON_DB_FILE_ITEM,
 ];
 
-const FINANCE_ITEMS: readonly GraphDriveItem[] = [
-  {
-    driveId: 'drive-123',
-    itemId: 'file-3',
-    name: 'budget.db',
-    parentPath: '/Finance',
-    kind: 'file',
-  },
-];
+const FINANCE_DB_FILE_ITEM: GraphDriveItem = {
+  driveId: 'drive-123',
+  itemId: 'file-3',
+  name: 'budget.db',
+  parentPath: '/Finance',
+  kind: 'file',
+};
+
+const FINANCE_ITEMS: readonly GraphDriveItem[] = [FINANCE_DB_FILE_ITEM];
 
 const createDeferred = <T>(): { promise: Promise<T>; resolve(value: T): void } => {
   let resolvePromise: (value: T) => void = () => {};
@@ -309,6 +309,37 @@ describe('settings file binding controller', () => {
     expect(controller.getState().items).toEqual([ROOT_FOLDER_ITEM, ROOT_DB_FILE_ITEM]);
     expect(controller.getState().hasLoaded).toBe(true);
     expect(controller.getState().canGoBack).toBe(false);
+  });
+
+  it('rebinds to a different database file from an already selected binding', async () => {
+    const controller = createSettingsFileBindingController(harness.graphClient, {
+      onBindingChange,
+    });
+
+    await controller.browseRoot();
+    controller.selectFile(ROOT_DB_FILE_ITEM);
+    await controller.browseRoot();
+    await controller.openFolder(ROOT_FOLDER_ITEM);
+    controller.selectFile(FINANCE_DB_FILE_ITEM);
+
+    expect(controller.getState().selectedBinding).toEqual({
+      driveId: 'drive-123',
+      itemId: 'file-3',
+      name: 'budget.db',
+      parentPath: '/Finance',
+    });
+    expect(onBindingChange).toHaveBeenNthCalledWith(1, {
+      driveId: 'drive-123',
+      itemId: 'file-1',
+      name: 'conspectus.db',
+      parentPath: '/',
+    });
+    expect(onBindingChange).toHaveBeenNthCalledWith(2, {
+      driveId: 'drive-123',
+      itemId: 'file-3',
+      name: 'budget.db',
+      parentPath: '/Finance',
+    });
   });
 
   it('captures graph browse failures as controller errors', async () => {

--- a/src/features/app-shell/routes/settingsLocalDataController.test.ts
+++ b/src/features/app-shell/routes/settingsLocalDataController.test.ts
@@ -1,0 +1,93 @@
+// Verifies confirmation and execution behavior for the destructive local app data reset controller.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createSettingsLocalDataController } from './settingsLocalDataController';
+
+const createDeferred = <T>(): { promise: Promise<T>; resolve(value: T): void } => {
+  let resolvePromise: (value: T) => void = () => {};
+
+  return {
+    promise: new Promise<T>((resolve) => {
+      resolvePromise = resolve;
+    }),
+    resolve: (value: T) => {
+      resolvePromise(value);
+    },
+  };
+};
+
+describe('settings local data controller', () => {
+  let clearAll: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  let onLocalDataReset: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    clearAll = vi.fn<() => Promise<void>>(async () => {});
+    onLocalDataReset = vi.fn<() => void>();
+  });
+
+  it('does not clear cache or binding when confirmation is canceled', () => {
+    const controller = createSettingsLocalDataController({ clearAll }, { onLocalDataReset });
+
+    controller.requestReset();
+    expect(controller.getState()).toEqual({
+      operation: 'confirming',
+      error: null,
+    });
+
+    controller.cancelReset();
+    expect(controller.getState()).toEqual({
+      operation: 'idle',
+      error: null,
+    });
+    expect(clearAll).not.toHaveBeenCalled();
+    expect(onLocalDataReset).not.toHaveBeenCalled();
+  });
+
+  it('clears cache and local binding when reset is confirmed', async () => {
+    const deferred = createDeferred<void>();
+    clearAll.mockImplementationOnce(async () => {
+      await deferred.promise;
+    });
+    const controller = createSettingsLocalDataController({ clearAll }, { onLocalDataReset });
+
+    controller.requestReset();
+
+    const confirmPromise = controller.confirmReset();
+    expect(controller.getState()).toEqual({
+      operation: 'resetting',
+      error: null,
+    });
+
+    deferred.resolve();
+    await confirmPromise;
+
+    expect(clearAll).toHaveBeenCalledTimes(1);
+    expect(onLocalDataReset).toHaveBeenCalledTimes(1);
+    const clearCallOrder = clearAll.mock.invocationCallOrder[0];
+    const resetCallOrder = onLocalDataReset.mock.invocationCallOrder[0];
+    expect(clearCallOrder).toBeDefined();
+    expect(resetCallOrder).toBeDefined();
+    expect(clearCallOrder ?? 0).toBeLessThan(resetCallOrder ?? 0);
+    expect(controller.getState()).toEqual({
+      operation: 'idle',
+      error: null,
+    });
+  });
+
+  it('keeps local binding untouched when cache clear fails', async () => {
+    clearAll.mockRejectedValueOnce(new Error('Mock cache clear failure.'));
+    const controller = createSettingsLocalDataController({ clearAll }, { onLocalDataReset });
+    controller.requestReset();
+
+    await controller.confirmReset();
+
+    expect(onLocalDataReset).not.toHaveBeenCalled();
+    expect(controller.getState()).toEqual({
+      operation: 'confirming',
+      error: {
+        message: 'Mock cache clear failure.',
+        cause: expect.any(Error),
+      },
+    });
+  });
+});

--- a/src/features/app-shell/routes/settingsLocalDataController.ts
+++ b/src/features/app-shell/routes/settingsLocalDataController.ts
@@ -1,0 +1,121 @@
+// Manages confirmation and execution state for destructive local app data reset actions in Settings.
+import type { CacheStore } from '@cache';
+
+export type SettingsLocalDataResetOperation = 'idle' | 'confirming' | 'resetting';
+
+export interface SettingsLocalDataResetError {
+  readonly message: string;
+  readonly cause?: unknown;
+}
+
+export interface SettingsLocalDataResetState {
+  readonly operation: SettingsLocalDataResetOperation;
+  readonly error: SettingsLocalDataResetError | null;
+}
+
+export type SettingsLocalDataResetStateListener = (state: SettingsLocalDataResetState) => void;
+
+export interface SettingsLocalDataController {
+  getState(): SettingsLocalDataResetState;
+  subscribe(listener: SettingsLocalDataResetStateListener): () => void;
+  requestReset(): void;
+  cancelReset(): void;
+  confirmReset(): Promise<void>;
+}
+
+interface CreateSettingsLocalDataControllerOptions {
+  readonly onLocalDataReset: () => void;
+}
+
+const INITIAL_STATE: SettingsLocalDataResetState = {
+  operation: 'idle',
+  error: null,
+};
+
+const toResetError = (error: unknown, fallbackMessage: string): SettingsLocalDataResetError => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return {
+      message: error.message,
+      cause: error,
+    };
+  }
+
+  return {
+    message: fallbackMessage,
+    cause: error,
+  };
+};
+
+export const createSettingsLocalDataController = (
+  cacheStore: Pick<CacheStore, 'clearAll'>,
+  options: CreateSettingsLocalDataControllerOptions,
+): SettingsLocalDataController => {
+  let state = INITIAL_STATE;
+  const listeners = new Set<SettingsLocalDataResetStateListener>();
+
+  const emitState = (): void => {
+    for (const listener of listeners) {
+      listener(state);
+    }
+  };
+
+  const updateState = (patch: Partial<SettingsLocalDataResetState>): void => {
+    state = {
+      ...state,
+      ...patch,
+    };
+    emitState();
+  };
+
+  return {
+    getState(): SettingsLocalDataResetState {
+      return state;
+    },
+    subscribe(listener: SettingsLocalDataResetStateListener): () => void {
+      listeners.add(listener);
+      listener(state);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    requestReset(): void {
+      if (state.operation !== 'idle') {
+        return;
+      }
+
+      updateState({
+        operation: 'confirming',
+        error: null,
+      });
+    },
+    cancelReset(): void {
+      if (state.operation !== 'confirming') {
+        return;
+      }
+
+      updateState(INITIAL_STATE);
+    },
+    async confirmReset(): Promise<void> {
+      if (state.operation !== 'confirming') {
+        return;
+      }
+
+      updateState({
+        operation: 'resetting',
+        error: null,
+      });
+
+      try {
+        await cacheStore.clearAll();
+        options.onLocalDataReset();
+        updateState(INITIAL_STATE);
+      } catch (error) {
+        updateState({
+          operation: 'confirming',
+          error: toResetError(error, 'Failed to reset local app data.'),
+        });
+      }
+    },
+  };
+};

--- a/src/shared/state/selectedDriveItemBindingStore.test.ts
+++ b/src/shared/state/selectedDriveItemBindingStore.test.ts
@@ -292,4 +292,48 @@ describe('createSelectedDriveItemBindingStore', () => {
       }),
     );
   });
+
+  it('clears only the active account binding and preserves other account bindings', () => {
+    const { storage, values } = createMemoryStorage();
+    const storageKey = 'binding-key';
+    const bindingOne = {
+      driveId: 'drive-123',
+      itemId: 'item-1',
+      name: 'first.db',
+      parentPath: '/Finance',
+    } as const;
+    const bindingTwo = {
+      driveId: 'drive-123',
+      itemId: 'item-2',
+      name: 'second.db',
+      parentPath: '/Private',
+    } as const;
+    values[storageKey] = JSON.stringify({
+      version: 2,
+      bindingsByAccountId: {
+        'account-1': bindingOne,
+        'account-2': bindingTwo,
+      },
+    });
+    const store = createSelectedDriveItemBindingStore(null, {
+      storage,
+      storageKey,
+      initialActiveAccountId: 'account-1',
+    });
+
+    store.clear();
+
+    expect(get(store)).toBeNull();
+    expect(values[storageKey]).toBe(
+      JSON.stringify({
+        version: 2,
+        bindingsByAccountId: {
+          'account-2': bindingTwo,
+        },
+      }),
+    );
+
+    store.setActiveAccountId('account-2');
+    expect(get(store)).toEqual(bindingTwo);
+  });
 });

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -45,6 +45,11 @@ type MockGraphClientOptions = {
   readonly failListChildren?: boolean;
 };
 
+type MockCacheStoreOptions = {
+  readonly failClearAll?: boolean;
+  readonly clearAllDelayMs?: number;
+};
+
 const installMockAuthClient = async (
   page: import('@playwright/test').Page,
   options: MockAuthClientOptions = {},
@@ -209,6 +214,38 @@ const installMockGraphClient = async (
   }, options);
 };
 
+const installMockCacheStore = async (
+  page: import('@playwright/test').Page,
+  options: MockCacheStoreOptions = {},
+): Promise<void> => {
+  await page.addInitScript((mockOptions: MockCacheStoreOptions) => {
+    let clearAllCallCount = 0;
+
+    (window as Window & { __CONSPECTUS_CACHE_STORE__?: unknown }).__CONSPECTUS_CACHE_STORE__ = {
+      async clearAll() {
+        clearAllCallCount += 1;
+        (
+          window as Window & { __CONSPECTUS_CACHE_CLEAR_ALL_CALL_COUNT__?: number }
+        ).__CONSPECTUS_CACHE_CLEAR_ALL_CALL_COUNT__ = clearAllCallCount;
+
+        if (typeof mockOptions.clearAllDelayMs === 'number' && mockOptions.clearAllDelayMs > 0) {
+          await new Promise((resolve) => {
+            setTimeout(resolve, mockOptions.clearAllDelayMs);
+          });
+        }
+
+        if (mockOptions.failClearAll) {
+          throw new Error('Mock cache clear failure.');
+        }
+      },
+    };
+
+    (
+      window as Window & { __CONSPECTUS_CACHE_CLEAR_ALL_CALL_COUNT__?: number }
+    ).__CONSPECTUS_CACHE_CLEAR_ALL_CALL_COUNT__ = clearAllCallCount;
+  }, options);
+};
+
 const getGraphListChildrenCallCount = async (
   page: import('@playwright/test').Page,
 ): Promise<number> =>
@@ -218,6 +255,16 @@ const getGraphListChildrenCallCount = async (
         __CONSPECTUS_GRAPH_LIST_CHILDREN_CALL_COUNT__?: unknown;
       }
     ).__CONSPECTUS_GRAPH_LIST_CHILDREN_CALL_COUNT__;
+    return typeof value === 'number' ? value : 0;
+  });
+
+const getCacheClearAllCallCount = async (page: import('@playwright/test').Page): Promise<number> =>
+  page.evaluate(() => {
+    const value = (
+      window as Window & {
+        __CONSPECTUS_CACHE_CLEAR_ALL_CALL_COUNT__?: unknown;
+      }
+    ).__CONSPECTUS_CACHE_CLEAR_ALL_CALL_COUNT__;
     return typeof value === 'number' ? value : 0;
   });
 
@@ -330,6 +377,7 @@ test('allows selecting a OneDrive .db file from the settings browser', async ({ 
   await expect(page.getByTestId('db-file-browser')).toHaveCount(0);
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('budget.db');
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('/Finance');
+  await expect(page.getByRole('button', { name: 'Change DB file' })).toBeVisible();
 
   await page.getByRole('link', { name: 'Accounts' }).click();
   await expect(page.getByRole('heading', { level: 2, name: 'Accounts' })).toBeVisible();
@@ -338,10 +386,14 @@ test('allows selecting a OneDrive .db file from the settings browser', async ({ 
   await expect(page.getByTestId('binding-status-message')).toContainText('DB file selected.');
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('budget.db');
 
-  await page.getByRole('button', { name: 'Select DB File' }).click();
+  await page.getByRole('button', { name: 'Change DB file' }).click();
   await expect(page.getByTestId('db-file-browser')).toBeVisible();
   await expect(page.getByTestId('open-folder-folder-finance')).toBeVisible();
   await expect(page.getByTestId('select-file-file-root-db')).toBeVisible();
+
+  await page.getByTestId('select-file-file-root-db').click();
+  await expect(page.getByTestId('selected-db-file-summary')).toContainText('conspectus.db');
+  await expect(page.getByTestId('selected-db-file-summary')).toContainText('/');
 });
 
 test('keeps the selected DB file after reload', async ({ page }) => {
@@ -366,6 +418,55 @@ test('keeps the selected DB file after reload', async ({ page }) => {
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('/');
   await expect(page.getByTestId('db-file-browser')).toHaveCount(0);
   expect(await getGraphListChildrenCallCount(page)).toBe(0);
+});
+
+test('resets local app data only after destructive confirmation', async ({ page }) => {
+  await installMockAuthClient(page, {
+    startAuthenticated: true,
+  });
+  await installMockGraphClient(page);
+  await installMockCacheStore(page, {
+    clearAllDelayMs: 250,
+  });
+
+  await page.goto(appPath('#/settings'));
+  await page.getByRole('button', { name: 'Select DB File' }).click();
+  await page.getByTestId('select-file-file-root-db').click();
+  await expect(page.getByTestId('selected-db-file-summary')).toContainText('conspectus.db');
+
+  await page.getByTestId('reset-local-app-data-button').click();
+  await expect(page.getByTestId('reset-local-app-data-confirmation')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Sign out' })).toBeDisabled();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+  await expect(page.getByTestId('reset-local-app-data-confirmation')).not.toBeVisible();
+  await expect(page.getByTestId('selected-db-file-summary')).toContainText('conspectus.db');
+  expect(await getCacheClearAllCallCount(page)).toBe(0);
+
+  await page.getByTestId('reset-local-app-data-button').click();
+  await page.getByTestId('confirm-reset-local-app-data-button').click();
+  await expect(page.getByTestId('reset-local-app-data-confirmation')).toContainText(
+    'Resetting local app data...',
+  );
+  await expect(page.getByRole('button', { name: 'Sign out' })).toBeDisabled();
+
+  await expect(page.getByTestId('reset-local-app-data-confirmation')).not.toBeVisible();
+  await expect(page.getByTestId('signed-in-account-summary')).toBeVisible();
+  await expect(page.getByTestId('binding-status-message')).toContainText(
+    'No DB file selected yet.',
+  );
+  await expect(page.getByTestId('selected-db-file-summary')).toHaveCount(0);
+  expect(await getCacheClearAllCallCount(page)).toBe(1);
+
+  const persistedBindingValue = await page.evaluate(() =>
+    window.localStorage.getItem('conspectus.selectedDriveItemBinding'),
+  );
+  expect(persistedBindingValue).toBeNull();
+
+  await page.reload();
+  await expect(page.getByTestId('binding-status-message')).toContainText(
+    'No DB file selected yet.',
+  );
+  await expect(page.getByTestId('selected-db-file-summary')).toHaveCount(0);
 });
 
 test('restores selected DB file after startup on a non-settings route', async ({ page }) => {


### PR DESCRIPTION
## Summary\n- add explicit Settings actions for Change DB file and Reset local app data\n- implement destructive reset confirmation flow with modal UX and in-flight action blocking\n- add local cache reset resolver used by Settings reset flow (local/session storage, CacheStorage, IndexedDB)\n- expand unit/e2e coverage for rebind and reset confirmation/cancel behavior\n- update Architecture clarifications and backlog marker for M3-08\n\n## Acceptance Criteria Mapping\n- AC1 (Rebind flow works end-to-end): implemented in SettingsRoute action UX + controller behavior tests + Playwright rebind flow assertions\n- AC2 (Reset clears local binding and cache reliably): implemented with confirmation-gated reset controller, cache clear before binding clear, surfaced reset error states, and Playwright reset confirmation/cancel coverage\n\n## Verification\n- 
pm run format\n- 
pm run lint\n- 
pm run typecheck\n- 
pm run test\n- 
pm run build\n- 
pm run test:e2e\n\nCloses #43