### PR TITLE
fix: [M5-10] Refine transfer card polish

### DIFF
--- a/docs/prompts/Post-Milestone-Review-Prompt-Template.md
+++ b/docs/prompts/Post-Milestone-Review-Prompt-Template.md
@@ -87,6 +87,9 @@ You MUST cover at least these perspectives. You are encouraged to add more persp
 
 6. **Testing** — Verify that every new or changed behavior has appropriate test coverage. Check for missing unit tests, integration tests, or E2E tests. Flag untested edge cases, error paths, and critical business logic.
 
+Pay particular attention to whether the written tests are comprehensive, whether they truly cover all important functionalities, edge cases, error conditions, and failure scenarios, and whether any tests are unnecessary or merely pseudo-tests that do not actually verify real functionality. Evaluate whether the tests would realistically catch regressions and implementation mistakes, rather than simply confirming the current implementation. Also check whether important negative test cases, boundary conditions, integration points, and business-critical paths are missing.
+Assess whether the tests would fail if the implementation contained realistic bugs. A test that always passes regardless of implementation correctness provides little value.
+
 7. **CI/CD** — Review workflow changes for correctness, security (permissions, secret handling), efficiency (unnecessary rebuilds, missing caching), and alignment with `docs/CI-CD-Pipelines.md`.
 
 8. **Documentation** — Verify that docs are up-to-date with implementation reality. Check module READMEs, architecture doc, backlog status markers, and documentation ownership rules.

--- a/docs/prompts/Task-Prompt-Template.md
+++ b/docs/prompts/Task-Prompt-Template.md
@@ -1,4 +1,4 @@
-Task: Implement issue `M5-08` end-to-end with full verification.
+Task: Implement issue `M5-10` end-to-end with full verification.
 
 ## Non-negotiable rules:
 
@@ -22,7 +22,7 @@ Always print in which step you are!
    - `docs/Architecture-and-Implementation-Plan.md`
    - `docs/Conspectus-Desktop-Info.md`
    - `docs/GitHub-Issues-MVP-Backlog.md`
-     Then locate `M5-08` and extract implementation steps, acceptance criteria, and dependencies/constraints from GitHub. Also from the comments on GitHub.
+     Then locate `M5-10` and extract implementation steps, acceptance criteria, and dependencies/constraints from GitHub. Also from the comments on GitHub.
 2. Plan with one planning subagent. Refine until concrete, testable, and mapped from each acceptance criterion to file-level code/test changes. Make clear, that the planning subagent should not write any code, just the plan.
 3. Create/use a dedicated issue branch with a proper name containing the milestone and issue number (e.g., `feature/M5-07-localize-formatting` or `bug/M5-07-fix-locale`).
    3.1. Increase the app version in `package.json` to `0.<milestone_number>.<issue_title_number>`. (e.g. `0.4.08` for issue `M4-08`)
@@ -74,5 +74,5 @@ Always print in which step you are!
 3. **UI/UX:** UI components must be fully responsive across screen sizes. The UI must communicate system status clearly. Always implement loading states for async actions, explicit error/success feedback, and prevent double-submissions. Good and simple but modern and beautiful UX is very important!
 4. **AI Anti-Patterns (STRICTLY FORBIDDEN):** Never implement "backup" solutions, redundant fallbacks, or placeholder code. Do not introduce technical debt.
 5. **Documentation:** Code must be self-explanatory. Add meaningful inline comments only for complex or non-obvious logic. Every file should start with a short description of what the file does and why it is needed.
-6. **Testing:** All new or changed behavior must be accompanied by appropriate, passing tests.
+6. **Testing:** All new or changed behavior must be accompanied by appropriate, passing tests. Tests should verify real functionality, cover important edge cases and failure scenarios, and provide meaningful regression protection.
 7. **Contextual Alignment:** Before coding, verify that prerequisites from previous tasks are complete. Ensure your implementation serves as a solid foundation for related upcoming issues in the backlog.

--- a/src/features/app-shell/routes/TransfersRoute.svelte
+++ b/src/features/app-shell/routes/TransfersRoute.svelte
@@ -132,7 +132,10 @@
       data-testid="transfers-month-previous-button"
       aria-label={$_('transfers.previousMonth')}
       title={$_('transfers.previousMonth')}
