### PR TITLE
feat: build Transfers UI (M5-06)

### DIFF
--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -407,7 +407,7 @@ An issue is only considered done when:
 - Depends on: `M5-02`
 - GitHub: [#59](https://github.com/Jon2050/Conspectus-Mobile/issues/59)
 
-### :green_circle: M5-06 Build Transfers screen UI
+### :white_check_mark: M5-06 Build Transfers screen UI
 
 - Label: `feature`
 - Milestone: `M5 - Accounts + Transfers Read UX`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.5.05",
+  "version": "0.5.06",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/db/accountQueryService.test.ts
+++ b/src/db/accountQueryService.test.ts
@@ -108,12 +108,12 @@ describe('account query service', () => {
     const result = service.listVisibleNonPrimaryAccounts();
 
     expect(result).toEqual([
-      { accountId: 11, name: 'alpha', amountCents: 8100 },
-      { accountId: 12, name: 'Alpha', amountCents: 2300 },
-      { accountId: 16, name: 'alpha', amountCents: 1200 },
-      { accountId: 10, name: 'Bravo', amountCents: 5400 },
+      { accountId: 11, name: 'alpha', amountCents: 8100, accountTypeId: 3 },
+      { accountId: 12, name: 'Alpha', amountCents: 2300, accountTypeId: 3 },
+      { accountId: 16, name: 'alpha', amountCents: 1200, accountTypeId: 3 },
+      { accountId: 10, name: 'Bravo', amountCents: 5400, accountTypeId: 3 },
     ]);
-    expect(Object.keys(result[0] ?? {}).sort()).toEqual(['accountId', 'amountCents', 'name']);
+    expect(Object.keys(result[0] ?? {}).sort()).toEqual(['accountId', 'accountTypeId', 'amountCents', 'name']);
     runtime.close();
   });
 
@@ -162,11 +162,11 @@ describe('account query service', () => {
       exec: () =>
         [
           {
-            columns: ['account_id', 'name', 'amount'],
+            columns: ['account_id', 'name', 'amount', 'ac_type_id'],
             values: [
-              ['not-a-number', 'Cash', 900],
-              [11, 123, 700],
-              [12, 'Safe', Number.POSITIVE_INFINITY],
+              ['not-a-number', 'Cash', 900, 1],
+              [11, 123, 700, 2],
+              [12, 'Safe', Number.POSITIVE_INFINITY, 3],
             ],
           } as unknown as QueryExecResult,
         ] as readonly QueryExecResult[],
@@ -180,7 +180,7 @@ describe('account query service', () => {
       exec: () =>
         [
           {
-            columns: ['account_id', 'name', 'amount'],
+            columns: ['account_id', 'name', 'amount', 'ac_type_id'],
             values: [[10, 'Cash']],
           } as unknown as QueryExecResult,
         ] as readonly QueryExecResult[],

--- a/src/db/accountQueryService.test.ts
+++ b/src/db/accountQueryService.test.ts
@@ -113,7 +113,12 @@ describe('account query service', () => {
       { accountId: 16, name: 'alpha', amountCents: 1200, accountTypeId: 3 },
       { accountId: 10, name: 'Bravo', amountCents: 5400, accountTypeId: 3 },
     ]);
-    expect(Object.keys(result[0] ?? {}).sort()).toEqual(['accountId', 'accountTypeId', 'amountCents', 'name']);
+    expect(Object.keys(result[0] ?? {}).sort()).toEqual([
+      'accountId',
+      'accountTypeId',
+      'amountCents',
+      'name',
+    ]);
     runtime.close();
   });
 

--- a/src/db/accountQueryService.ts
+++ b/src/db/accountQueryService.ts
@@ -6,14 +6,20 @@ import { DbRuntimeError, toDbRuntimeError } from './dbRuntimeErrors';
 import { appBrowserDbRuntime } from './browserDbRuntime';
 
 const VISIBLE_NON_PRIMARY_ACCOUNTS_SQL = `
-  SELECT account_id, name, amount
+  SELECT account_id, name, amount, ac_type_id
   FROM account
   WHERE visible = 1
     AND ac_type_id NOT IN (1, 2)
   ORDER BY ac_order ASC, LOWER(name) ASC, account_id ASC;
 `;
 
-const ACCOUNT_RESULT_COLUMNS = ['account_id', 'name', 'amount'] as const;
+const ALL_ACCOUNTS_SQL = `
+  SELECT account_id, name, amount, ac_type_id
+  FROM account
+  ORDER BY account_id ASC;
+`;
+
+const ACCOUNT_RESULT_COLUMNS = ['account_id', 'name', 'amount', 'ac_type_id'] as const;
 
 const hasExpectedColumns = (columns: readonly string[]): boolean =>
   columns.length === ACCOUNT_RESULT_COLUMNS.length &&
@@ -39,6 +45,13 @@ const toName = (value: unknown): string => {
   }
 
   return value;
+};
+
+const toNullableInteger = (value: unknown, fieldName: string): number | null => {
+  if (value === null) {
+    return null;
+  }
+  return toInteger(value, fieldName);
 };
 
 const mapAccountQueryResult = (results: readonly QueryExecResult[]): readonly AccountRecord[] => {
@@ -70,12 +83,14 @@ const mapAccountQueryResult = (results: readonly QueryExecResult[]): readonly Ac
       accountId: toInteger(row[0], 'account_id'),
       name: toName(row[1]),
       amountCents: toInteger(row[2], 'amount'),
+      accountTypeId: toNullableInteger(row[3], 'ac_type_id'),
     };
   });
 };
 
 export interface AccountQueryService {
   listVisibleNonPrimaryAccounts(): readonly AccountRecord[];
+  listAllAccounts(): readonly AccountRecord[];
 }
 
 export const createAccountQueryService = (
@@ -90,6 +105,19 @@ export const createAccountQueryService = (
         error,
         'db_query_failed',
         'Failed to load visible non-primary accounts from the local SQLite database.',
+      );
+    }
+  },
+
+  listAllAccounts(): readonly AccountRecord[] {
+    try {
+      const results = dbRuntime.exec(ALL_ACCOUNTS_SQL);
+      return mapAccountQueryResult(results);
+    } catch (error) {
+      throw toDbRuntimeError(
+        error,
+        'db_query_failed',
+        'Failed to load all accounts from the local SQLite database.',
       );
     }
   },

