### PR TITLE
fix: restore OneDrive snapshot download in browser

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -475,6 +475,7 @@ M4-06 implementation clarification:
 - Retryability is intentionally narrow: only normalized Graph `network_error` failures are retried; auth, permission, not-found, conflict, and local snapshot validation failures still fail fast on the first attempt.
 - The default startup retry policy is 3 total attempts with a `250ms` base delay capped at `1000ms`; when retries are exhausted, the final failure preserves the normalized `network_error` identity for later handling and surfaces actionable user messaging.
 - When retries are exhausted but a cached snapshot already exists, startup still resolves to the existing `stale` branch and continues with the cached DB instead of discarding readable local data.
+- Browser snapshot downloads use `@microsoft.graph.downloadUrl` from the metadata response instead of the Graph `/content` redirect endpoint, because the redirect path can fail under browser CORS handling while the preauthenticated download URL avoids that failure mode.
 
 M4-07 implementation clarification:
 

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -439,6 +439,14 @@ An issue is only considered done when:
 - Depends on: `none`
 - GitHub: [#63](https://github.com/Jon2050/Conspectus-Mobile/issues/63)
 
+### :green_circle: M5-10 Follow-up UI cleanup and usability polish
+
+- Label: `feature`
+- Milestone: `M5 - Accounts + Transfers Read UX`
+- Summary: Work includes a later cleanup pass for the Milestone 5 UI and overall usability once the remaining planned work is further along. It intentionally keeps the exact polish scope open for later review.
+- Depends on: `M5-06, M5-07, M5-08, M5-09`
+- GitHub: [#174](https://github.com/Jon2050/Conspectus-Mobile/issues/174)
+
 ### :green_circle: M6-01 Build Add Transfer form UI (bottom sheet)
 
 - Label: `feature`

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta name="description" content="Mobile PWA for Conspectus personal finance tracking." />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com; frame-src 'self' https://login.microsoftonline.com; worker-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com https://*.1drv.com https://*.microsoftpersonalcontent.com; frame-src 'self' https://login.microsoftonline.com; worker-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'"
     />
     <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f3f4f6" />

--- a/scripts/verify-build-channel.mjs
+++ b/scripts/verify-build-channel.mjs
@@ -277,6 +277,29 @@ const verifyCspMetaTag = (indexHtml) => {
       scriptSourceDirectiveValue.includes("'wasm-unsafe-eval'"),
     "Content-Security-Policy script-src directive must include 'wasm-unsafe-eval' for sql.js WASM runtime support.",
   );
+
+  const connectSourceDirectiveValue = extractDirectiveValue(cspContent, 'connect-src');
+  const requiredConnectSources = [
+    "'self'",
+    'https://login.microsoftonline.com',
+    'https://graph.microsoft.com',
+    'https://*.1drv.com',
+    'https://*.microsoftpersonalcontent.com',
+  ];
+
+  assert(
+    connectSourceDirectiveValue !== null,
+    'Content-Security-Policy connect-src directive is required for auth and OneDrive download requests.',
+  );
+
+  const missingConnectSources = requiredConnectSources.filter(
+    (source) => !connectSourceDirectiveValue.includes(source),
+  );
+
+  assert(
+    missingConnectSources.length === 0,
+    `Content-Security-Policy connect-src directive is missing required source(s): ${missingConnectSources.join(', ')}.`,
+  );
 };
 
 const main = () => {

--- a/scripts/verify-build-channel.test.ts
+++ b/scripts/verify-build-channel.test.ts
@@ -23,7 +23,7 @@ type DistFixtureOptions = {
 };
 
 const BASE_CSP_META_CONTENT =
-  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'self'";
+  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com https://*.1drv.com https://*.microsoftpersonalcontent.com; object-src 'none'; base-uri 'self'";
 
 const createDistFixture = (
   fixtureRootPath: string,
@@ -170,7 +170,7 @@ describe('verify-build-channel script', () => {
         `if ('serviceWorker' in navigator) { navigator.serviceWorker.register('/conspectus/webapp/sw.js', { scope: '/conspectus/webapp/' }); }`,
         {
           cspMetaContent:
-            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'self'",
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com https://*.1drv.com https://*.microsoftpersonalcontent.com; object-src 'none'; base-uri 'self'",
         },
       );
 
@@ -187,6 +187,38 @@ describe('verify-build-channel script', () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(
         "Content-Security-Policy script-src directive must include 'wasm-unsafe-eval' for sql.js WASM runtime support.",
+      );
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('fails when connect-src does not allow OneDrive download hosts', () => {
+    const fixturePath = createFixtureDirectory();
+
+    try {
+      const distPath = createDistFixture(
+        fixturePath,
+        `if ('serviceWorker' in navigator) { navigator.serviceWorker.register('/conspectus/webapp/sw.js', { scope: '/conspectus/webapp/' }); }`,
+        {
+          cspMetaContent:
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com; object-src 'none'; base-uri 'self'",
+        },
+      );
+
+      const result = runVerifier([
+        '--dist',
+        distPath,
+        '--channel',
+        'production',
+        '--base',
+        '/conspectus/webapp/',
+      ]);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        'Content-Security-Policy connect-src directive is missing required source(s): https://*.1drv.com, https://*.microsoftpersonalcontent.com.',
       );
     } finally {
       rmSync(fixturePath, { force: true, recursive: true });

--- a/src/features/app-shell/cachedDatabaseSnapshotService.test.ts
+++ b/src/features/app-shell/cachedDatabaseSnapshotService.test.ts
@@ -30,6 +30,7 @@ const createMetadata = (
   eTag: '"etag-1"',
   sizeBytes: defaultBytes.length,
   lastModifiedDateTime: '2026-03-11T08:30:00.000Z',
+  downloadUrl: 'https://download.example.com/conspectus.db',
   ...overrides,
 });
 
@@ -59,7 +60,7 @@ describe('cached database snapshot service', () => {
 
     const snapshot = await service.downloadAndCacheSnapshot(DRIVE_ITEM_BINDING, metadata);
 
-    expect(graphClient.downloadFile).toHaveBeenCalledWith(DRIVE_ITEM_BINDING, undefined);
+    expect(graphClient.downloadFile).toHaveBeenCalledWith(metadata.downloadUrl, undefined);
     expect(snapshot).toEqual<CachedDatabaseSnapshot>({
       binding: DRIVE_ITEM_BINDING,
       metadata: {

--- a/src/features/app-shell/cachedDatabaseSnapshotService.ts
+++ b/src/features/app-shell/cachedDatabaseSnapshotService.ts
@@ -57,7 +57,7 @@ export const createCachedDatabaseSnapshotService = (
       metadata: GraphFileMetadata,
       onProgress?: (loadedBytes: number, totalBytes: number | null) => void,
     ): Promise<CachedDatabaseSnapshot> {
-      const dbBytes = await graphClient.downloadFile(binding, onProgress);
+      const dbBytes = await graphClient.downloadFile(metadata.downloadUrl, onProgress);
       validateDownloadedBytes(dbBytes, metadata);
 
       const snapshot: CachedDatabaseSnapshot = {

--- a/src/features/app-shell/graphClientResolver.test.ts
+++ b/src/features/app-shell/graphClientResolver.test.ts
@@ -33,6 +33,7 @@ const createStubGraphClient = (): GraphClient => ({
     eTag: '"etag-1"',
     sizeBytes: 1,
     lastModifiedDateTime: '2026-03-09T10:15:00Z',
+    downloadUrl: 'https://download.example.com/conspectus.db',
   })),
   downloadFile: vi.fn(async () => Uint8Array.from([1])),
   uploadFile: vi.fn(async () => ({

--- a/src/features/app-shell/routes/settingsFileBindingController.test.ts
+++ b/src/features/app-shell/routes/settingsFileBindingController.test.ts
@@ -80,6 +80,7 @@ const createGraphClientHarness = (): {
         eTag: '"etag-1"',
         sizeBytes: 2048,
         lastModifiedDateTime: '2026-03-09T10:15:00Z',
+        downloadUrl: 'https://download.example.com/conspectus.db',
       })),
       downloadFile: vi.fn(async () => Uint8Array.from([1, 2, 3])),
       uploadFile: vi.fn(async () => ({

--- a/src/features/app-shell/startupFreshnessService.test.ts
+++ b/src/features/app-shell/startupFreshnessService.test.ts
@@ -32,6 +32,7 @@ const createMetadata = (overrides: Partial<GraphFileMetadata> = {}): GraphFileMe
   eTag: '"etag-1"',
   sizeBytes: 2048,
   lastModifiedDateTime: '2026-03-11T10:15:00.000Z',
+  downloadUrl: 'https://download.example.com/conspectus.db',
   ...overrides,
 });
 

--- a/src/graph/README.md
+++ b/src/graph/README.md
@@ -15,7 +15,7 @@ Expected public interfaces (`src/graph/index.ts`):
 
 - `DriveItemBinding`: stored identity for the selected OneDrive database file.
 - `DriveFolderReference` and `GraphDriveItem`: typed OneDrive browse models for folder/file selection.
-- `GraphFileMetadata`: eTag/size/modified metadata used by sync decisions.
+- `GraphFileMetadata`: eTag/size/modified metadata plus the preauthenticated download URL used by sync decisions.
 - `GraphUploadResult`: post-upload metadata returned from Graph.
 - `GraphClient`: browse, metadata, download, and conditional-upload operations.
 - `createGraphClient`: factory that injects auth-backed bearer tokens into Graph requests.

--- a/src/graph/graphClient.test.ts
+++ b/src/graph/graphClient.test.ts
@@ -284,7 +284,7 @@ describe('createGraphClient', () => {
     expect(parsedUrl.origin).toBe('https://graph.microsoft.com');
     expect(parsedUrl.pathname).toBe('/v1.0/drives/drive-123/items/item-456');
     expect(parsedUrl.searchParams.get('$select')).toBe(
-      'eTag,size,lastModifiedDateTime,@microsoft.graph.downloadUrl',
+      'eTag,size,lastModifiedDateTime,content.downloadUrl',
     );
 
     const requestHeaders = getRequestHeaders(getFetchCall(fetchFn));
@@ -482,6 +482,26 @@ describe('createGraphClient', () => {
     await expect(client.getFileMetadata(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
       code: 'unknown',
       message: 'Microsoft Graph metadata response did not include the required file fields.',
+    });
+  });
+
+  it('accepts the legacy content download URL annotation shape from Graph metadata', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        eTag: '"etag-1"',
+        size: 2048,
+        lastModifiedDateTime: '2026-03-09T10:15:00Z',
+        '@content.downloadUrl': 'https://download.example.com/conspectus.db',
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.getFileMetadata(DRIVE_ITEM_BINDING)).resolves.toEqual({
+      eTag: '"etag-1"',
+      sizeBytes: 2048,
+      lastModifiedDateTime: '2026-03-09T10:15:00Z',
+      downloadUrl: 'https://download.example.com/conspectus.db',
     });
   });
 

--- a/src/graph/graphClient.test.ts
+++ b/src/graph/graphClient.test.ts
@@ -261,6 +261,7 @@ describe('createGraphClient', () => {
         eTag: '"etag-1"',
         size: 2048,
         lastModifiedDateTime: '2026-03-09T10:15:00Z',
+        '@microsoft.graph.downloadUrl': 'https://download.example.com/conspectus.db',
       }),
     );
     const client = createGraphClient({ authClient, fetchFn });
@@ -271,6 +272,7 @@ describe('createGraphClient', () => {
       eTag: '"etag-1"',
       sizeBytes: 2048,
       lastModifiedDateTime: '2026-03-09T10:15:00Z',
+      downloadUrl: 'https://download.example.com/conspectus.db',
     });
     expect(authClient.getAccessToken).toHaveBeenCalledWith(['Files.ReadWrite']);
 
@@ -281,13 +283,15 @@ describe('createGraphClient', () => {
     const parsedUrl = new URL(requestUrl as string);
     expect(parsedUrl.origin).toBe('https://graph.microsoft.com');
     expect(parsedUrl.pathname).toBe('/v1.0/drives/drive-123/items/item-456');
-    expect(parsedUrl.searchParams.get('$select')).toBe('eTag,size,lastModifiedDateTime');
+    expect(parsedUrl.searchParams.get('$select')).toBe(
+      'eTag,size,lastModifiedDateTime,@microsoft.graph.downloadUrl',
+    );
 
     const requestHeaders = getRequestHeaders(getFetchCall(fetchFn));
     expect(requestHeaders.get('Authorization')).toBe('Bearer graph-token');
   });
 
-  it('downloads file bytes from the Graph content endpoint', async () => {
+  it('downloads file bytes from the preauthenticated OneDrive download URL without auth headers', async () => {
     const authClient = createAuthClient();
     const fetchFn = vi.fn(
       async () =>
@@ -297,13 +301,13 @@ describe('createGraphClient', () => {
     );
     const client = createGraphClient({ authClient, fetchFn });
 
-    const bytes = await client.downloadFile(DRIVE_ITEM_BINDING);
+    const bytes = await client.downloadFile('https://download.example.com/conspectus.db');
 
     expect(Array.from(bytes)).toEqual([1, 2, 3, 4]);
-    const [requestUrl] = getFetchCall(fetchFn);
-    expect(requestUrl).toBe(
-      'https://graph.microsoft.com/v1.0/drives/drive-123/items/item-456/content',
-    );
+    expect(authClient.getAccessToken).not.toHaveBeenCalled();
+    const [requestUrl, requestInit] = getFetchCall(fetchFn);
+    expect(requestUrl).toBe('https://download.example.com/conspectus.db');
+    expect(new Headers(requestInit?.headers).get('Authorization')).toBeNull();
   });
 
   it('uploads file bytes with If-Match and returns normalized metadata', async () => {
@@ -464,6 +468,23 @@ describe('createGraphClient', () => {
     });
   });
 
+  it('rejects metadata responses missing the download URL with an unknown Graph error', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        eTag: '"etag-1"',
+        size: 2048,
+        lastModifiedDateTime: '2026-03-09T10:15:00Z',
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.getFileMetadata(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
+      code: 'unknown',
+      message: 'Microsoft Graph metadata response did not include the required file fields.',
+    });
+  });
+
   it('rejects blank eTag metadata payloads with an unknown Graph error', async () => {
     const authClient = createAuthClient();
     const fetchFn = vi.fn(async () =>
@@ -495,7 +516,9 @@ describe('createGraphClient', () => {
     const fetchFn = vi.fn(async () => response);
     const client = createGraphClient({ authClient, fetchFn });
 
-    await expect(client.downloadFile(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
+    await expect(
+      client.downloadFile('https://download.example.com/conspectus.db'),
+    ).rejects.toMatchObject({
       code: 'network_error',
     });
   });
@@ -587,7 +610,10 @@ describe('createGraphClient', () => {
     const client = createGraphClient({ authClient, fetchFn });
     const onProgress = vi.fn();
 
-    const result = await client.downloadFile(DRIVE_ITEM_BINDING, onProgress);
+    const result = await client.downloadFile(
+      'https://download.example.com/conspectus.db',
+      onProgress,
+    );
 
     const text = new TextDecoder().decode(result);
     expect(text).toBe('hello world!');

--- a/src/graph/graphClient.ts
+++ b/src/graph/graphClient.ts
@@ -13,7 +13,7 @@ import type {
 
 const GRAPH_API_BASE_URL = 'https://graph.microsoft.com/v1.0';
 const CHILDREN_FIELDS = 'id,name,parentReference,file,folder';
-const METADATA_FIELDS = 'eTag,size,lastModifiedDateTime';
+const METADATA_FIELDS = 'eTag,size,lastModifiedDateTime,@microsoft.graph.downloadUrl';
 
 type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
 
@@ -31,6 +31,7 @@ interface GraphItemPayload {
   readonly eTag?: unknown;
   readonly size?: unknown;
   readonly lastModifiedDateTime?: unknown;
+  readonly '@microsoft.graph.downloadUrl'?: unknown;
 }
 
 interface GraphChildrenPayload {
@@ -320,10 +321,10 @@ const normalizeDriveItem = (
   };
 };
 
-const normalizeGraphItem = (
+const normalizeGraphItemBase = (
   payload: unknown,
   invalidResponseMessage: string,
-): GraphFileMetadata | GraphUploadResult => {
+): Omit<GraphFileMetadata, 'downloadUrl'> => {
   if (!isGraphItemPayload(payload)) {
     throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
   }
@@ -344,6 +345,27 @@ const normalizeGraphItem = (
     lastModifiedDateTime: payload.lastModifiedDateTime,
   };
 };
+
+const normalizeFileMetadata = (
+  payload: unknown,
+  invalidResponseMessage: string,
+): GraphFileMetadata => {
+  const baseMetadata = normalizeGraphItemBase(payload, invalidResponseMessage);
+
+  if (!isGraphItemPayload(payload) || !isNonEmptyString(payload['@microsoft.graph.downloadUrl'])) {
+    throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
+  }
+
+  return {
+    ...baseMetadata,
+    downloadUrl: payload['@microsoft.graph.downloadUrl'],
+  };
+};
+
+const normalizeUploadResult = (
+  payload: unknown,
+  invalidResponseMessage: string,
+): GraphUploadResult => normalizeGraphItemBase(payload, invalidResponseMessage);
 
 const normalizeChildrenPayload = (
   payload: unknown,
@@ -441,17 +463,28 @@ export const createGraphClient = (options: CreateGraphClientOptions): GraphClien
         'Microsoft Graph metadata response did not include the required file fields.',
       );
 
-      return normalizeGraphItem(
+      return normalizeFileMetadata(
         payload,
         'Microsoft Graph metadata response did not include the required file fields.',
       );
     },
 
     async downloadFile(
-      binding,
+      downloadUrl,
       onProgress?: (loadedBytes: number, totalBytes: number | null) => void,
     ): Promise<Uint8Array> {
-      const response = await executeRequest(buildDriveItemUrl(binding, '/content'));
+      let response: Response;
+
+      try {
+        response = await fetchFn(downloadUrl);
+      } catch (error) {
+        throw normalizeNetworkError(error);
+      }
+
+      if (!response.ok) {
+        throw await normalizeHttpError(response);
+      }
+
       try {
         const contentLength = response.headers.get('Content-Length');
         const totalBytes = contentLength !== null ? parseInt(contentLength, 10) : null;
@@ -536,10 +569,10 @@ export const createGraphClient = (options: CreateGraphClientOptions): GraphClien
               }
               try {
                 resolve(
-                  normalizeGraphItem(
+                  normalizeUploadResult(
                     payload,
                     'Microsoft Graph upload response did not include the required file fields.',
-                  ) as GraphUploadResult,
+                  ),
                 );
               } catch (error) {
                 reject(
@@ -595,10 +628,10 @@ export const createGraphClient = (options: CreateGraphClientOptions): GraphClien
         'Microsoft Graph upload response did not include the required file fields.',
       );
 
-      return normalizeGraphItem(
+      return normalizeUploadResult(
         payload,
         'Microsoft Graph upload response did not include the required file fields.',
-      ) as GraphUploadResult;
+      );
     },
   };
 };

--- a/src/graph/graphClient.ts
+++ b/src/graph/graphClient.ts
@@ -13,7 +13,7 @@ import type {
 
 const GRAPH_API_BASE_URL = 'https://graph.microsoft.com/v1.0';
 const CHILDREN_FIELDS = 'id,name,parentReference,file,folder';
-const METADATA_FIELDS = 'eTag,size,lastModifiedDateTime,@microsoft.graph.downloadUrl';
+const METADATA_FIELDS = 'eTag,size,lastModifiedDateTime,content.downloadUrl';
 
 type FetchFn = (input: string, init?: RequestInit) => Promise<Response>;
 
@@ -32,6 +32,7 @@ interface GraphItemPayload {
   readonly size?: unknown;
   readonly lastModifiedDateTime?: unknown;
   readonly '@microsoft.graph.downloadUrl'?: unknown;
+  readonly '@content.downloadUrl'?: unknown;
 }
 
 interface GraphChildrenPayload {
@@ -352,13 +353,23 @@ const normalizeFileMetadata = (
 ): GraphFileMetadata => {
   const baseMetadata = normalizeGraphItemBase(payload, invalidResponseMessage);
 
-  if (!isGraphItemPayload(payload) || !isNonEmptyString(payload['@microsoft.graph.downloadUrl'])) {
+  if (!isGraphItemPayload(payload)) {
+    throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
+  }
+
+  const downloadUrl = isNonEmptyString(payload['@microsoft.graph.downloadUrl'])
+    ? payload['@microsoft.graph.downloadUrl']
+    : isNonEmptyString(payload['@content.downloadUrl'])
+      ? payload['@content.downloadUrl']
+      : null;
+
+  if (downloadUrl === null) {
     throw new GraphClientError('unknown', invalidResponseMessage, undefined, payload);
   }
 
   return {
     ...baseMetadata,
-    downloadUrl: payload['@microsoft.graph.downloadUrl'],
+    downloadUrl,
   };
 };
 

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -26,6 +26,7 @@ export interface GraphFileMetadata {
   readonly eTag: string;
   readonly sizeBytes: number;
   readonly lastModifiedDateTime: string;
+  readonly downloadUrl: string;
 }
 
 export interface GraphUploadResult {
@@ -53,7 +54,7 @@ export interface GraphClient {
   listChildren(folder?: DriveFolderReference): Promise<readonly GraphDriveItem[]>;
   getFileMetadata(binding: DriveItemBinding): Promise<GraphFileMetadata>;
   downloadFile(
-    binding: DriveItemBinding,
+    downloadUrl: string,
     onProgress?: (loadedBytes: number, totalBytes: number | null) => void,
   ): Promise<Uint8Array>;
   uploadFile(

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -395,6 +395,7 @@ const installMockGraphClient = async (
           eTag: mockOptions.metadataETag ?? '"etag-1"',
           sizeBytes: defaultDownloadBytes.length,
           lastModifiedDateTime: mockOptions.metadataLastModifiedDateTime ?? '2026-03-09T10:15:00Z',
+          downloadUrl: 'https://download.example.com/conspectus.db',
         };
       },
       async downloadFile() {


### PR DESCRIPTION
﻿## Summary

- restore OneDrive snapshot downloads in the browser by using the short-lived download URL metadata path
- accept Graph download URL metadata variants and allow the resulting OneDrive hosts in CSP
- add a high-level Milestone 5 follow-up issue for later UI cleanup and usability polish

## Verification

- npm run format
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm run test:e2e

## Notes

- New follow-up issue: #174
