### PR TITLE
feat: [M6-01] Add transfer bottom sheet form

### DIFF
--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -447,7 +447,7 @@ An issue is only considered done when:
 - Depends on: `M5-06, M5-07, M5-08, M5-09`
 - GitHub: [#174](https://github.com/Jon2050/Conspectus-Mobile/issues/174)
 
-### :green_circle: M6-01 Build Add Transfer form UI (bottom sheet)
+### :white_check_mark: M6-01 Build Add Transfer form UI (bottom sheet)
 
 - Label: `feature`
 - Milestone: `M6 - Add Transfer Write Path`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.5.10",
+  "version": "0.6.01",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.5.10",
+      "version": "0.6.01",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.5.10",
+  "version": "0.6.01",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/features/app-shell/components/BottomSheet.svelte
+++ b/src/features/app-shell/components/BottomSheet.svelte
@@ -100,7 +100,7 @@
     box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
     display: flex;
     flex-direction: column;
-    max-height: 90vh;
+    max-height: min(90dvh, 90vh);
   }
 
   .bottom-sheet__dialog::backdrop {

--- a/src/features/app-shell/routes/AddRoute.svelte
+++ b/src/features/app-shell/routes/AddRoute.svelte
@@ -1,4 +1,329 @@
-<section class="placeholder-screen" data-testid="route-add">
-  <h2>Add</h2>
-  <p>Add route placeholder for transfer creation form and validation states.</p>
+<!-- Renders the Add Transfer bottom-sheet form with all MVP fields for mobile data entry. -->
+<script lang="ts">
+  import { _ } from 'svelte-i18n';
+  import BottomSheet from '../components/BottomSheet.svelte';
+  import {
+    createInitialFormFields,
+    NO_CATEGORY_SELECTED,
+    type AddTransferAccountOption,
+    type AddTransferCategoryOption,
+    type AddTransferFormFields,
+  } from './addTransferFormState';
+
+  export let fromAccountOptions: readonly AddTransferAccountOption[] = [];
+  export let toAccountOptions: readonly AddTransferAccountOption[] = [];
+  export let categoryOptions: readonly AddTransferCategoryOption[] = [];
+  export let fields: AddTransferFormFields = createInitialFormFields();
+  export let isSubmitting = false;
+  export let formError: string | null = null;
+
+  let isOpen = true;
+
+  const navIconBaseUrl = import.meta.env.BASE_URL;
+  const categoryIconUrl = `${navIconBaseUrl}icons/category_55.png`;
+
+  const handleClose = (): void => {
+    isOpen = false;
+    if (typeof window !== 'undefined') {
+      window.location.hash = '#/transfers';
+    }
+  };
+
+  const handleReopen = (): void => {
+    fields = createInitialFormFields();
+    isOpen = true;
+  };
+</script>
+
+<section class="add-route" data-testid="route-add">
+  {#if !isOpen}
+    <div class="add-route__closed" data-testid="add-route-closed">
+      <p>{$_('addTransfer.title')}</p>
+      <button
+        type="button"
+        class="app-button app-button--primary"
+        data-testid="add-route-reopen-button"
+        on:click={handleReopen}>{$_('addTransfer.submit')}</button
+      >
+    </div>
+  {/if}
+
+  <BottomSheet {isOpen} title={$_('addTransfer.title')} on:close={handleClose}>
+    <form
+      class="add-transfer-form"
+      data-testid="add-transfer-form"
+      aria-busy={isSubmitting}
+      on:submit|preventDefault
+    >
+      {#if formError !== null}
+        <p class="add-transfer-form__error" role="alert" data-testid="add-transfer-form-error">
+          {formError}
+        </p>
+      {/if}
+
+      <div class="add-transfer-form__field">
+        <label class="add-transfer-form__label" for="add-transfer-date"
+          >{$_('addTransfer.date')}</label
+        >
+        <input
+          id="add-transfer-date"
+          type="date"
+          class="app-input"
+          data-testid="add-transfer-date"
+          bind:value={fields.date}
+          disabled={isSubmitting}
+        />
+      </div>
+
+      <div class="add-transfer-form__field">
+        <label class="add-transfer-form__label" for="add-transfer-name"
+          >{$_('addTransfer.name')}</label
+        >
+        <input
+          id="add-transfer-name"
+          type="text"
+          class="app-input"
+          data-testid="add-transfer-name"
+          placeholder={$_('addTransfer.namePlaceholder')}
+          bind:value={fields.name}
+          disabled={isSubmitting}
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="add-transfer-form__field">
+        <label class="add-transfer-form__label" for="add-transfer-amount"
+          >{$_('addTransfer.amount')}</label
+        >
+        <input
+          id="add-transfer-amount"
+          type="text"
+          inputmode="decimal"
+          class="app-input"
+          data-testid="add-transfer-amount"
+          placeholder={$_('addTransfer.amountPlaceholder')}
+          bind:value={fields.amount}
+          disabled={isSubmitting}
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="add-transfer-form__field">
+        <label class="add-transfer-form__label" for="add-transfer-from-account"
+          >{$_('addTransfer.fromAccount')}</label
+        >
+        <select
+          id="add-transfer-from-account"
+          class="app-input"
+          data-testid="add-transfer-from-account"
+          bind:value={fields.fromAccountId}
+          disabled={isSubmitting}
+        >
+          <option value={null}>{$_('addTransfer.fromAccountPlaceholder')}</option>
+          {#each fromAccountOptions as account (account.accountId)}
+            <option value={account.accountId}>{account.name}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="add-transfer-form__field">
+        <label class="add-transfer-form__label" for="add-transfer-to-account"
+          >{$_('addTransfer.toAccount')}</label
+        >
+        <select
+          id="add-transfer-to-account"
+          class="app-input"
+          data-testid="add-transfer-to-account"
+          bind:value={fields.toAccountId}
+          disabled={isSubmitting}
+        >
+          <option value={null}>{$_('addTransfer.toAccountPlaceholder')}</option>
+          {#each toAccountOptions as account (account.accountId)}
+            <option value={account.accountId}>{account.name}</option>
+          {/each}
+        </select>
+      </div>
+
+      <div class="add-transfer-form__field">
+        <div class="add-transfer-form__label-row">
+          <img
+            class="add-transfer-form__category-icon"
+            src={categoryIconUrl}
+            alt=""
+            aria-hidden="true"
+            width="20"
+            height="20"
+          />
+          <label class="add-transfer-form__label" for="add-transfer-category-1"
+            >{$_('addTransfer.categories')}</label
+          >
+        </div>
+        <div class="add-transfer-form__category-selects">
+          <select
+            id="add-transfer-category-1"
+            class="app-input"
+            data-testid="add-transfer-category-1"
+            bind:value={fields.category1Id}
+            disabled={isSubmitting}
+          >
+            <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option>
+            {#each categoryOptions as cat (cat.categoryId)}
+              <option value={cat.categoryId}>{cat.name}</option>
+            {/each}
+          </select>
+          <select
+            id="add-transfer-category-2"
+            class="app-input"
+            data-testid="add-transfer-category-2"
+            bind:value={fields.category2Id}
+            disabled={isSubmitting}
+          >
+            <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option>
+            {#each categoryOptions as cat (cat.categoryId)}
+              <option value={cat.categoryId}>{cat.name}</option>
+            {/each}
+          </select>
+          <select
+            id="add-transfer-category-3"
+            class="app-input"
+            data-testid="add-transfer-category-3"
+            bind:value={fields.category3Id}
+            disabled={isSubmitting}
+          >
+            <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option>
+            {#each categoryOptions as cat (cat.categoryId)}
+              <option value={cat.categoryId}>{cat.name}</option>
+            {/each}
+          </select>
+        </div>
+      </div>
+
+      <div class="add-transfer-form__field">
+        <label class="add-transfer-form__label" for="add-transfer-buyplace"
+          >{$_('addTransfer.buyplace')}</label
+        >
+        <input
+          id="add-transfer-buyplace"
+          type="text"
+          class="app-input"
+          data-testid="add-transfer-buyplace"
+          placeholder={$_('addTransfer.buyplacePlaceholder')}
+          bind:value={fields.buyplace}
+          disabled={isSubmitting}
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="add-transfer-form__actions">
+        <button
+          type="button"
+          class="app-button app-button--secondary add-transfer-form__action"
+          data-testid="add-transfer-close"
+          disabled={isSubmitting}
+          on:click={handleClose}
+        >
+          {$_('addTransfer.close')}
+        </button>
+        <button
+          type="submit"
+          class="app-button app-button--primary add-transfer-form__action"
+          data-testid="add-transfer-submit"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? $_('addTransfer.saving') : $_('addTransfer.submit')}
+        </button>
+      </div>
+    </form>
+  </BottomSheet>
 </section>
+
+<style>
+  .add-route {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .add-route__closed {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 2rem 1rem;
+    border-radius: var(--radius-lg);
+    background: var(--surface-strong);
+    box-shadow: var(--shadow-sm);
+    text-align: center;
+  }
+
+  .add-route__closed p {
+    margin: 0;
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+
+  .add-transfer-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-bottom: 0.5rem;
+  }
+
+  .add-transfer-form__error {
+    margin: 0;
+    padding: 0.8rem 0.9rem;
+    border: 1px solid color-mix(in srgb, var(--error) 45%, transparent);
+    border-radius: var(--radius-md);
+    color: color-mix(in srgb, var(--error) 76%, black);
+    background: color-mix(in srgb, var(--error) 10%, var(--surface-strong));
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .add-transfer-form__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .add-transfer-form__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+
+  .add-transfer-form__label-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .add-transfer-form__category-icon {
+    flex: none;
+    object-fit: contain;
+    opacity: 0.7;
+  }
+
+  .add-transfer-form__category-selects {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .add-transfer-form__actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr);
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+  }
+
+  .add-transfer-form__action {
+    width: 100%;
+  }
+
+  @media (max-width: 360px) {
+    .add-transfer-form__actions {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/features/app-shell/routes/AddRoute.test.ts
+++ b/src/features/app-shell/routes/AddRoute.test.ts
@@ -1,0 +1,201 @@
+// Verifies the Add Transfer form renders all MVP fields with correct attributes and classes.
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+
+import AddRoute from './AddRoute.svelte';
+
+describe('AddRoute component', () => {
+  it('renders the route container with the add route testid', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="route-add"');
+  });
+
+  it('renders the bottom sheet dialog with the form title', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('<dialog');
+    expect(body).toContain('aria-modal="true"');
+  });
+
+  it('renders the add transfer form element', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="add-transfer-form"');
+    expect(body).toContain('<form');
+  });
+
+  it('renders the date field with app-input class', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="add-transfer-date"');
+    expect(body).toContain('type="date"');
+    expect(body).toMatch(/id="add-transfer-date"[^>]*class="app-input"/);
+  });
+
+  it('renders the name field with app-input class', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="add-transfer-name"');
+    expect(body).toContain('type="text"');
+    expect(body).toMatch(/id="add-transfer-name"[^>]*class="app-input"/);
+  });
+
+  it('renders the amount field with decimal inputmode and app-input class', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="add-transfer-amount"');
+    expect(body).toContain('inputmode="decimal"');
+    expect(body).toMatch(/id="add-transfer-amount"[^>]*class="app-input"/);
+  });
+
+  it('renders the from-account select with app-input class', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="add-transfer-from-account"');
+    expect(body).toMatch(/id="add-transfer-from-account"[^>]*class="app-input"/);
+  });
+
+  it('renders the to-account select with app-input class', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="add-transfer-to-account"');
+    expect(body).toMatch(/id="add-transfer-to-account"[^>]*class="app-input"/);
+  });
+
+  it('renders all three category selects with app-input class', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="add-transfer-category-1"');
+    expect(body).toContain('data-testid="add-transfer-category-2"');
+    expect(body).toContain('data-testid="add-transfer-category-3"');
+    expect(body).toMatch(/id="add-transfer-category-1"[^>]*class="app-input"/);
+    expect(body).toMatch(/id="add-transfer-category-2"[^>]*class="app-input"/);
+    expect(body).toMatch(/id="add-transfer-category-3"[^>]*class="app-input"/);
+  });
+
+  it('renders the buyplace field with app-input class', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="add-transfer-buyplace"');
+    expect(body).toMatch(/id="add-transfer-buyplace"[^>]*class="app-input"/);
+  });
+
+  it('renders the submit button with primary styling', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="add-transfer-submit"');
+    expect(body).toContain('app-button--primary');
+    expect(body).toContain('Transfer speichern');
+    expect(body).not.toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
+  });
+
+  it('renders a touch-friendly close action inside the sheet', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('data-testid="add-transfer-close"');
+    expect(body).toContain('app-button--secondary');
+    expect(body).toContain('Schließen');
+  });
+
+  it('renders the category icon affordance', () => {
+    const { body } = render(AddRoute);
+
+    expect(body).toContain('category_55.png');
+    expect(body).toMatch(/<img[^>]*category_55\.png/);
+  });
+
+  it('renders account select placeholder options when no options are provided', () => {
+    const { body } = render(AddRoute);
+
+    // Default empty options: only placeholder option should be rendered for each select
+    const fromSelectMatch = body.match(/data-testid="add-transfer-from-account"[\s\S]*?<\/select>/);
+    expect(fromSelectMatch).not.toBeNull();
+    expect(fromSelectMatch![0]).toContain('<option');
+
+    const toSelectMatch = body.match(/data-testid="add-transfer-to-account"[\s\S]*?<\/select>/);
+    expect(toSelectMatch).not.toBeNull();
+    expect(toSelectMatch![0]).toContain('<option');
+  });
+
+  it('renders provided account options in the from-account select', () => {
+    const { body } = render(AddRoute, {
+      props: {
+        fromAccountOptions: [
+          { accountId: 10, name: 'Checking' },
+          { accountId: 20, name: 'Savings' },
+        ],
+      },
+    });
+
+    expect(body).toContain('Checking');
+    expect(body).toContain('Savings');
+  });
+
+  it('renders provided category options in the category selects', () => {
+    const { body } = render(AddRoute, {
+      props: {
+        categoryOptions: [
+          { categoryId: 1, name: 'Food' },
+          { categoryId: 2, name: 'Travel' },
+        ],
+      },
+    });
+
+    // Each category option appears 3 times (once per select)
+    const foodMatches = body.match(/Food/g);
+    expect(foodMatches).not.toBeNull();
+    expect(foodMatches!.length).toBe(3);
+  });
+
+  it('uses app-input on every editable form control', () => {
+    const { body } = render(AddRoute);
+    const controlTestIds = [
+      'add-transfer-date',
+      'add-transfer-name',
+      'add-transfer-amount',
+      'add-transfer-from-account',
+      'add-transfer-to-account',
+      'add-transfer-category-1',
+      'add-transfer-category-2',
+      'add-transfer-category-3',
+      'add-transfer-buyplace',
+    ];
+
+    for (const testId of controlTestIds) {
+      const controlMatch = body.match(
+        new RegExp(`<(?:input|select)[^>]*data-testid="${testId}"[^>]*>`),
+      );
+      expect(controlMatch, `${testId} should render`).not.toBeNull();
+      expect(controlMatch![0], `${testId} should use app-input`).toContain('class="app-input"');
+    }
+  });
+
+  it('renders a form-level loading state and disables controls while submitting', () => {
+    const { body } = render(AddRoute, {
+      props: {
+        isSubmitting: true,
+      },
+    });
+
+    expect(body).toContain('aria-busy="true"');
+    expect(body).toContain('Transfer wird gespeichert...');
+    expect(body).toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
+    expect(body).toMatch(/data-testid="add-transfer-name"[^>]*disabled/);
+    expect(body).toMatch(/data-testid="add-transfer-buyplace"[^>]*disabled/);
+    expect(body).toMatch(/data-testid="add-transfer-close"[^>]*disabled/);
+  });
+
+  it('renders a form-level error without disabling normal editing', () => {
+    const { body } = render(AddRoute, {
+      props: {
+        formError: 'Unable to save the transfer yet.',
+      },
+    });
+
+    expect(body).toContain('data-testid="add-transfer-form-error"');
+    expect(body).toContain('role="alert"');
+    expect(body).toContain('Unable to save the transfer yet.');
+    expect(body).not.toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
+  });
+});

