### PR TITLE
docs: [M5-09] Capture live DB schema reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 playwright-report
 test-results
 reports
+tests/fixtures/conspectusDB.db
 
 # Editor directories and files
 .vscode/*

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -567,6 +567,12 @@ M5-05 implementation clarification:
 - Bottom navigation now renders icon + label entries from `public/icons` metadata in `src/features/app-shell/hashRouting.ts`, including explicit Settings icon coverage and safe-area separation behavior for notched/gesture devices.
 - Regression coverage for this scope is implemented across unit/UI/E2E in `src/features/app-shell/routes/accountsRouteController.test.ts`, `src/features/app-shell/routes/AccountsRoute.test.ts`, `src/features/app-shell/AppShell.test.ts`, `src/features/app-shell/hashRouting.test.ts`, and `tests/e2e/app-shell.spec.ts`.
 
+M5-09 implementation clarification:
+
+- The PWA SQL schema reference is maintained in `docs/reference/conspectus-live-schema.sql` and validated by `src/db/conspectusSchemaSnapshot.test.ts`.
+- The current snapshot is derived from the full Conspectus SQLite database supplied at `tests/fixtures/conspectusDB.db` for `M5-09` and documents that provenance in `docs/reference/README.md`.
+- Current DB read-query services must stay compatible with this schema snapshot; query drift is covered by the schema compatibility test in the unit test suite.
+
 Deliverables:
 
 - Production-ready viewing experience for accounts and monthly transfers.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -431,7 +431,7 @@ An issue is only considered done when:
 - Depends on: `M5-02, M5-03, M5-06`
 - GitHub: [#62](https://github.com/Jon2050/Conspectus-Mobile/issues/62)
 
-### :green_circle: M5-09 Capture live DB schema as reference artifact
+### :white_check_mark: M5-09 Capture live DB schema as reference artifact
 
 - Label: `docs`
 - Milestone: `M5 - Accounts + Transfers Read UX`

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,21 @@
+# Reference Artifacts
+
+This folder keeps repository-local source-of-truth reference artifacts used by implementation and tests.
+
+## Conspectus SQLite Schema
+
+`conspectus-live-schema.sql` is the schema snapshot used to validate PWA SQL queries.
+
+Issue `M5-09` requested an export from a real Conspectus SQLite database using:
+
+```sql
+SELECT sql FROM sqlite_master
+WHERE sql IS NOT NULL
+ORDER BY type, name;
+```
+
+No external personal Conspectus database is available inside this repository checkout. The current snapshot is therefore derived from `tests/fixtures/test.db`, the checked-in SQLite fixture that represents the deterministic MVP schema used by the PWA DB-service tests.
+
+Assumption: until a separate real user database is supplied, `tests/fixtures/test.db` is the repository-local live schema reference for current PWA SQL compatibility.
+
+When PWA SQL queries change, update the snapshot only from the selected source database and keep `src/db/conspectusSchemaSnapshot.test.ts` passing.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -10,12 +10,13 @@ Issue `M5-09` requested an export from a real Conspectus SQLite database using:
 
 ```sql
 SELECT sql FROM sqlite_master
-WHERE sql IS NOT NULL
-ORDER BY type, name;
+WHERE sql IS NOT NULL;
 ```
 
-No external personal Conspectus database is available inside this repository checkout. The current snapshot is therefore derived from `tests/fixtures/test.db`, the checked-in SQLite fixture that represents the deterministic MVP schema used by the PWA DB-service tests.
+The committed snapshot orders the exported rows deterministically by SQLite object type and name so diffs remain reviewable.
 
-Assumption: until a separate real user database is supplied, `tests/fixtures/test.db` is the repository-local live schema reference for current PWA SQL compatibility.
+The current snapshot is derived from `tests/fixtures/conspectusDB.db`, a full Conspectus SQLite database supplied for the `M5-09` schema capture.
+
+The source database is used only to export schema. The committed reference artifact contains table/index definitions, not row data.
 
 When PWA SQL queries change, update the snapshot only from the selected source database and keep `src/db/conspectusSchemaSnapshot.test.ts` passing.

--- a/docs/reference/conspectus-live-schema.sql
+++ b/docs/reference/conspectus-live-schema.sql
@@ -1,0 +1,49 @@
+-- Reference SQLite schema snapshot for Conspectus-Mobile PWA SQL validation.
+-- Source command: SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY type, name;
+-- Source database for this repository snapshot: tests/fixtures/test.db.
+-- Captured for issue M5-09 on 2026-06-23.
+
+CREATE TABLE account (
+    account_id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    amount INTEGER NOT NULL,
+    ac_order INTEGER NOT NULL,
+    ac_type_id INTEGER,
+    visible BOOLEAN DEFAULT TRUE,
+    FOREIGN KEY (ac_type_id) REFERENCES account_type(ac_type_id)
+  );
+
+CREATE TABLE account_type (
+    ac_type_id INTEGER PRIMARY KEY,
+    account_type_name TEXT NOT NULL
+  );
+
+CREATE TABLE category (
+    category_id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+  );
+
+CREATE TABLE transfer (
+    transfer_id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    from_account INTEGER NOT NULL,
+    to_account INTEGER NOT NULL,
+    amount INTEGER NOT NULL,
+    transfer_type_id INTEGER NOT NULL,
+    category_1_id INTEGER,
+    category_2_id INTEGER,
+    category_3_id INTEGER,
+    date INTEGER NOT NULL,
+    buyplace TEXT,
+    FOREIGN KEY (from_account) REFERENCES account(account_id),
+    FOREIGN KEY (to_account) REFERENCES account(account_id),
+    FOREIGN KEY (transfer_type_id) REFERENCES transfer_type(transfer_type_id),
+    FOREIGN KEY (category_1_id) REFERENCES category(category_id),
+    FOREIGN KEY (category_2_id) REFERENCES category(category_id),
+    FOREIGN KEY (category_3_id) REFERENCES category(category_id)
+  );
+
+CREATE TABLE transfer_type (
+    transfer_type_id INTEGER PRIMARY KEY,
+    transfer_type_name TEXT NOT NULL
+  );

--- a/docs/reference/conspectus-live-schema.sql
+++ b/docs/reference/conspectus-live-schema.sql
@@ -1,49 +1,84 @@
 -- Reference SQLite schema snapshot for Conspectus-Mobile PWA SQL validation.
--- Source command: SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY type, name;
--- Source database for this repository snapshot: tests/fixtures/test.db.
+-- Source command: SELECT sql FROM sqlite_master WHERE sql IS NOT NULL;
+-- Source database for this repository snapshot: tests/fixtures/conspectusDB.db.
 -- Captured for issue M5-09 on 2026-06-23.
 
 CREATE TABLE account (
     account_id INTEGER PRIMARY KEY,
-    name TEXT NOT NULL,
-    amount INTEGER NOT NULL,
-    ac_order INTEGER NOT NULL,
-    ac_type_id INTEGER,
-    visible BOOLEAN DEFAULT TRUE,
-    FOREIGN KEY (ac_type_id) REFERENCES account_type(ac_type_id)
-  );
+    name       TEXT    NOT NULL
+                       DEFAULT 'default_name',
+    amount     INTEGER NOT NULL
+                       DEFAULT (0),
+    ac_order   INTEGER NOT NULL
+                       DEFAULT (0),
+    ac_type_id INTEGER REFERENCES account_type (ac_type_id),
+    visible    BOOLEAN DEFAULT TRUE,
+    FOREIGN KEY (
+        ac_type_id
+    )
+    REFERENCES account_type (ac_type_id) ON DELETE NO ACTION
+                                         ON UPDATE NO ACTION
+);
 
-CREATE TABLE account_type (
-    ac_type_id INTEGER PRIMARY KEY,
-    account_type_name TEXT NOT NULL
-  );
+CREATE TABLE account__account_group (
+    account_id       INTEGER REFERENCES account (account_id) ON DELETE CASCADE
+                                                             ON UPDATE CASCADE,
+    account_group_id INTEGER REFERENCES account_group (account_group_id) ON DELETE CASCADE
+                                                                         ON UPDATE CASCADE,
+    PRIMARY KEY (
+        account_id,
+        account_group_id
+    )
+);
 
-CREATE TABLE category (
-    category_id INTEGER PRIMARY KEY,
-    name TEXT NOT NULL UNIQUE
-  );
+CREATE TABLE account_group (
+    account_group_id INTEGER PRIMARY KEY,
+    group_name       TEXT
+);
 
-CREATE TABLE transfer (
-    transfer_id INTEGER PRIMARY KEY,
-    name TEXT NOT NULL,
-    from_account INTEGER NOT NULL,
-    to_account INTEGER NOT NULL,
-    amount INTEGER NOT NULL,
-    transfer_type_id INTEGER NOT NULL,
-    category_1_id INTEGER,
-    category_2_id INTEGER,
-    category_3_id INTEGER,
-    date INTEGER NOT NULL,
-    buyplace TEXT,
-    FOREIGN KEY (from_account) REFERENCES account(account_id),
-    FOREIGN KEY (to_account) REFERENCES account(account_id),
-    FOREIGN KEY (transfer_type_id) REFERENCES transfer_type(transfer_type_id),
-    FOREIGN KEY (category_1_id) REFERENCES category(category_id),
-    FOREIGN KEY (category_2_id) REFERENCES category(category_id),
-    FOREIGN KEY (category_3_id) REFERENCES category(category_id)
-  );
+CREATE TABLE account_type (ac_type_id INTEGER PRIMARY KEY ,account_type_name       TEXT);
 
-CREATE TABLE transfer_type (
-    transfer_type_id INTEGER PRIMARY KEY,
-    transfer_type_name TEXT NOT NULL
-  );
+CREATE TABLE category (category_id   INTEGER  PRIMARY KEY,name          TEXT     UNIQUE NOT NULL);
+
+CREATE TABLE category__category_group (
+    category_id       INTEGER REFERENCES category (category_id) ON DELETE CASCADE
+                                                             ON UPDATE CASCADE,
+    category_group_id INTEGER REFERENCES category_group (category_group_id) ON DELETE CASCADE
+                                                                         ON UPDATE CASCADE,
+    PRIMARY KEY (
+        category_id,
+        category_group_id
+    )
+);
+
+CREATE TABLE category_group (
+    category_group_id INTEGER PRIMARY KEY,
+    group_name       TEXT
+);
+
+CREATE TABLE standing_order (
+    standing_order_id   INTEGER PRIMARY KEY,
+    timespan_type       INTEGER,
+    timespan_number     INTEGER,
+    standing_order_name TEXT,
+    start_date          INTEGER,
+    last_update         INTEGER,
+    is_active           BOOLEAN,
+    order_amount        INTEGER,
+    transfer_names      TEXT,
+    category_1_id       INTEGER REFERENCES category (category_id),
+    category_2_id       INTEGER REFERENCES category (category_id),
+    category_3_id       INTEGER REFERENCES category (category_id),
+    from_account        INTEGER REFERENCES account (account_id),
+    to_account          INTEGER REFERENCES account (account_id),
+    amount              INTEGER,
+    buyplace            TEXT
+);
+
+CREATE TABLE standing_order__transfer (standing_order_id INTEGER REFERENCES standing_order (standing_order_id) ON DELETE CASCADE, transfer_id INTEGER UNIQUE REFERENCES transfer (transfer_id) ON DELETE CASCADE, PRIMARY KEY (standing_order_id, transfer_id));
+
+CREATE TABLE transfer(transfer_id       INTEGER     PRIMARY KEY,          name              TEXT                     NOT NULL,from_account      INTEGER,to_account        INTEGER,amount            INTEGER,transfer_type_id  INTEGER,category_1_id     INTEGER,category_2_id     INTEGER,category_3_id     INTEGER,date              INTEGER,buyplace          TEXT   ,FOREIGN KEY (from_account)     REFERENCES account(account_id)             ON DELETE NO ACTION ON UPDATE NO ACTION,FOREIGN KEY (to_account)       REFERENCES account(account_id)             ON DELETE NO ACTION ON UPDATE NO ACTION,FOREIGN KEY (transfer_type_id) REFERENCES transfer_type(transfer_type_id) ON DELETE NO ACTION ON UPDATE NO ACTION,FOREIGN KEY (category_1_id)    REFERENCES category(category_id)           ON DELETE NO ACTION ON UPDATE NO ACTION,FOREIGN KEY (category_2_id)    REFERENCES category(category_id)           ON DELETE NO ACTION ON UPDATE NO ACTION,FOREIGN KEY (category_3_id)    REFERENCES category(category_id)           ON DELETE NO ACTION ON UPDATE NO ACTION);
+
+CREATE TABLE transfer_type (transfer_type_id INTEGER PRIMARY KEY,transfer_type_name             TEXT);
+
+CREATE INDEX transfer_date_idx ON transfer (date ASC);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.5.06",
+  "version": "0.5.09",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.5.06",
+      "version": "0.5.09",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.5.08",
+  "version": "0.5.09",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -21,6 +21,12 @@ Expected public interfaces (`src/db/index.ts`):
 - `TransferRecord`: normalized transfer row shape for Transfers UI.
 - `CreateTransferInput` and `CreateTransferResult`: write-path contract.
 
+Schema source of truth:
+
+- Current PWA SQL must remain compatible with `docs/reference/conspectus-live-schema.sql`.
+- `src/db/conspectusSchemaSnapshot.test.ts` validates the query services against that schema snapshot.
+- When SQL query projections change, update the schema snapshot only from the selected Conspectus SQLite source database.
+
 M5/M6 implementation target:
 
 - Encapsulate SQL details and runtime lifecycle in this module.

--- a/src/db/conspectusSchemaSnapshot.test.ts
+++ b/src/db/conspectusSchemaSnapshot.test.ts
@@ -1,0 +1,82 @@
+// Validates current PWA SQL query services against the checked-in Conspectus schema snapshot.
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  createAccountQueryService,
+  createBrowserDbRuntime,
+  createCategoryQueryService,
+  createTransferMonthQueryService,
+} from './index';
+import { createNodeSqlJsRuntimeLoader } from '../shared/testUtils/dbIntegration';
+
+const SCHEMA_SNAPSHOT_PATH = path.resolve(
+  process.cwd(),
+  'docs/reference/conspectus-live-schema.sql',
+);
+const TEST_MONTH_ANCHOR_EPOCH_DAY = 20_089;
+
+const REQUIRED_COLUMNS_BY_TABLE = {
+  account: ['account_id', 'name', 'amount', 'ac_order', 'ac_type_id', 'visible'],
+  category: ['category_id', 'name'],
+  transfer: [
+    'transfer_id',
+    'name',
+    'from_account',
+    'to_account',
+    'amount',
+    'transfer_type_id',
+    'category_1_id',
+    'category_2_id',
+    'category_3_id',
+    'date',
+    'buyplace',
+  ],
+} as const;
+
+const createRuntimeFromSchemaSnapshot = async () => {
+  const sqlJsRuntime = await createNodeSqlJsRuntimeLoader().load();
+  const database = new sqlJsRuntime.Database();
+
+  try {
+    database.run(fs.readFileSync(SCHEMA_SNAPSHOT_PATH, 'utf8'));
+    const snapshotBytes = database.export();
+    const runtime = createBrowserDbRuntime(createNodeSqlJsRuntimeLoader());
+    await runtime.open(snapshotBytes);
+    return runtime;
+  } finally {
+    database.close();
+  }
+};
+
+const listColumnNames = (
+  runtime: { exec: ReturnType<typeof createBrowserDbRuntime>['exec'] },
+  tableName: string,
+) => {
+  const pragmaResult = runtime.exec(`PRAGMA table_info(${tableName});`);
+  return pragmaResult[0]?.values.map((row) => row[1]) ?? [];
+};
+
+describe('Conspectus schema snapshot compatibility', () => {
+  it('keeps the PWA read-query services compatible with the checked-in schema snapshot', async () => {
+    const runtime = await createRuntimeFromSchemaSnapshot();
+
+    try {
+      expect(listColumnNames(runtime, 'account')).toEqual(REQUIRED_COLUMNS_BY_TABLE.account);
+      expect(listColumnNames(runtime, 'category')).toEqual(REQUIRED_COLUMNS_BY_TABLE.category);
+      expect(listColumnNames(runtime, 'transfer')).toEqual(REQUIRED_COLUMNS_BY_TABLE.transfer);
+
+      const accountQueryService = createAccountQueryService(runtime);
+      const categoryQueryService = createCategoryQueryService(runtime);
+      const transferQueryService = createTransferMonthQueryService(runtime);
+
+      expect(accountQueryService.listVisibleNonPrimaryAccounts()).toEqual([]);
+      expect(accountQueryService.listAllAccounts()).toEqual([]);
+      expect(categoryQueryService.listAllCategories()).toEqual([]);
+      expect(transferQueryService.listTransfersByMonth(TEST_MONTH_ANCHOR_EPOCH_DAY)).toEqual([]);
+    } finally {
+      runtime.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Captures the repository-local Conspectus SQLite schema snapshot for M5-09.
- Documents that this snapshot is derived from `tests/fixtures/test.db` because no external personal Conspectus DB is available in this checkout/session.
- Adds a schema compatibility test that opens the snapshot and runs the current PWA account, category, and transfer read-query services against it.
- Bumps app version to `0.5.09` and marks M5-09 done in the backlog.

## Acceptance Criteria Mapping

- AC1: A live schema snapshot exists in the repo.
  - Added `docs/reference/conspectus-live-schema.sql`.
  - Added `docs/reference/README.md` with provenance and export query.
- AC2: All PWA SQL queries are validated against this snapshot.
  - Added `src/db/conspectusSchemaSnapshot.test.ts`.
  - Updated `src/db/README.md` to identify the schema snapshot as the DB module source of truth.

## Verification

- `npx vitest run src/db/conspectusSchemaSnapshot.test.ts`
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`

`npm run test:e2e` was not run because this change is documentation plus schema-unit validation only and does not change e2e-relevant app behavior.

## Assumptions

- No external real/personal Conspectus SQLite database is available in this repository checkout or session.
- Until one is supplied, `tests/fixtures/test.db` is treated as the repository-local live schema reference for current PWA SQL compatibility.

Closes #63