### PR TITLE
feat: [M5-10] Polish read-flow UI

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -573,6 +573,13 @@ M5-09 implementation clarification:
 - The current snapshot is derived from the full Conspectus SQLite database supplied at `tests/fixtures/conspectusDB.db` for `M5-09` and documents that provenance in `docs/reference/README.md`.
 - Current DB read-query services must stay compatible with this schema snapshot; query drift is covered by the schema compatibility test in the unit test suite.
 
+M5-10 implementation clarification:
+
+- The Milestone 5 read UX polish pass keeps scope to existing Accounts and Transfers screens, with no read-query, sync, or write-path behavior changes.
+- Accounts and transfer cards now use responsive wrapping rules for long names, large currency values, account paths, categories, and buyplace text so narrow mobile widths remain readable.
+- Transfer month navigation uses compact arrow controls with localized accessible labels, and the transfer swipe region label is localized through the app i18n files.
+- Reduced-motion preferences are honored globally for transitions and skeleton animations, and duplicate dark-mode amount color token declarations were collapsed.
+
 Deliverables:
 
 - Production-ready viewing experience for accounts and monthly transfers.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -439,7 +439,7 @@ An issue is only considered done when:
 - Depends on: `none`
 - GitHub: [#63](https://github.com/Jon2050/Conspectus-Mobile/issues/63)
 
-### :green_circle: M5-10 Follow-up UI cleanup and usability polish
+### :white_check_mark: M5-10 Follow-up UI cleanup and usability polish
 
 - Label: `feature`
 - Milestone: `M5 - Accounts + Transfers Read UX`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.5.09",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.5.09",
+      "version": "0.5.10",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.5.09",
+  "version": "0.5.10",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/app.css
+++ b/src/app.css
@@ -47,11 +47,20 @@
     --accent-soft: #134e4a;
     --amount-positive: #34d399;
     --amount-negative: #fca5a5;
-    --amount-positive: #79ff21;
-    --amount-negative: #e54b4b;
     --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
     --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
     --shadow-lg: 0 10px 25px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
   }
 }
 

--- a/src/features/app-shell/routes/AccountsRoute.svelte
+++ b/src/features/app-shell/routes/AccountsRoute.svelte
@@ -187,13 +187,15 @@
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.8rem;
     align-items: start;