--- a/src/db/categoryQueryService.ts
+++ b/src/db/categoryQueryService.ts
@@ -1,0 +1,94 @@
+import type { QueryExecResult } from 'sql.js';
+
+import type { BrowserDbRuntime, CategoryRecord } from './index';
+import { DbRuntimeError, toDbRuntimeError } from './dbRuntimeErrors';
+import { appBrowserDbRuntime } from './browserDbRuntime';
+
+const ALL_CATEGORIES_SQL = `
+  SELECT category_id, name
+  FROM category
+  ORDER BY LOWER(name) ASC;
+`;
+
+const CATEGORY_RESULT_COLUMNS = ['category_id', 'name'] as const;
+
+const hasExpectedColumns = (columns: readonly string[]): boolean =>
+  columns.length === CATEGORY_RESULT_COLUMNS.length &&
+  CATEGORY_RESULT_COLUMNS.every((expectedColumn, index) => columns[index] === expectedColumn);
+
+const toInteger = (value: unknown, fieldName: string): number => {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
+    throw new DbRuntimeError(
+      'db_query_failed',
+      `Expected "${fieldName}" to be a safe integer in category query results.`,
+    );
+  }
+
+  return value;
+};
+
+const toName = (value: unknown): string => {
+  if (typeof value !== 'string') {
+    throw new DbRuntimeError(
+      'db_query_failed',
+      'Expected "name" to be a string in category query results.',
+    );
+  }
+
+  return value;
+};
+
+const mapCategoryQueryResult = (results: readonly QueryExecResult[]): readonly CategoryRecord[] => {
+  if (results.length === 0) {
+    return [];
+  }
+
+  const firstResult = results[0];
+  if (firstResult === undefined) {
+    return [];
+  }
+
+  if (!hasExpectedColumns(firstResult.columns)) {
+    throw new DbRuntimeError(
+      'db_query_failed',
+      'Category query result columns did not match the expected category projection.',
+    );
+  }
+
+  return firstResult.values.map((row, rowIndex) => {
+    if (row.length !== CATEGORY_RESULT_COLUMNS.length) {
+      throw new DbRuntimeError(
+        'db_query_failed',
+        `Category query row at index ${rowIndex} had an unexpected number of columns.`,
+      );
+    }
+
+    return {
+      categoryId: toInteger(row[0], 'category_id'),
+      name: toName(row[1]),
+    };
+  });
+};
+
+export interface CategoryQueryService {
+  listAllCategories(): readonly CategoryRecord[];
+}
+
+export const createCategoryQueryService = (
+  dbRuntime: Pick<BrowserDbRuntime, 'exec'>,
+): CategoryQueryService => ({
+  listAllCategories(): readonly CategoryRecord[] {
+    try {
+      const results = dbRuntime.exec(ALL_CATEGORIES_SQL);
+      return mapCategoryQueryResult(results);
+    } catch (error) {
+      throw toDbRuntimeError(
+        error,
+        'db_query_failed',
+        'Failed to load all categories from the local SQLite database.',
+      );
+    }
+  },
+});
+
+export const appCategoryQueryService = createCategoryQueryService(appBrowserDbRuntime);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -13,6 +13,11 @@ export {
   type TransferMonthQueryService,
 } from './transferMonthQueryService';
 export {
+  appCategoryQueryService,
+  createCategoryQueryService,
+  type CategoryQueryService,
+} from './categoryQueryService';
+export {
   appBrowserDbRuntime,
   createBrowserDbRuntime,
   type BrowserDbRuntime,
@@ -29,6 +34,12 @@ export interface AccountRecord {
   readonly accountId: number;
   readonly name: string;
   readonly amountCents: number;
+  readonly accountTypeId: number | null;
+}
+
+export interface CategoryRecord {
+  readonly categoryId: number;
+  readonly name: string;
 }
 
 export interface TransferRecord {

--- a/src/features/app-shell/routes/TransfersRoute.svelte
+++ b/src/features/app-shell/routes/TransfersRoute.svelte
@@ -2,6 +2,20 @@
 <script lang="ts">
   import { cubicOut } from 'svelte/easing';
   import { fly } from 'svelte/transition';
+  import { onDestroy } from 'svelte';
+  import { appSyncStateStore, type SyncState } from '@shared';
+  import {
+    createAccountQueryService,
+    createCategoryQueryService,
+    createTransferMonthQueryService,
+  } from '@db';
+  import SkeletonCard from '../components/SkeletonCard.svelte';
+  import { resolveAppDbRuntime } from '../dbRuntimeResolver';
+  import {
+    createTransfersRouteController,
+    type TransfersRouteController,
+    type TransfersRouteState,
+  } from './transfersRouteController';
   import {
     formatMonthLabel,
     getCurrentMonthAnchorEpochDay,
@@ -10,52 +24,75 @@
     toMonthKey,
   } from './transfersMonthNavigation';
 
+  export let controller: TransfersRouteController = createTransfersRouteController(
+    createTransferMonthQueryService(resolveAppDbRuntime()),
+    createAccountQueryService(resolveAppDbRuntime()),
+    createCategoryQueryService(resolveAppDbRuntime()),
+  );
+
   const MONTH_LABEL_TRANSITION_DURATION_MS = 180;
 
   let monthAnchorEpochDay = getCurrentMonthAnchorEpochDay();
   let swipeStartX: number | null = null;
   let swipeStartY: number | null = null;
   let monthTransitionDirection: 'previous' | 'next' = 'next';
+  let state: TransfersRouteState = controller.getState();
+  let lastObservedSyncState: SyncState = 'idle';
 
   $: monthKey = toMonthKey(monthAnchorEpochDay);
   $: monthLabel = formatMonthLabel(monthAnchorEpochDay);
   $: monthLabelTransitionKey = `${monthTransitionDirection}-${monthKey}`;
   $: monthLabelTransitionOffsetX = monthTransitionDirection === 'next' ? 20 : -20;
 
+  $: {
+    void controller.load(monthAnchorEpochDay);
+  }
+
+  const unsubscribeController = controller.subscribe((nextState) => {
+    state = nextState;
+  });
+
+  const unsubscribeSyncState = appSyncStateStore.subscribe((syncSnapshot) => {
+    if (syncSnapshot.state === lastObservedSyncState) {
+      return;
+    }
+    lastObservedSyncState = syncSnapshot.state;
+    if (
+      syncSnapshot.state === 'synced' ||
+      syncSnapshot.state === 'stale' ||
+      syncSnapshot.state === 'offline'
+    ) {
+      void controller.load(monthAnchorEpochDay);
+    }
+  });
+
+  onDestroy(() => {
+    unsubscribeController();
+    unsubscribeSyncState();
+  });
+
   const clearSwipeStart = (): void => {
     swipeStartX = null;
     swipeStartY = null;
   };
-
   const shiftMonth = (deltaMonths: number): void => {
-    if (deltaMonths === 0) {
-      return;
-    }
-
+    if (deltaMonths === 0) return;
     monthTransitionDirection = deltaMonths > 0 ? 'next' : 'previous';
     monthAnchorEpochDay = shiftMonthAnchorEpochDay(monthAnchorEpochDay, deltaMonths);
   };
-
-  const handlePreviousMonthClick = (): void => {
-    shiftMonth(-1);
-  };
-
-  const handleNextMonthClick = (): void => {
-    shiftMonth(1);
-  };
+  const handlePreviousMonthClick = (): void => shiftMonth(-1);
+  const handleNextMonthClick = (): void => shiftMonth(1);
 
   const handleTouchStart = (event: TouchEvent): void => {
     if (event.target instanceof Element && event.target.closest('button') !== null) {
       clearSwipeStart();
       return;
     }
-
     const touch = event.touches.item(0) ?? event.touches[0];
     if (touch == null) {
       clearSwipeStart();
       return;
     }
-
     swipeStartX = touch.clientX;
     swipeStartY = touch.clientY;
   };
@@ -65,44 +102,37 @@
       clearSwipeStart();
       return;
     }
-
     const touch = event.changedTouches.item(0) ?? event.changedTouches[0];
     if (touch == null) {
       clearSwipeStart();
       return;
     }
-
     const swipeIntent = resolveSwipeIntent({
       startX: swipeStartX,
       startY: swipeStartY,
       endX: touch.clientX,
       endY: touch.clientY,
     });
-
-    if (swipeIntent === 'previous') {
-      shiftMonth(-1);
-    } else if (swipeIntent === 'next') {
-      shiftMonth(1);
-    }
-
+    if (swipeIntent === 'previous') shiftMonth(-1);
+    else if (swipeIntent === 'next') shiftMonth(1);
     clearSwipeStart();
   };
 </script>
 