--- a/src/features/app-shell/routes/addTransferFormState.test.ts
+++ b/src/features/app-shell/routes/addTransferFormState.test.ts
@@ -1,0 +1,107 @@
+// Verifies form-state factory defaults, ISO date formatting, and epoch-day conversion logic.
+import { describe, expect, it } from 'vitest';
+
+import {
+  createInitialFormFields,
+  getTodayIsoDate,
+  isoDateToEpochDay,
+  NO_CATEGORY_SELECTED,
+} from './addTransferFormState';
+
+describe('addTransferFormState', () => {
+  describe('NO_CATEGORY_SELECTED', () => {
+    it('is a negative sentinel value', () => {
+      expect(NO_CATEGORY_SELECTED).toBe(-1);
+    });
+  });
+
+  describe('getTodayIsoDate', () => {
+    it('returns a date string matching YYYY-MM-DD format', () => {
+      const result = getTodayIsoDate();
+
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('returns a parseable date that represents today', () => {
+      const result = getTodayIsoDate();
+      const parsed = new Date(result + 'T00:00:00');
+      const now = new Date();
+
+      expect(parsed.getFullYear()).toBe(now.getFullYear());
+      expect(parsed.getMonth()).toBe(now.getMonth());
+      expect(parsed.getDate()).toBe(now.getDate());
+    });
+  });
+
+  describe('isoDateToEpochDay', () => {
+    it('converts the Unix epoch date (1970-01-01) to epoch day 0', () => {
+      expect(isoDateToEpochDay('1970-01-01')).toBe(0);
+    });
+
+    it('converts 2024-01-15 to the expected epoch day', () => {
+      // 2024-01-15 = 19,738 days since 1970-01-01
+      const result = isoDateToEpochDay('2024-01-15');
+      const expectedMs = Date.UTC(2024, 0, 15);
+      const expectedEpochDay = Math.floor(expectedMs / (24 * 60 * 60 * 1000));
+
+      expect(result).toBe(expectedEpochDay);
+    });
+
+    it('converts 2000-06-30 correctly', () => {
+      const result = isoDateToEpochDay('2000-06-30');
+      const expectedMs = Date.UTC(2000, 5, 30);
+      const expectedEpochDay = Math.floor(expectedMs / (24 * 60 * 60 * 1000));
+
+      expect(result).toBe(expectedEpochDay);
+    });
+  });
+
+  describe('createInitialFormFields', () => {
+    it('returns fields with today as the default date', () => {
+      const fields = createInitialFormFields();
+
+      expect(fields.date).toBe(getTodayIsoDate());
+    });
+
+    it('returns empty name', () => {
+      const fields = createInitialFormFields();
+
+      expect(fields.name).toBe('');
+    });
+
+    it('returns empty amount string', () => {
+      const fields = createInitialFormFields();
+
+      expect(fields.amount).toBe('');
+    });
+
+    it('returns null account selections', () => {
+      const fields = createInitialFormFields();
+
+      expect(fields.fromAccountId).toBeNull();
+      expect(fields.toAccountId).toBeNull();
+    });
+
+    it('returns NO_CATEGORY_SELECTED for all three categories', () => {
+      const fields = createInitialFormFields();
+
+      expect(fields.category1Id).toBe(NO_CATEGORY_SELECTED);
+      expect(fields.category2Id).toBe(NO_CATEGORY_SELECTED);
+      expect(fields.category3Id).toBe(NO_CATEGORY_SELECTED);
+    });
+
+    it('returns empty buyplace', () => {
+      const fields = createInitialFormFields();
+
+      expect(fields.buyplace).toBe('');
+    });
+
+    it('returns a new object on each call', () => {
+      const a = createInitialFormFields();
+      const b = createInitialFormFields();
+
+      expect(a).not.toBe(b);
+      expect(a).toEqual(b);
+    });
+  });
+});

--- a/src/features/app-shell/routes/addTransferFormState.ts
+++ b/src/features/app-shell/routes/addTransferFormState.ts
@@ -1,0 +1,65 @@
+// Defines the Add Transfer form field model, option shapes, and initial-state factory.
+// M6-01 scope: UI form shell only. Validation (M6-03) and submission (M6-05) are separate.
+import { MILLIS_PER_DAY } from '@shared';
+
+/** A selectable account option for the from/to dropdowns. */
+export interface AddTransferAccountOption {
+  readonly accountId: number;
+  readonly name: string;
+}
+
+/** A selectable category option for the category dropdowns. */
+export interface AddTransferCategoryOption {
+  readonly categoryId: number;
+  readonly name: string;
+}
+
+/** Sentinel value for "no category selected" in category dropdowns. */
+export const NO_CATEGORY_SELECTED = -1;
+
+/** Shape of form field values managed by the Add Transfer bottom sheet. */
+export interface AddTransferFormFields {
+  /** ISO date string (YYYY-MM-DD) for native date input binding. */
+  date: string;
+  name: string;
+  /** Raw amount string from the text input (parsed later in M6-03). */
+  amount: string;
+  fromAccountId: number | null;
+  toAccountId: number | null;
+  category1Id: number;
+  category2Id: number;
+  category3Id: number;
+  buyplace: string;
+}
+
+/** Returns today's date as an ISO date string (YYYY-MM-DD) in local time. */
+export const getTodayIsoDate = (): string => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+/** Converts an ISO date string (YYYY-MM-DD) to an epoch day number. */
+export const isoDateToEpochDay = (isoDate: string): number => {
+  const utcMs = Date.UTC(
+    Number(isoDate.slice(0, 4)),
+    Number(isoDate.slice(5, 7)) - 1,
+    Number(isoDate.slice(8, 10)),
+  );
+  return Math.floor(utcMs / MILLIS_PER_DAY);
+};
+
+/** Creates a fresh set of form field values defaulting to today's date. */
+export const createInitialFormFields = (): AddTransferFormFields => ({
+  date: getTodayIsoDate(),
+  name: '',
+  amount: '',
+  fromAccountId: null,
+  toAccountId: null,
+  category1Id: NO_CATEGORY_SELECTED,
+  category2Id: NO_CATEGORY_SELECTED,
+  category3Id: NO_CATEGORY_SELECTED,
+  buyplace: '',
+});

--- a/src/features/app-shell/routes/placeholderRoutes.test.ts
+++ b/src/features/app-shell/routes/placeholderRoutes.test.ts
@@ -2,28 +2,9 @@
 import { describe, expect, it } from 'vitest';
 import { render } from 'svelte/server';
 
-import AddRoute from './AddRoute.svelte';
 import SettingsRoute from './SettingsRoute.svelte';
 
 describe('route placeholder components', () => {
-  it.each([
-    {
-      component: AddRoute,
-      testId: 'route-add',
-      heading: 'Add',
-      bodyText: 'Add route placeholder for transfer creation form and validation states.',
-    },
-  ])(
-    'renders $testId with stable placeholder content',
-    ({ component, testId, heading, bodyText }) => {
-      const { body } = render(component);
-
-      expect(body).toContain(`data-testid="${testId}"`);
-      expect(body).toContain(`<h2>${heading}</h2>`);
-      expect(body).toContain(`<p>${bodyText}</p>`);
-    },
-  );
-
   it('renders settings route with sign-in controls and auth status messaging', () => {
     const { body } = render(SettingsRoute);
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -36,6 +36,25 @@
     "primarySpendings": "AUSGABEN",
     "buyplace": "Geschäft"
   },
+  "addTransfer": {
+    "title": "Neuer Transfer",
+    "date": "Datum",
+    "name": "Beschreibung",
+    "namePlaceholder": "z.B. Einkauf, Miete...",
+    "amount": "Betrag (€)",
+    "amountPlaceholder": "0,00",
+    "fromAccount": "Von Konto",
+    "fromAccountPlaceholder": "Quellkonto wählen",
+    "toAccount": "Auf Konto",
+    "toAccountPlaceholder": "Zielkonto wählen",
+    "categories": "Kategorien",
+    "categoryPlaceholder": "Keine Kategorie",
+    "buyplace": "Einkaufsort",
+    "buyplacePlaceholder": "z.B. Supermarkt...",
+    "submit": "Transfer speichern",
+    "saving": "Transfer wird gespeichert...",
+    "close": "Schließen"
+  },
   "settings": {
     "title": "Einstellungen",
     "description": "Authentifizierung für den OneDrive-Zugriff.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -36,6 +36,25 @@
     "primarySpendings": "SPENDINGS",
     "buyplace": "Store"
   },
+  "addTransfer": {
+    "title": "New Transfer",
+    "date": "Date",
+    "name": "Description",
+    "namePlaceholder": "e.g. Groceries, Rent...",
+    "amount": "Amount (€)",
+    "amountPlaceholder": "0.00",
+    "fromAccount": "From account",
+    "fromAccountPlaceholder": "Select source account",
+    "toAccount": "To account",
+    "toAccountPlaceholder": "Select destination account",
+    "categories": "Categories",
+    "categoryPlaceholder": "No category",
+    "buyplace": "Buyplace",
+    "buyplacePlaceholder": "e.g. Supermarket...",
+    "submit": "Save transfer",
+    "saving": "Saving transfer...",
+    "close": "Close"
+  },
   "settings": {
     "title": "Settings",
     "description": "Authentication controls for OneDrive account access.",

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -928,11 +928,53 @@ test('loads a mobile app shell and navigates primary routes', async ({ page }) =
 
   await page.getByRole('link', { name: 'Add' }).click();
   await expect(page).toHaveURL(/#\/add$/);
-  await expect(page.getByRole('heading', { level: 2, name: 'Add' })).toBeVisible();
+  await expect(page.getByRole('heading', { level: 3, name: 'New Transfer' })).toBeVisible();
 
+  await page.getByTestId('add-transfer-close').click();
+  await expect(page).toHaveURL(/#\/transfers$/);
   await page.getByRole('link', { name: 'Settings' }).click();
   await expect(page).toHaveURL(/#\/settings$/);
   await expect(page.getByRole('heading', { level: 2, name: 'Settings' })).toBeVisible();
+});
+
+test('renders an editable add transfer bottom sheet on mobile viewports', async ({ page }) => {
+  await page.goto(appPath('#/add'));
+
+  await expect(page.getByTestId('route-add')).toHaveCount(1);
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByRole('heading', { level: 3, name: 'New Transfer' })).toBeVisible();
+  await expect(page.getByTestId('add-transfer-form')).toBeVisible();
+
+  const editableControls = [
+    'add-transfer-date',
+    'add-transfer-name',
+    'add-transfer-amount',
+    'add-transfer-from-account',
+    'add-transfer-to-account',
+    'add-transfer-category-1',
+    'add-transfer-category-2',
+    'add-transfer-category-3',
+    'add-transfer-buyplace',
+  ];
+
+  for (const testId of editableControls) {
+    const control = page.getByTestId(testId);
+    await expect(control).toBeVisible();
+    await expect(control).toBeEnabled();
+    await expect(control).toHaveClass(/app-input/);
+  }
+
+  await page.getByTestId('add-transfer-date').fill('2024-04-15');
+  await page.getByTestId('add-transfer-name').fill('Groceries');
+  await page.getByTestId('add-transfer-amount').fill('12.34');
+  await page.getByTestId('add-transfer-buyplace').fill('Supermarket');
+
+  const submitButton = page.getByTestId('add-transfer-submit');
+  await expect(submitButton).toBeEnabled();
+  await expect(page.getByTestId('add-transfer-close')).toBeEnabled();
+  await submitButton.scrollIntoViewIfNeeded();
+  await expect(submitButton).toBeInViewport();
+  await expect(page.getByTestId('add-transfer-buyplace')).toHaveValue('Supermarket');
 });
 
 test('renders readable account cards with semantic amount styling on narrow mobile widths', async ({


### PR DESCRIPTION
## Summary

Closes #64.

Implements M6-01 Add Transfer form UI as a BottomSheet-based mobile form.

## Acceptance Criteria Mapping

- Form is usable on mobile screen sizes: implemented a scrollable bottom sheet layout with safe dynamic viewport height, touch-friendly actions, and E2E coverage on Chromium and Pixel 5.
- All MVP fields are present and editable: date, name, amount, from account, to account, three category selectors, and buyplace are rendered as editable controls.
- Icon affordances use repository assets: category affordance uses `public/icons/category_55.png` through the app base path.
- Advanced requirement: the form uses `<BottomSheet />`, and every editable input/select uses `.app-input`.
- Form states: added explicit form-level loading and error display hooks for later write-flow integration.

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run test:e2e`

All local verification gates passed before push.

## Notes

- Assumption: M6-01 is UI-only. Account/category option loading, validation, persistence, upload, retry, and offline write blocking remain in later M6 issues.
