### PR TITLE
docs: [M6-01] Document add transfer form scope

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -623,6 +623,12 @@ Substeps:
 9. Optional maintenance toggle:
    - run `VACUUM` every N writes or manual trigger in settings.
 
+M6-01 implementation clarification:
+
+- The Add Transfer route now renders the full MVP data-entry surface in `src/features/app-shell/routes/AddRoute.svelte` using the shared `BottomSheet` component.
+- The route owns only the UI shell and field state for M6-01: date, name, amount, source account, destination account, three category selectors, optional buyplace, form-level loading/error display, and a sheet-local close action.
+- Account/category option loading, desktop-parity validation, SQL writes, DB export/upload, retry/conflict handling, and offline write blocking remain scoped to the later M6 issues that already track those behaviors.
+
 Deliverables:
 
 - End-to-end write feature with clear success/error behavior.


### PR DESCRIPTION
## Summary

Follow-up completion item for M6-01 after #188.

Documents the implemented Add Transfer form UI boundary in the Milestone 6 section of the architecture plan.

## Scope

- Adds the M6-01 implementation clarification only.
- Records that option loading, validation, writes, upload, conflict/retry, and offline write blocking remain in later M6 issues.

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run test:e2e`

All local verification gates passed before push.