-<section class="placeholder-screen transfers-route" data-testid="route-transfers">
+<section
+  class="transfers-route"
+  data-testid="route-transfers"
+  aria-busy={state.operation === 'loading'}
+>
   <h2>Transfers</h2>
-
   <div class="transfers-route__month-navigation" data-testid="transfers-month-navigation">
     <button
       type="button"
       class="app-button app-button--secondary transfers-route__month-button"
       data-testid="transfers-month-previous-button"
       aria-label="Previous month"
-      on:click={handlePreviousMonthClick}
+      on:click={handlePreviousMonthClick}>Previous</button
     >
-      Previous
-    </button>
-
     <p
       class="transfers-route__month-label"
       data-testid="transfers-month-label"
@@ -125,16 +155,13 @@
         </span>
       {/key}
     </p>
-
     <button
       type="button"
       class="app-button app-button--secondary transfers-route__month-button"
       data-testid="transfers-month-next-button"
       aria-label="Next month"
-      on:click={handleNextMonthClick}
+      on:click={handleNextMonthClick}>Next</button
     >
-      Next
-    </button>
   </div>
 
   <div
@@ -146,14 +173,95 @@
     on:touchend={handleTouchEnd}
     on:touchcancel={clearSwipeStart}
   >
-    <p>Transfer list rendering ships in M5-06. Month navigation is ready for query integration.</p>
-    <p class="transfers-route__swipe-hint">Swipe left or right to switch months.</p>
+    <p
+      class="transfers-route__status"
+      class:transfers-route__status--error={state.operation === 'error'}
+      data-testid="transfers-route-status"
+      aria-live="polite"
+      role={state.operation === 'error' ? 'alert' : undefined}
+    >
+      {#if state.operation === 'loading'}
+        Loading transfers...
+      {:else if state.operation === 'error'}
+        {state.error?.message ?? 'Failed to load transfers.'}
+      {:else if state.operation === 'empty'}
+        No transfers found for this month.
+      {:else}
+        {state.transfers.length} transfers found.
+      {/if}
+    </p>
+
+    {#if state.operation === 'loading'}
+      <div class="transfers-route__loading" data-testid="transfers-route-loading">
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+    {:else if state.operation === 'empty'}
+      <div class="transfers-route__empty" data-testid="transfers-route-empty">
+        <p>There are no transfers recorded for this month.</p>
+      </div>
+    {:else if state.operation === 'ready'}
+      <ul class="transfers-route__cards" data-testid="transfers-route-cards">
+        {#each state.transfers as transfer (transfer.transferId)}
+          <li class="transfers-route__card-item">
+            <article
+              class={`transfer-card transfer-card--${transfer.amountSemantic}`}
+              data-testid={`transfer-card-${transfer.transferId}`}
+              data-transfer-id={transfer.transferId}
+            >
+              <div class="transfer-card__header">
+                <div>
+                  <p class="transfer-card__date">{transfer.dateDisplay}</p>
+                  <h3 class="transfer-card__name">{transfer.name}</h3>
+                </div>
+                <span
+                  class="transfer-card__amount"
+                  data-testid={`transfer-amount-${transfer.transferId}`}
+                  >{transfer.amountDisplay}</span
+                >
+              </div>
+              <div class="transfer-card__accounts">
+                <span class="transfer-card__account transfer-card__account--from"
+                  >{transfer.fromAccountName}</span
+                >
+                <span class="transfer-card__account-arrow">→</span>
+                <span class="transfer-card__account transfer-card__account--to"
+                  >{transfer.toAccountName}</span
+                >
+              </div>
+              {#if transfer.categoryNames.length > 0}
+                <ul class="transfer-card__categories">
+                  {#each transfer.categoryNames as category (category)}
+                    <li class="transfer-card__category">
+                      <span class="app-badge">{category}</span>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            </article>
+          </li>
+        {/each}
+      </ul>
+    {/if}
   </div>
 </section>
 
 <style>
   .transfers-route {
+    --transfers-amount-positive: #0f6b43;
+    --transfers-amount-negative: #b42318;
+    --transfers-amount-neutral: var(--text-secondary);
+    display: flex;
+    flex-direction: column;
     gap: 1rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .transfers-route {
+      --transfers-amount-positive: #34d399;
+      --transfers-amount-negative: #fca5a5;
+      --transfers-amount-neutral: #d1d5db;
+    }
   }
 
   .transfers-route__month-navigation {
@@ -183,20 +291,153 @@
   }
 
   .transfers-route__swipe-surface {
-    border: 1px dashed color-mix(in srgb, var(--border) 72%, transparent);
-    border-radius: var(--radius-md);
-    padding: 1rem;
-    background: color-mix(in srgb, var(--surface) 82%, transparent);
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
     touch-action: pan-y;
   }
 
-  .transfers-route__swipe-surface p {
+  .transfers-route__status {
+    margin: 0;
+    color: var(--text-secondary);
+    min-height: 1.5rem;
+  }
+
+  .transfers-route__status--error {
+    padding: 1rem;
+    border-radius: var(--radius-md);
+    color: color-mix(in srgb, var(--negative) 72%, var(--text-primary));
+    background: color-mix(in srgb, var(--negative) 14%, var(--surface-strong));
+  }
+
+  .transfers-route__loading,
+  .transfers-route__empty {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .transfers-route__empty {
+    padding: 1rem;
+    border-radius: var(--radius-lg);
+    background: var(--surface-strong);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .transfers-route__empty p {
+    margin: 0;
+    color: var(--text-secondary);
+  }
+
+  .transfers-route__cards {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .transfers-route__card-item {
     margin: 0;
   }
 
-  .transfers-route__swipe-hint {
-    margin-top: 0.45rem;
-    font-size: 0.9rem;
+  .transfer-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    padding: 1rem;
+    border-radius: var(--radius-lg);
+    background: var(--surface-strong);
+    box-shadow: var(--shadow-sm);
+    border-left: 4px solid var(--accent);
+  }
+
+  .transfer-card--positive {
+    border-left-color: var(--positive);
+  }
+  .transfer-card--negative {
+    border-left-color: var(--negative);
+  }
+  .transfer-card--neutral {
+    border-left-color: var(--accent);
+  }
+
+  .transfer-card__header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.8rem;
+    align-items: start;
+  }
+
+  .transfer-card__date {
+    margin: 0 0 0.2rem 0;
+    font-size: 0.8rem;
     color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+  }
+
+  .transfer-card__name {
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.2;
+    word-break: break-word;
+  }
+
+  .transfer-card__amount {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    text-align: right;
+    color: var(--text-primary);
+  }
+
+  .transfer-card--positive .transfer-card__amount {
+    color: var(--transfers-amount-positive);
+  }
+  .transfer-card--negative .transfer-card__amount {
+    color: var(--transfers-amount-negative);
+  }
+  .transfer-card--neutral .transfer-card__amount {
+    color: var(--transfers-amount-neutral);
+  }
+
+  .transfer-card__accounts {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+  }
+
+  .transfer-card__account {
+    font-weight: 500;
+  }
+
+  .transfer-card__account-arrow {
+    opacity: 0.6;
+  }
+
+  .transfer-card__categories {
+    list-style: none;
+    padding: 0;
+    margin: 0.2rem 0 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .transfer-card__category {
+    margin: 0;
+  }
+
+  .app-badge {
+    display: inline-block;
+    padding: 0.15rem 0.5rem;
+    font-size: 0.75rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--text-secondary) 15%, transparent);
+    color: var(--text-primary);
+    white-space: nowrap;
   }
 </style>

--- a/src/features/app-shell/routes/TransfersRoute.test.ts
+++ b/src/features/app-shell/routes/TransfersRoute.test.ts
@@ -5,7 +5,10 @@ import { render } from 'svelte/server';
 import TransfersRoute from './TransfersRoute.svelte';
 
 describe('TransfersRoute', () => {
-  const createMockController = (operation: 'loading' | 'ready' | 'empty' | 'error' = 'ready', transfers = []) => ({
+  const createMockController = (
+    operation: 'loading' | 'ready' | 'empty' | 'error' = 'ready',
+    transfers = [],
+  ) => ({
     getState: vi.fn(() => ({
       operation,
       transfers,

--- a/src/features/app-shell/routes/TransfersRoute.test.ts
+++ b/src/features/app-shell/routes/TransfersRoute.test.ts
@@ -1,12 +1,23 @@
-// Validates TransfersRoute month-navigation rendering contracts for M5-04.
-import { describe, expect, it } from 'vitest';
+// Validates TransfersRoute month-navigation and list rendering contracts for M5-06.
+import { describe, expect, it, vi } from 'vitest';
 import { render } from 'svelte/server';
 
 import TransfersRoute from './TransfersRoute.svelte';
 
 describe('TransfersRoute', () => {
-  it('renders month navigation controls and swipe surface placeholders', () => {
-    const { body } = render(TransfersRoute);
+  const createMockController = (operation: 'loading' | 'ready' | 'empty' | 'error' = 'ready', transfers = []) => ({
+    getState: vi.fn(() => ({
+      operation,
+      transfers,
+      error: null,
+    })),
+    subscribe: vi.fn(() => () => {}),
+    load: vi.fn().mockResolvedValue(undefined),
+  });
+
+  it('renders month navigation controls and swipe surface', () => {
+    const controller = createMockController('ready');
+    const { body } = render(TransfersRoute, { props: { controller: controller as any } });
 
     expect(body).toContain('data-testid="route-transfers"');
     expect(body).toContain('<h2>Transfers</h2>');
@@ -15,13 +26,28 @@ describe('TransfersRoute', () => {
     expect(body).toContain('data-testid="transfers-month-next-button"');
     expect(body).toContain('data-testid="transfers-month-label"');
     expect(body).toContain('data-testid="transfers-month-swipe-surface"');
-    expect(body).toContain('Transfer list rendering ships in M5-06.');
   });
 
   it('exposes a deterministic YYYY-MM month key marker', () => {
-    const { body } = render(TransfersRoute);
+    const controller = createMockController('ready');
+    const { body } = render(TransfersRoute, { props: { controller: controller as any } });
     const monthKeyMatch = body.match(/data-month-key="(\d{4}-\d{2})"/u);
 
     expect(monthKeyMatch).not.toBeNull();
+  });
+
+  it('shows loading skeletons when controller is in loading state', () => {
+    const controller = createMockController('loading');
+    const { body } = render(TransfersRoute, { props: { controller: controller as any } });
+
+    expect(body).toContain('data-testid="transfers-route-loading"');
+  });
+
+  it('shows empty state when no transfers exist for the month', () => {
+    const controller = createMockController('empty');
+    const { body } = render(TransfersRoute, { props: { controller: controller as any } });
+
+    expect(body).toContain('data-testid="transfers-route-empty"');
+    expect(body).toContain('No transfers found');
   });
 });

--- a/src/features/app-shell/routes/TransfersRoute.test.ts
+++ b/src/features/app-shell/routes/TransfersRoute.test.ts
@@ -1,6 +1,7 @@
 // Validates TransfersRoute month-navigation and list rendering contracts for M5-06.
 import { describe, expect, it, vi } from 'vitest';
 import { render } from 'svelte/server';
+import type { TransfersRouteController } from './transfersRouteController';
 
 import TransfersRoute from './TransfersRoute.svelte';
 
@@ -20,7 +21,9 @@ describe('TransfersRoute', () => {
 
   it('renders month navigation controls and swipe surface', () => {
     const controller = createMockController('ready');
-    const { body } = render(TransfersRoute, { props: { controller: controller as any } });
+    const { body } = render(TransfersRoute, {
+      props: { controller: controller as unknown as TransfersRouteController },
+    });
 
     expect(body).toContain('data-testid="route-transfers"');
     expect(body).toContain('<h2>Transfers</h2>');
@@ -33,7 +36,9 @@ describe('TransfersRoute', () => {
 
   it('exposes a deterministic YYYY-MM month key marker', () => {
     const controller = createMockController('ready');
-    const { body } = render(TransfersRoute, { props: { controller: controller as any } });
+    const { body } = render(TransfersRoute, {
+      props: { controller: controller as unknown as TransfersRouteController },
+    });
     const monthKeyMatch = body.match(/data-month-key="(\d{4}-\d{2})"/u);
 
     expect(monthKeyMatch).not.toBeNull();
@@ -41,14 +46,18 @@ describe('TransfersRoute', () => {
 
   it('shows loading skeletons when controller is in loading state', () => {
     const controller = createMockController('loading');
-    const { body } = render(TransfersRoute, { props: { controller: controller as any } });
+    const { body } = render(TransfersRoute, {
+      props: { controller: controller as unknown as TransfersRouteController },
+    });
 
     expect(body).toContain('data-testid="transfers-route-loading"');
   });
 
   it('shows empty state when no transfers exist for the month', () => {
     const controller = createMockController('empty');
-    const { body } = render(TransfersRoute, { props: { controller: controller as any } });
+    const { body } = render(TransfersRoute, {
+      props: { controller: controller as unknown as TransfersRouteController },
+    });
 
     expect(body).toContain('data-testid="transfers-route-empty"');
     expect(body).toContain('No transfers found');

--- a/src/features/app-shell/routes/accountsRouteController.test.ts
+++ b/src/features/app-shell/routes/accountsRouteController.test.ts
@@ -24,9 +24,9 @@ const getStateSnapshot = (state: AccountsRouteState): AccountsRouteState => ({
 describe('accounts route controller', () => {
   it('loads account rows into ready cards with amount semantics and formatting', async () => {
     const listVisibleNonPrimaryAccounts = vi.fn(() => [
-      { accountId: 12, name: 'Cash', amountCents: 1250 },
-      { accountId: 18, name: 'Loan', amountCents: -9750 },
-      { accountId: 19, name: 'Offset', amountCents: 0 },
+      { accountId: 12, name: 'Cash', amountCents: 1250, accountTypeId: null },
+      { accountId: 18, name: 'Loan', amountCents: -9750, accountTypeId: null },
+      { accountId: 19, name: 'Offset', amountCents: 0, accountTypeId: null },
     ]);
     const controller = createAccountsRouteController({ listVisibleNonPrimaryAccounts });
 

--- a/src/features/app-shell/routes/transfersRouteController.ts
+++ b/src/features/app-shell/routes/transfersRouteController.ts
@@ -1,0 +1,164 @@
+import type { AccountQueryService, CategoryQueryService, TransferMonthQueryService } from '@db';
+import { formatAmountDisplay, formatEpochDayToDate, type AmountSemantic } from '@shared';
+
+export type TransfersRouteOperation = 'loading' | 'ready' | 'empty' | 'error';
+
+export interface TransfersRouteError {
+  readonly message: string;
+  readonly cause?: unknown;
+}
+
+export interface TransfersRouteTransfer {
+  readonly transferId: number;
+  readonly bookingDateEpochDay: number;
+  readonly dateDisplay: string;
+  readonly name: string;
+  readonly amountCents: number;
+  readonly amountDisplay: string;
+  readonly amountSemantic: AmountSemantic;
+  readonly fromAccountName: string;
+  readonly toAccountName: string;
+  readonly categoryNames: readonly string[];
+  readonly buyplace: string | null;
+}
+
+export interface TransfersRouteState {
+  readonly operation: TransfersRouteOperation;
+  readonly transfers: readonly TransfersRouteTransfer[];
+  readonly error: TransfersRouteError | null;
+}
+
+export type TransfersRouteStateListener = (state: TransfersRouteState) => void;
+
+export interface TransfersRouteController {
+  getState(): TransfersRouteState;
+  subscribe(listener: TransfersRouteStateListener): () => void;
+  load(monthAnchorEpochDay: number): Promise<void>;
+}
+
+const INITIAL_STATE: TransfersRouteState = {
+  operation: 'loading',
+  transfers: [],
+  error: null,
+};
+
+const toTransfersRouteError = (error: unknown, fallbackMessage: string): TransfersRouteError => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return { message: error.message, cause: error };
+  }
+  return { message: fallbackMessage, cause: error };
+};
+
+const isDbRuntimeNotOpenError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: unknown }).code === 'db_not_open';
+
+export const createTransfersRouteController = (
+  transferMonthQueryService: Pick<TransferMonthQueryService, 'listTransfersByMonth'>,
+  accountQueryService: Pick<AccountQueryService, 'listAllAccounts'>,
+  categoryQueryService: Pick<CategoryQueryService, 'listAllCategories'>,
+): TransfersRouteController => {
+  let state: TransfersRouteState = INITIAL_STATE;
+  const listeners = new Set<TransfersRouteStateListener>();
+
+  const emitState = (): void => {
+    for (const listener of listeners) {
+      listener(state);
+    }
+  };
+
+  const updateState = (patch: Partial<TransfersRouteState>): void => {
+    state = { ...state, ...patch };
+    emitState();
+  };
+
+  return {
+    getState(): TransfersRouteState {
+      return state;
+    },
+
+    subscribe(listener: TransfersRouteStateListener): () => void {
+      listeners.add(listener);
+      listener(state);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    async load(monthAnchorEpochDay: number): Promise<void> {
+      updateState({
+        operation: 'loading',
+        transfers: [],
+        error: null,
+      });
+
+      try {
+        const rawTransfers = transferMonthQueryService.listTransfersByMonth(monthAnchorEpochDay);
+
+        if (rawTransfers.length === 0) {
+          updateState({
+            operation: 'empty',
+            transfers: [],
+            error: null,
+          });
+          return;
+        }
+
+        const accounts = accountQueryService.listAllAccounts();
+        const categories = categoryQueryService.listAllCategories();
+
+        const accountMap = new Map(accounts.map((a) => [a.accountId, a]));
+        const categoryMap = new Map(categories.map((c) => [c.categoryId, c.name]));
+
+        const transfers = rawTransfers.map((t): TransfersRouteTransfer => {
+          const fromAccount = accountMap.get(t.fromAccountId);
+          const toAccount = accountMap.get(t.toAccountId);
+
+          let semantic: AmountSemantic = 'neutral';
+          if (toAccount?.accountTypeId === 1 || toAccount?.accountTypeId === 2) {
+            semantic = 'negative';
+          } else if (fromAccount?.accountTypeId === 1 || fromAccount?.accountTypeId === 2) {
+            semantic = 'positive';
+          }
+
+          return {
+            transferId: t.transferId,
+            bookingDateEpochDay: t.bookingDateEpochDay,
+            dateDisplay: formatEpochDayToDate(t.bookingDateEpochDay),
+            name: t.name,
+            amountCents: t.amountCents,
+            amountDisplay: formatAmountDisplay(t.amountCents, semantic),
+            amountSemantic: semantic,
+            fromAccountName: fromAccount?.name ?? `Unknown (${t.fromAccountId})`,
+            toAccountName: toAccount?.name ?? `Unknown (${t.toAccountId})`,
+            categoryNames: t.categoryIds.map((id) => categoryMap.get(id) ?? `Unknown (${id})`),
+            buyplace: t.buyplace,
+          };
+        });
+
+        updateState({
+          operation: 'ready',
+          transfers,
+          error: null,
+        });
+      } catch (error) {
+        if (isDbRuntimeNotOpenError(error)) {
+          updateState({
+            operation: 'empty',
+            transfers: [],
+            error: null,
+          });
+          return;
+        }
+
+        updateState({
+          operation: 'error',
+          transfers: [],
+          error: toTransfersRouteError(error, 'Failed to load transfers for the selected month.'),
+        });
+      }
+    },
+  };
+};

--- a/src/shared/formatters.ts
+++ b/src/shared/formatters.ts
@@ -1,0 +1,27 @@
+const WHOLE_DOLLAR_FORMATTER = new Intl.NumberFormat('en-US');
+const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type AmountSemantic = 'positive' | 'negative' | 'neutral';
+
+export const formatAmountDisplay = (amountCents: number, semantic: AmountSemantic): string => {
+  const absoluteAmountCents = Math.abs(amountCents);
+  const wholeDollars = Math.trunc(absoluteAmountCents / 100);
+  const remainingCents = absoluteAmountCents % 100;
+  const currencyValue = `$${WHOLE_DOLLAR_FORMATTER.format(wholeDollars)}.${remainingCents
+    .toString()
+    .padStart(2, '0')}`;
+
+  if (semantic === 'positive') return `+${currencyValue}`;
+  if (semantic === 'negative') return `-${currencyValue}`;
+  return currencyValue;
+};
+
+export const formatEpochDayToDate = (epochDay: number): string => {
+  const date = new Date(epochDay * MILLIS_PER_DAY);
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+};

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,3 +1,4 @@
 export * from './config';
 export * from './state';
+export { formatAmountDisplay, formatEpochDayToDate, type AmountSemantic } from './formatters';
 export * from './utils';

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -624,11 +624,12 @@ const installMockDbRuntime = async (
 
             return [
               {
-                columns: ['account_id', 'name', 'amount'],
+                columns: ['account_id', 'name', 'amount', 'ac_type_id'],
                 values: accountRows.map((account) => [
                   account.accountId,
                   account.name,
                   account.amountCents,
+                  null,
                 ]),
               },
             ];


### PR DESCRIPTION
Resolves #60

## Description
This PR builds the complete feature layer and UI components for the Transfers view mapping `transfersMonthNavigation` state to DB queries.

- Updates `AccountQueryService` with full account fetches to hydrate type definitions for determining exact transfer amount contexts (`positive`, `negative`, `neutral`).
- Creates `CategoryQueryService`.
- Rewrites `TransfersRoute.svelte` using skeleton cards, swipe intent coordination, sync-state reloading hooks, and new mapping via `TransfersRouteController`.
- Ensures accurate mobile testing configurations without clipping content.

All local UI verification, E2E scenarios, and tests execute cleanly.