-      on:click={handlePreviousMonthClick}><span aria-hidden="true">‹</span></button
+      on:click={handlePreviousMonthClick}
+      ><span class="transfers-route__month-button-content" aria-hidden="true"
+        >{$_('transfers.previousMonthButton')}</span
+      ></button
     >
     <p
       class="transfers-route__month-label"
@@ -147,7 +150,10 @@
       data-testid="transfers-month-next-button"
       aria-label={$_('transfers.nextMonth')}
       title={$_('transfers.nextMonth')}
-      on:click={handleNextMonthClick}><span aria-hidden="true">›</span></button
+      on:click={handleNextMonthClick}
+      ><span class="transfers-route__month-button-content" aria-hidden="true"
+        >{$_('transfers.nextMonthButton')}</span
+      ></button
     >
   </div>
 
@@ -201,7 +207,12 @@
                   <p class="transfer-card__date">
                     {formatEpochDayToDate(transfer.bookingDateEpochDay, $locale)}
                   </p>
-                  <h3 class="transfer-card__name">{transfer.name}</h3>
+                  <h3 class="transfer-card__name">
+                    {#if transfer.buyplace}<span class="transfer-card__buyplace-prefix"
+                        >({transfer.buyplace})
+                      </span>
+                    {/if}{transfer.name}
+                  </h3>
                 </div>
                 <span
                   class="transfer-card__amount"
@@ -244,12 +255,6 @@
                     {/each}
                   </ul>
                 {/if}
-                {#if transfer.buyplace}
-                  <p class="transfer-card__buyplace">
-                    <span>{$_('transfers.buyplace')}:</span>
-                    {transfer.buyplace}
-                  </p>
-                {/if}
               </div>
             </article>
           </li>
@@ -279,17 +284,28 @@
 
   .transfers-route__month-navigation {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    grid-template-columns: 2.5rem minmax(0, 1fr) 2.5rem;
     gap: 0.5rem;
     align-items: center;
   }
 
   .transfers-route__month-button {
-    min-width: 2.75rem;
-    min-height: 2.75rem;
-    padding-inline: 0.75rem;
-    font-size: 1.4rem;
+    width: 2.5rem;
+    min-width: 2.5rem;
+    min-height: 2.5rem;
+    padding: 0;
+    font-size: 1.35rem;
     line-height: 1;
+  }
+
+  .transfers-route__month-button-content {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1em;
+    height: 1em;
+    line-height: 1;
+    transform: translateY(-0.04em);
   }
 
   .transfers-route__month-label {
@@ -349,7 +365,7 @@
     padding: 0;
     margin: 0;
     display: grid;
-    gap: 0.25rem;
+    gap: 0.2rem;
   }
 
   .transfers-route__card-item {
@@ -359,8 +375,8 @@
   .transfer-card {
     display: flex;
     flex-direction: column;
-    gap: 0.45rem;
-    padding: 0.65rem 0.8rem;
+    gap: 0.08rem;
+    padding: 0.4rem 0.75rem 0.1rem;
     border-radius: var(--radius-lg);
     background: var(--surface-strong);
     box-shadow: var(--shadow-sm);
@@ -388,6 +404,7 @@
   .transfer-card__date {
     margin: 0;
     font-size: 0.7rem;
+    line-height: 1.1;
     color: var(--text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.02em;
@@ -396,9 +413,13 @@
   .transfer-card__name {
     margin: 0;
     font-size: 1rem;
-    line-height: 1.2;
+    line-height: 1.25;
     overflow-wrap: anywhere;
     min-width: 0;
+  }
+
+  .transfer-card__buyplace-prefix {
+    font-weight: 600;
   }
 
   .transfer-card__amount {
@@ -408,6 +429,7 @@
     text-align: right;
     color: var(--text-primary);
     justify-self: end;
+    line-height: 1.15;
   }
 
   .transfer-card--positive .transfer-card__amount {
@@ -423,8 +445,8 @@
   .transfer-card__details {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
-    gap: 0.5rem;
+    align-items: center;
+    gap: 0.35rem;
     flex-wrap: wrap;
     min-width: 0;
   }
@@ -435,6 +457,7 @@
     align-items: center;
     gap: 0.4rem;
     font-size: 0.85rem;
+    line-height: 0.9;
     color: var(--text-secondary);
     min-width: 0;
     flex: 1 1 12rem;
@@ -447,7 +470,7 @@
   }
 
   .transfer-card__account-arrow {
-    opacity: 0.6;
+    opacity: 0.8;
   }
 
   .transfer-card__categories {
@@ -456,7 +479,7 @@
     margin: 0;
     display: flex;
     flex-wrap: wrap;
-    gap: 0.4rem;
+    gap: 0.3rem;
     justify-content: flex-end;
     min-width: 0;
   }
@@ -467,24 +490,13 @@
 
   .app-badge {
     display: inline-block;
-    padding: 0.15rem 0.5rem;
+    padding: 0.06rem 0.45rem;
     font-size: 0.75rem;
+    line-height: 1.2;
     border-radius: 999px;
     background: color-mix(in srgb, var(--text-secondary) 15%, transparent);
     color: var(--text-primary);
     overflow-wrap: anywhere;
-  }
-
-  .transfer-card__buyplace {
-    flex-basis: 100%;
-    margin: 0;
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-    overflow-wrap: anywhere;
-  }
-
-  .transfer-card__buyplace span {
-    font-weight: 600;
   }
 
   @media (max-width: 380px) {

--- a/src/features/app-shell/routes/TransfersRoute.test.ts
+++ b/src/features/app-shell/routes/TransfersRoute.test.ts
@@ -89,8 +89,8 @@ describe('TransfersRoute', () => {
 
     expect(body).toContain('AUSGABEN');
     expect(body).toContain('EINNAHMEN');
-    expect(body).toContain('Ort:');
-    expect(body).toContain('Local Market');
+    expect(body.indexOf('(Local Market)')).toBeLessThan(body.indexOf('Test Transfer'));
+    expect(body).not.toContain('Ort:');
     expect(body).not.toContain('Original From Name');
     expect(body).not.toContain('Original To Name');
   });

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -22,7 +22,9 @@
   "transfers": {
     "title": "Transfers",
     "previousMonth": "Vorheriger Monat",
+    "previousMonthButton": "‹",
     "nextMonth": "Nächster Monat",
+    "nextMonthButton": "›",
     "swipeArea": "Wischbereich für Transfermonate",
     "loading": "Transfers werden geladen...",
     "errorDefault": "Fehler beim Laden der Transfers.",
@@ -31,7 +33,7 @@
     "emptyBox": "Es gibt keine Transfers für diesen Monat.",
     "primaryIncome": "EINNAHMEN",
     "primarySpendings": "AUSGABEN",
-    "buyplace": "Ort"
+    "buyplace": "Geschäft"
   },
   "settings": {
     "title": "Einstellungen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -22,7 +22,9 @@
   "transfers": {
     "title": "Transfers",
     "previousMonth": "Previous month",
+    "previousMonthButton": "‹",
     "nextMonth": "Next month",
+    "nextMonthButton": "›",
     "swipeArea": "Transfer month swipe area",
     "loading": "Loading transfers...",
     "errorDefault": "Failed to load transfers.",
@@ -31,7 +33,7 @@
     "emptyBox": "There are no transfers recorded for this month.",
     "primaryIncome": "INCOME",
     "primarySpendings": "SPENDINGS",
-    "buyplace": "Place"
+    "buyplace": "Store"
   },
   "settings": {
     "title": "Settings",


### PR DESCRIPTION
## Summary

Follow-up refinement for `M5-10` transfer read-flow polish.

- Compacts transfer cards and reduces vertical spacing around the account/category row.
- Renders buyplace inline before the transfer title as `({buyplace}) {title}`.
- Keeps buyplace text visually aligned with the title color.
- Makes previous/next month buttons compact square controls and sources their visible glyphs from i18n.
- Includes the prompt-template wording edits that were already present in the local worktree, per request to commit all uncommitted changes.

## Verification

- `npm run format` - passed
- `npm run lint` - passed
- `npm run typecheck` - passed
- `npm run test` - passed
- `npm run build` - passed with existing Vite large chunk warning
- `npm run test:e2e` - passed (`86` tests)
