### PR TITLE
docs: document rebase-only PR merges

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,6 +43,7 @@
 ## Merge And Cleanup (PR Path)
 
 - [ ] Required GitHub checks are green.
+- [ ] PR will be merged into `main` with `Rebase and merge`.
 - [ ] PR will be merged into `main` once checks/review requirements are satisfied.
 - [ ] Head branch will be deleted after merge.
 - [ ] Linked issue/backlog marker will only be marked done after merge.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ This enables filtering by agent: `git log --grep="Agent: Claude"`.
 Issue completion definition (required):
 
 - Every issue must be implemented from a dedicated issue branch and merged through a PR.
+- PRs must be merged into `main` with `Rebase and merge` (linear history; no merge commits or squash merges).
 - All scoped code/tests/docs changes are committed and pushed.
 - Local quality gates pass (`format`, `lint`, `typecheck`, `test`, `build`, and `test:e2e` when relevant).
 - Required GitHub checks are green.


### PR DESCRIPTION
## Summary
- document in the README that PRs into \main\ must use rebase and merge
- add the same rule to the PR checklist

## Testing
- not run (per request)