+    min-width: 0;
   }
 
   .account-card__name {
     margin: 0;
     font-size: 1rem;
     line-height: 1.2;
-    word-break: break-word;
+    overflow-wrap: anywhere;
+    min-width: 0;
   }
 
   .account-card__amount {
@@ -202,6 +204,7 @@
     white-space: nowrap;
     text-align: right;
     color: var(--text-primary);
+    justify-self: end;
   }
 
   .account-card--positive .account-card__amount {
@@ -214,5 +217,17 @@
 
   .account-card--neutral .account-card__amount {
     color: var(--text-secondary);
+  }
+
+  @media (max-width: 380px) {
+    .account-card__header {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0.35rem;
+    }
+
+    .account-card__amount {
+      justify-self: start;
+      text-align: left;
+    }
   }
 </style>

--- a/src/features/app-shell/routes/TransfersRoute.svelte
+++ b/src/features/app-shell/routes/TransfersRoute.svelte
@@ -131,7 +131,8 @@
       class="app-button app-button--secondary transfers-route__month-button"
       data-testid="transfers-month-previous-button"
       aria-label={$_('transfers.previousMonth')}
-      on:click={handlePreviousMonthClick}>{$_('transfers.previousMonth')}</button
+      title={$_('transfers.previousMonth')}
+      on:click={handlePreviousMonthClick}><span aria-hidden="true">‹</span></button
     >
     <p
       class="transfers-route__month-label"
@@ -145,7 +146,8 @@
       class="app-button app-button--secondary transfers-route__month-button"
       data-testid="transfers-month-next-button"
       aria-label={$_('transfers.nextMonth')}
-      on:click={handleNextMonthClick}>{$_('transfers.nextMonth')}</button
+      title={$_('transfers.nextMonth')}
+      on:click={handleNextMonthClick}><span aria-hidden="true">›</span></button
     >
   </div>
 
@@ -153,7 +155,7 @@
     class="transfers-route__swipe-surface"
     data-testid="transfers-month-swipe-surface"
     role="group"
-    aria-label="Transfer month swipe area"
+    aria-label={$_('transfers.swipeArea')}
     on:touchstart={handleTouchStart}
     on:touchend={handleTouchEnd}
     on:touchcancel={clearSwipeStart}
@@ -169,6 +171,8 @@
         {$_('transfers.loading')}
       {:else if state.operation === 'error'}
         {state.error?.message ?? $_('transfers.errorDefault')}
+      {:else if state.operation === 'empty'}
+        {$_('transfers.emptyStatus')}
       {:else if state.operation === 'ready'}
         {$_('transfers.countFound', { values: { count: state.transfers.length } })}
       {/if}
@@ -240,6 +244,12 @@
                     {/each}
                   </ul>
                 {/if}
+                {#if transfer.buyplace}
+                  <p class="transfer-card__buyplace">
+                    <span>{$_('transfers.buyplace')}:</span>
+                    {transfer.buyplace}
+                  </p>
+                {/if}
               </div>
             </article>
           </li>
@@ -275,8 +285,11 @@
   }
 
   .transfers-route__month-button {
-    min-height: 2.5rem;
-    font-size: 0.88rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+    padding-inline: 0.75rem;
+    font-size: 1.4rem;
+    line-height: 1;
   }
 
   .transfers-route__month-label {
@@ -346,8 +359,8 @@
   .transfer-card {
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
-    padding: 0.25rem 0.8rem;
+    gap: 0.45rem;
+    padding: 0.65rem 0.8rem;
     border-radius: var(--radius-lg);
     background: var(--surface-strong);
     box-shadow: var(--shadow-sm);
@@ -369,6 +382,7 @@
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.8rem;
     align-items: start;
+    min-width: 0;
   }
 
   .transfer-card__date {
@@ -383,7 +397,8 @@
     margin: 0;
     font-size: 1rem;
     line-height: 1.2;
-    word-break: break-word;
+    overflow-wrap: anywhere;
+    min-width: 0;
   }
 
   .transfer-card__amount {
@@ -392,6 +407,7 @@
     white-space: nowrap;
     text-align: right;
     color: var(--text-primary);
+    justify-self: end;
   }
 
   .transfer-card--positive .transfer-card__amount {
@@ -407,10 +423,10 @@
   .transfer-card__details {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.5rem;
     flex-wrap: wrap;
-    margin-top: -0.4rem;
+    min-width: 0;
   }
 
   .transfer-card__accounts {
@@ -420,10 +436,14 @@
     gap: 0.4rem;
     font-size: 0.85rem;
     color: var(--text-secondary);
+    min-width: 0;
+    flex: 1 1 12rem;
   }
 
   .transfer-card__account {
     font-weight: 500;
+    overflow-wrap: anywhere;
+    min-width: 0;
   }
 
   .transfer-card__account-arrow {
@@ -438,6 +458,7 @@
     flex-wrap: wrap;
     gap: 0.4rem;
     justify-content: flex-end;
+    min-width: 0;
   }
 
   .transfer-card__category {
@@ -451,6 +472,30 @@
     border-radius: 999px;
     background: color-mix(in srgb, var(--text-secondary) 15%, transparent);
     color: var(--text-primary);
-    white-space: nowrap;
+    overflow-wrap: anywhere;
+  }
+
+  .transfer-card__buyplace {
+    flex-basis: 100%;
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    overflow-wrap: anywhere;
+  }
+
+  .transfer-card__buyplace span {
+    font-weight: 600;
+  }
+
+  @media (max-width: 380px) {
+    .transfer-card__header {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0.3rem;
+    }
+
+    .transfer-card__amount {
+      justify-self: start;
+      text-align: left;
+    }
   }
 </style>

--- a/src/features/app-shell/routes/TransfersRoute.test.ts
+++ b/src/features/app-shell/routes/TransfersRoute.test.ts
@@ -30,8 +30,11 @@ describe('TransfersRoute', () => {
     expect(body).toContain('data-testid="transfers-month-navigation"');
     expect(body).toContain('data-testid="transfers-month-previous-button"');
     expect(body).toContain('data-testid="transfers-month-next-button"');
+    expect(body).toContain('aria-label="Vorheriger Monat"');
+    expect(body).toContain('aria-label="Nächster Monat"');
     expect(body).toContain('data-testid="transfers-month-label"');
     expect(body).toContain('data-testid="transfers-month-swipe-surface"');
+    expect(body).toContain('aria-label="Wischbereich für Transfermonate"');
   });
 
   it('exposes a deterministic YYYY-MM month key marker', () => {
@@ -60,6 +63,7 @@ describe('TransfersRoute', () => {
     });
 
     expect(body).toContain('data-testid="transfers-route-empty"');
+    expect(body).toContain('Für diesen Monat sind keine Transfers vorhanden.');
     expect(body).toContain('Es gibt keine Transfers für diesen Monat.');
   });
 
@@ -73,7 +77,7 @@ describe('TransfersRoute', () => {
       fromAccountName: 'Original From Name',
       toAccountName: 'Original To Name',
       categoryNames: [],
-      buyplace: null,
+      buyplace: 'Local Market',
       fromAccountTypeId: 2, // PRIMARY_SPENDINGS -> AUSGABEN
       toAccountTypeId: 1, // PRIMARY_INCOME -> EINNAHMEN
     };
@@ -85,6 +89,8 @@ describe('TransfersRoute', () => {
 
     expect(body).toContain('AUSGABEN');
     expect(body).toContain('EINNAHMEN');
+    expect(body).toContain('Ort:');
+    expect(body).toContain('Local Market');
     expect(body).not.toContain('Original From Name');
     expect(body).not.toContain('Original To Name');
   });

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -23,13 +23,15 @@
     "title": "Transfers",
     "previousMonth": "Vorheriger Monat",
     "nextMonth": "Nächster Monat",
+    "swipeArea": "Wischbereich für Transfermonate",
     "loading": "Transfers werden geladen...",
     "errorDefault": "Fehler beim Laden der Transfers.",
     "emptyStatus": "Für diesen Monat sind keine Transfers vorhanden.",
     "countFound": "{count} Transfers gefunden.",
     "emptyBox": "Es gibt keine Transfers für diesen Monat.",
     "primaryIncome": "EINNAHMEN",
-    "primarySpendings": "AUSGABEN"
+    "primarySpendings": "AUSGABEN",
+    "buyplace": "Ort"
   },
   "settings": {
     "title": "Einstellungen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -23,13 +23,15 @@
     "title": "Transfers",
     "previousMonth": "Previous month",
     "nextMonth": "Next month",
+    "swipeArea": "Transfer month swipe area",
     "loading": "Loading transfers...",
     "errorDefault": "Failed to load transfers.",
     "emptyStatus": "No transfers found for this month.",
     "countFound": "{count} transfers found.",
     "emptyBox": "There are no transfers recorded for this month.",
     "primaryIncome": "INCOME",
-    "primarySpendings": "SPENDINGS"
+    "primarySpendings": "SPENDINGS",
+    "buyplace": "Place"
   },
   "settings": {
     "title": "Settings",


### PR DESCRIPTION
## Summary

Closes #174

This PR completes `M5-10` as a scoped Milestone 5 read-flow polish pass:

- improves Accounts and Transfers card wrapping for long names, large amounts, account paths, categories, and buyplace text on narrow mobile widths
- replaces long visible transfer month button labels with compact arrow controls while preserving localized accessible labels
- localizes the transfer swipe surface label and renders transfer `buyplace` detail when present
- adds global reduced-motion handling and removes duplicate dark-mode amount color token declarations
- bumps the app version to `0.5.10`
- marks `M5-10` done in the backlog and records the implementation clarification in the architecture plan

## Acceptance Criteria Mapping

- `A later pass improves the M5 UI quality and usability.`
  - Implemented responsive read-flow UI polish in Accounts and Transfers.
  - Kept scope to existing M5 read behavior; no DB/query/sync/write-path changes.

- `Specific changes are intentionally left open for later review.`
  - Final scope was inferred from the completed M5 architecture and current UI: readability, accessible labels, localized copy, and motion preference cleanup.

## Verification

- `npm run format` - passed
- `npm run lint` - passed
- `npm run typecheck` - passed
- `npm run test` - passed (`47` app test files, `7` script test files)
- `npm run build` - passed with existing Vite large chunk warning
- `npm run test:e2e` - passed (`86` tests)
- Local reviewer subagent - APPROVED

## Notes

Assumption: because issue #174 intentionally left the exact polish scope open and had no comments, this PR treats `M5-10` as a narrow Accounts/Transfers read UX cleanup only. It explicitly does not start any Milestone 6 add-transfer/write-path work.
