### PR TITLE
feat: load account and category options reactively in add-transfer form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.6.01",
+  "version": "0.6.02",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.6.01",
+      "version": "0.6.02",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.6.01",
+  "version": "0.6.02",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/db/accountQueryService.test.ts
+++ b/src/db/accountQueryService.test.ts
@@ -148,6 +148,70 @@ describe('account query service', () => {
     runtime.close();
   });
 
+  it('returns add-transfer from-account options with primary income first', async () => {
+    const runtime = await createRuntimeWithFixtureRows([
+      {
+        accountId: 1,
+        name: 'Primary Income',
+        amountCents: 0,
+        acOrder: 99,
+        acTypeId: 1,
+        visible: 0,
+      },
+      {
+        accountId: 2,
+        name: 'Primary Spendings',
+        amountCents: 0,
+        acOrder: 0,
+        acTypeId: 2,
+        visible: 1,
+      },
+      { accountId: 3, name: 'Wallet', amountCents: 500, acOrder: 2, acTypeId: 3, visible: 1 },
+      { accountId: 4, name: 'Checking', amountCents: 700, acOrder: 1, acTypeId: 3, visible: 1 },
+      { accountId: 5, name: 'Hidden', amountCents: 900, acOrder: 1, acTypeId: 3, visible: 0 },
+    ]);
+    const service = createAccountQueryService(runtime);
+
+    expect(service.listAddTransferFromAccountOptions()).toEqual([
+      { accountId: 1, name: 'Primary Income', amountCents: 0, accountTypeId: 1 },
+      { accountId: 4, name: 'Checking', amountCents: 700, accountTypeId: 3 },
+      { accountId: 3, name: 'Wallet', amountCents: 500, accountTypeId: 3 },
+    ]);
+    runtime.close();
+  });
+
+  it('returns add-transfer to-account options with primary spendings first', async () => {
+    const runtime = await createRuntimeWithFixtureRows([
+      {
+        accountId: 1,
+        name: 'Primary Income',
+        amountCents: 0,
+        acOrder: 0,
+        acTypeId: 1,
+        visible: 1,
+      },
+      {
+        accountId: 2,
+        name: 'Primary Spendings',
+        amountCents: 0,
+        acOrder: 99,
+        acTypeId: 2,
+        visible: 0,
+      },
+      { accountId: 3, name: 'Wallet', amountCents: 500, acOrder: 2, acTypeId: 3, visible: 1 },
+      { accountId: 4, name: 'Checking', amountCents: 700, acOrder: 1, acTypeId: 3, visible: 1 },
+      { accountId: 5, name: 'Hidden', amountCents: 900, acOrder: 1, acTypeId: 3, visible: 0 },
+    ]);
+    const service = createAccountQueryService(runtime);
+
+    expect(service.listAddTransferToAccountOptions()).toEqual([
+      { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+      { accountId: 4, name: 'Checking', amountCents: 700, accountTypeId: 3 },
+      { accountId: 3, name: 'Wallet', amountCents: 500, accountTypeId: 3 },
+    ]);
+    runtime.close();
+  });
+
   it('resolves a runtime provider on each service call', () => {
     const firstRuntime = {
       exec: vi.fn(() => [

--- a/src/db/accountQueryService.ts
+++ b/src/db/accountQueryService.ts
@@ -19,6 +19,28 @@ const ALL_ACCOUNTS_SQL = `
   ORDER BY account_id ASC;
 `;
 
+const ADD_TRANSFER_FROM_ACCOUNT_OPTIONS_SQL = `
+  SELECT account_id, name, amount, ac_type_id
+  FROM account
+  WHERE (visible = 1 AND ac_type_id NOT IN (1, 2))
+    OR ac_type_id = 1
+  ORDER BY CASE WHEN ac_type_id = 1 THEN 0 ELSE 1 END,
+    ac_order ASC,
+    LOWER(name) ASC,
+    account_id ASC;
+`;
+
+const ADD_TRANSFER_TO_ACCOUNT_OPTIONS_SQL = `
+  SELECT account_id, name, amount, ac_type_id
+  FROM account
+  WHERE (visible = 1 AND ac_type_id NOT IN (1, 2))
+    OR ac_type_id = 2
+  ORDER BY CASE WHEN ac_type_id = 2 THEN 0 ELSE 1 END,
+    ac_order ASC,
+    LOWER(name) ASC,
+    account_id ASC;
+`;
+
 const ACCOUNT_RESULT_COLUMNS = ['account_id', 'name', 'amount', 'ac_type_id'] as const;
 
 const hasExpectedColumns = (columns: readonly string[]): boolean =>
@@ -91,6 +113,8 @@ const mapAccountQueryResult = (results: readonly QueryExecResult[]): readonly Ac
 export interface AccountQueryService {
   listVisibleNonPrimaryAccounts(): readonly AccountRecord[];
   listAllAccounts(): readonly AccountRecord[];
+  listAddTransferFromAccountOptions(): readonly AccountRecord[];
+  listAddTransferToAccountOptions(): readonly AccountRecord[];
 }
 
 type AccountQueryRuntime = Pick<BrowserDbRuntime, 'exec'>;
@@ -124,6 +148,36 @@ export const createAccountQueryService = (
         error,
         'db_query_failed',
         'Failed to load all accounts from the local SQLite database.',
+      );
+    }
+  },
+
+  listAddTransferFromAccountOptions(): readonly AccountRecord[] {
+    try {
+      const results = resolveAccountQueryRuntime(dbRuntime).exec(
+        ADD_TRANSFER_FROM_ACCOUNT_OPTIONS_SQL,
+      );
+      return mapAccountQueryResult(results);
+    } catch (error) {
+      throw toDbRuntimeError(
+        error,
+        'db_query_failed',
+        'Failed to load add-transfer source account options from the local SQLite database.',
+      );
+    }
+  },
+
+  listAddTransferToAccountOptions(): readonly AccountRecord[] {
+    try {
+      const results = resolveAccountQueryRuntime(dbRuntime).exec(
+        ADD_TRANSFER_TO_ACCOUNT_OPTIONS_SQL,
+      );
+      return mapAccountQueryResult(results);
+    } catch (error) {
+      throw toDbRuntimeError(
+        error,
+        'db_query_failed',
+        'Failed to load add-transfer destination account options from the local SQLite database.',
       );
     }
   },

--- a/src/db/categoryQueryService.test.ts
+++ b/src/db/categoryQueryService.test.ts
@@ -49,6 +49,15 @@ describe('createCategoryQueryService', () => {
     ]);
   });
 
+  it('requests categories in case-insensitive name order', () => {
+    const exec = vi.fn(() => [] as readonly QueryExecResult[]);
+    const service = createCategoryQueryService({ exec });
+
+    service.listAllCategories();
+
+    expect(exec).toHaveBeenCalledWith(expect.stringContaining('ORDER BY LOWER(name) ASC'));
+  });
+
   it('resolves a runtime provider on each service call', () => {
     const firstRuntime = {
       exec: vi.fn(() => [

--- a/src/features/app-shell/routes/AddRoute.svelte
+++ b/src/features/app-shell/routes/AddRoute.svelte
@@ -1,26 +1,53 @@
 <!-- Renders the Add Transfer bottom-sheet form with all MVP fields for mobile data entry. -->
 <script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
   import { _ } from 'svelte-i18n';
+  import { appAccountQueryService, appCategoryQueryService } from '@db';
+  import { appSyncStateStore, type SyncState, type SyncStateStore } from '@shared';
   import BottomSheet from '../components/BottomSheet.svelte';
   import {
     createInitialFormFields,
     NO_CATEGORY_SELECTED,
-    type AddTransferAccountOption,
-    type AddTransferCategoryOption,
     type AddTransferFormFields,
   } from './addTransferFormState';
+  import {
+    createAddTransferOptionsController,
+    shouldReloadAddTransferOptionsForSyncState,
+    type AddTransferOptionsController,
+    type AddTransferOptionsState,
+  } from './addTransferOptionsController';
 
-  export let fromAccountOptions: readonly AddTransferAccountOption[] = [];
-  export let toAccountOptions: readonly AddTransferAccountOption[] = [];
-  export let categoryOptions: readonly AddTransferCategoryOption[] = [];
+  export let controller: AddTransferOptionsController = createAddTransferOptionsController(
+    appAccountQueryService,
+    appCategoryQueryService,
+  );
   export let fields: AddTransferFormFields = createInitialFormFields();
   export let isSubmitting = false;
   export let formError: string | null = null;
+  export let syncStateStore: SyncStateStore = appSyncStateStore;
 
   let isOpen = true;
+  let optionsState: AddTransferOptionsState = controller.getState();
+  let lastObservedSyncState: SyncState = 'idle';
+  $: isOptionsLoading = optionsState.operation === 'loading';
+  $: effectiveFormError = formError ?? optionsState.error?.message ?? null;
+  $: controlsAreDisabled = isSubmitting || isOptionsLoading;
 
   const navIconBaseUrl = import.meta.env.BASE_URL;
   const categoryIconUrl = `${navIconBaseUrl}icons/category_55.png`;
+  const unsubscribeController = controller.subscribe((nextState) => {
+    optionsState = nextState;
+  });
+  const unsubscribeSyncState = syncStateStore.subscribe((syncSnapshot) => {
+    if (syncSnapshot.state === lastObservedSyncState) {
+      return;
+    }
+
+    lastObservedSyncState = syncSnapshot.state;
+    if (shouldReloadAddTransferOptionsForSyncState(syncSnapshot.state)) {
+      void controller.load();
+    }
+  });
 
   const handleClose = (): void => {
     isOpen = false;
@@ -33,6 +60,15 @@
     fields = createInitialFormFields();
     isOpen = true;
   };
+
+  onMount(() => {
+    void controller.load();
+  });
+
+  onDestroy(() => {
+    unsubscribeController();
+    unsubscribeSyncState();
+  });
 </script>
 
 <section class="add-route" data-testid="route-add">
@@ -52,12 +88,18 @@
     <form
       class="add-transfer-form"
       data-testid="add-transfer-form"
-      aria-busy={isSubmitting}
+      aria-busy={isSubmitting || isOptionsLoading}
       on:submit|preventDefault
     >
-      {#if formError !== null}
+      {#if isOptionsLoading}
+        <p class="add-transfer-form__status" data-testid="add-transfer-options-loading">
+          {$_('addTransfer.loadingOptions')}
+        </p>
+      {/if}
+
+      {#if effectiveFormError !== null}
         <p class="add-transfer-form__error" role="alert" data-testid="add-transfer-form-error">
-          {formError}
+          {effectiveFormError}
         </p>
       {/if}
 
@@ -71,7 +113,7 @@
           class="app-input"
           data-testid="add-transfer-date"
           bind:value={fields.date}
-          disabled={isSubmitting}
+          disabled={controlsAreDisabled}
         />
       </div>
 
@@ -86,7 +128,7 @@
           data-testid="add-transfer-name"
           placeholder={$_('addTransfer.namePlaceholder')}
           bind:value={fields.name}
-          disabled={isSubmitting}
+          disabled={controlsAreDisabled}
           autocomplete="off"
         />
       </div>
@@ -103,7 +145,7 @@
           data-testid="add-transfer-amount"
           placeholder={$_('addTransfer.amountPlaceholder')}
           bind:value={fields.amount}
-          disabled={isSubmitting}
+          disabled={controlsAreDisabled}
           autocomplete="off"
         />
       </div>
@@ -117,10 +159,10 @@
           class="app-input"
           data-testid="add-transfer-from-account"
           bind:value={fields.fromAccountId}
-          disabled={isSubmitting}
+          disabled={controlsAreDisabled}
         >
           <option value={null}>{$_('addTransfer.fromAccountPlaceholder')}</option>
-          {#each fromAccountOptions as account (account.accountId)}
+          {#each optionsState.fromAccountOptions as account (account.accountId)}
             <option value={account.accountId}>{account.name}</option>
           {/each}
         </select>
@@ -135,10 +177,10 @@
           class="app-input"
           data-testid="add-transfer-to-account"
           bind:value={fields.toAccountId}
-          disabled={isSubmitting}
+          disabled={controlsAreDisabled}
         >
           <option value={null}>{$_('addTransfer.toAccountPlaceholder')}</option>
-          {#each toAccountOptions as account (account.accountId)}
+          {#each optionsState.toAccountOptions as account (account.accountId)}
             <option value={account.accountId}>{account.name}</option>
           {/each}
         </select>
@@ -164,10 +206,10 @@
             class="app-input"
             data-testid="add-transfer-category-1"
             bind:value={fields.category1Id}
-            disabled={isSubmitting}
+            disabled={controlsAreDisabled}
           >
             <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option>
-            {#each categoryOptions as cat (cat.categoryId)}
+            {#each optionsState.categoryOptions as cat (cat.categoryId)}
               <option value={cat.categoryId}>{cat.name}</option>
             {/each}
           </select>
@@ -176,10 +218,10 @@
             class="app-input"
             data-testid="add-transfer-category-2"
             bind:value={fields.category2Id}
-            disabled={isSubmitting}
+            disabled={controlsAreDisabled}
           >
             <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option>
-            {#each categoryOptions as cat (cat.categoryId)}
+            {#each optionsState.categoryOptions as cat (cat.categoryId)}
               <option value={cat.categoryId}>{cat.name}</option>
             {/each}
           </select>
@@ -188,10 +230,10 @@
             class="app-input"
             data-testid="add-transfer-category-3"
             bind:value={fields.category3Id}
-            disabled={isSubmitting}
+            disabled={controlsAreDisabled}
           >
             <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option>
-            {#each categoryOptions as cat (cat.categoryId)}
+            {#each optionsState.categoryOptions as cat (cat.categoryId)}
               <option value={cat.categoryId}>{cat.name}</option>
             {/each}
           </select>
@@ -209,7 +251,7 @@
           data-testid="add-transfer-buyplace"
           placeholder={$_('addTransfer.buyplacePlaceholder')}
           bind:value={fields.buyplace}
-          disabled={isSubmitting}
+          disabled={controlsAreDisabled}
           autocomplete="off"
         />
       </div>
@@ -228,7 +270,7 @@
           type="submit"
           class="app-button app-button--primary add-transfer-form__action"
           data-testid="add-transfer-submit"
-          disabled={isSubmitting}
+          disabled={controlsAreDisabled}
         >
           {isSubmitting ? $_('addTransfer.saving') : $_('addTransfer.submit')}
         </button>
@@ -276,6 +318,13 @@
     border-radius: var(--radius-md);
     color: color-mix(in srgb, var(--error) 76%, black);
     background: color-mix(in srgb, var(--error) 10%, var(--surface-strong));
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .add-transfer-form__status {
+    margin: 0;
+    color: var(--text-secondary);
     font-size: 0.9rem;
     font-weight: 600;
   }

--- a/src/features/app-shell/routes/AddRoute.test.ts
+++ b/src/features/app-shell/routes/AddRoute.test.ts
@@ -3,30 +3,61 @@ import { describe, expect, it } from 'vitest';
 import { render } from 'svelte/server';
 
 import AddRoute from './AddRoute.svelte';
+import type {
+  AddTransferOptionsController,
+  AddTransferOptionsState,
+} from './addTransferOptionsController';
+
+const READY_OPTIONS_STATE: AddTransferOptionsState = {
+  operation: 'ready',
+  fromAccountOptions: [],
+  toAccountOptions: [],
+  categoryOptions: [],
+  error: null,
+};
+
+const createMockOptionsController = (
+  state: AddTransferOptionsState = READY_OPTIONS_STATE,
+): AddTransferOptionsController => ({
+  getState: () => state,
+  subscribe: (listener) => {
+    listener(state);
+    return () => {};
+  },
+  load: async () => {},
+});
+
+const renderAddRoute = (props: Record<string, unknown> = {}) =>
+  render(AddRoute, {
+    props: {
+      controller: createMockOptionsController(),
+      ...props,
+    },
+  });
 
 describe('AddRoute component', () => {
   it('renders the route container with the add route testid', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="route-add"');
   });
 
   it('renders the bottom sheet dialog with the form title', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('<dialog');
     expect(body).toContain('aria-modal="true"');
   });
 
   it('renders the add transfer form element', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="add-transfer-form"');
     expect(body).toContain('<form');
   });
 
   it('renders the date field with app-input class', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="add-transfer-date"');
     expect(body).toContain('type="date"');
@@ -34,7 +65,7 @@ describe('AddRoute component', () => {
   });
 
   it('renders the name field with app-input class', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="add-transfer-name"');
     expect(body).toContain('type="text"');
@@ -42,7 +73,7 @@ describe('AddRoute component', () => {
   });
 
   it('renders the amount field with decimal inputmode and app-input class', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="add-transfer-amount"');
     expect(body).toContain('inputmode="decimal"');
@@ -50,21 +81,21 @@ describe('AddRoute component', () => {
   });
 
   it('renders the from-account select with app-input class', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="add-transfer-from-account"');
     expect(body).toMatch(/id="add-transfer-from-account"[^>]*class="app-input"/);
   });
 
   it('renders the to-account select with app-input class', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="add-transfer-to-account"');
     expect(body).toMatch(/id="add-transfer-to-account"[^>]*class="app-input"/);
   });
 
   it('renders all three category selects with app-input class', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="add-transfer-category-1"');
     expect(body).toContain('data-testid="add-transfer-category-2"');
@@ -75,14 +106,14 @@ describe('AddRoute component', () => {
   });
 
   it('renders the buyplace field with app-input class', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="add-transfer-buyplace"');
     expect(body).toMatch(/id="add-transfer-buyplace"[^>]*class="app-input"/);
   });
 
   it('renders the submit button with primary styling', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="add-transfer-submit"');
     expect(body).toContain('app-button--primary');
@@ -91,7 +122,7 @@ describe('AddRoute component', () => {
   });
 
   it('renders a touch-friendly close action inside the sheet', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('data-testid="add-transfer-close"');
     expect(body).toContain('app-button--secondary');
@@ -99,14 +130,14 @@ describe('AddRoute component', () => {
   });
 
   it('renders the category icon affordance', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     expect(body).toContain('category_55.png');
     expect(body).toMatch(/<img[^>]*category_55\.png/);
   });
 
   it('renders account select placeholder options when no options are provided', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
 
     // Default empty options: only placeholder option should be rendered for each select
     const fromSelectMatch = body.match(/data-testid="add-transfer-from-account"[\s\S]*?<\/select>/);
@@ -119,27 +150,46 @@ describe('AddRoute component', () => {
   });
 
   it('renders provided account options in the from-account select', () => {
-    const { body } = render(AddRoute, {
-      props: {
+    const { body } = renderAddRoute({
+      controller: createMockOptionsController({
+        ...READY_OPTIONS_STATE,
         fromAccountOptions: [
           { accountId: 10, name: 'Checking' },
           { accountId: 20, name: 'Savings' },
         ],
-      },
+      }),
     });
 
     expect(body).toContain('Checking');
     expect(body).toContain('Savings');
   });
 
+  it('renders provided account options in the to-account select', () => {
+    const { body } = renderAddRoute({
+      controller: createMockOptionsController({
+        ...READY_OPTIONS_STATE,
+        toAccountOptions: [
+          { accountId: 30, name: 'Credit Card' },
+          { accountId: 40, name: 'Savings' },
+        ],
+      }),
+    });
+
+    const toSelectMatch = body.match(/data-testid="add-transfer-to-account"[\s\S]*?<\/select>/);
+    expect(toSelectMatch).not.toBeNull();
+    expect(toSelectMatch![0]).toContain('Credit Card');
+    expect(toSelectMatch![0]).toContain('Savings');
+  });
+
   it('renders provided category options in the category selects', () => {
-    const { body } = render(AddRoute, {
-      props: {
+    const { body } = renderAddRoute({
+      controller: createMockOptionsController({
+        ...READY_OPTIONS_STATE,
         categoryOptions: [
           { categoryId: 1, name: 'Food' },
           { categoryId: 2, name: 'Travel' },
         ],
-      },
+      }),
     });
 
     // Each category option appears 3 times (once per select)
@@ -148,8 +198,17 @@ describe('AddRoute component', () => {
     expect(foodMatches!.length).toBe(3);
   });
 
+  it('renders a no-category sentinel option in all three category selects', () => {
+    const { body } = renderAddRoute();
+
+    const placeholderMatches = body.match(/Keine Kategorie/g);
+
+    expect(placeholderMatches).not.toBeNull();
+    expect(placeholderMatches!.length).toBe(3);
+  });
+
   it('uses app-input on every editable form control', () => {
-    const { body } = render(AddRoute);
+    const { body } = renderAddRoute();
     const controlTestIds = [
       'add-transfer-date',
       'add-transfer-name',
@@ -172,10 +231,8 @@ describe('AddRoute component', () => {
   });
 
   it('renders a form-level loading state and disables controls while submitting', () => {
-    const { body } = render(AddRoute, {
-      props: {
-        isSubmitting: true,
-      },
+    const { body } = renderAddRoute({
+      isSubmitting: true,
     });
 
     expect(body).toContain('aria-busy="true"');
@@ -187,15 +244,41 @@ describe('AddRoute component', () => {
   });
 
   it('renders a form-level error without disabling normal editing', () => {
-    const { body } = render(AddRoute, {
-      props: {
-        formError: 'Unable to save the transfer yet.',
-      },
+    const { body } = renderAddRoute({
+      formError: 'Unable to save the transfer yet.',
     });
 
     expect(body).toContain('data-testid="add-transfer-form-error"');
     expect(body).toContain('role="alert"');
     expect(body).toContain('Unable to save the transfer yet.');
+    expect(body).not.toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
+  });
+
+  it('renders option loading status and disables editing while options load', () => {
+    const { body } = renderAddRoute({
+      controller: createMockOptionsController({
+        ...READY_OPTIONS_STATE,
+        operation: 'loading',
+      }),
+    });
+
+    expect(body).toContain('data-testid="add-transfer-options-loading"');
+    expect(body).toContain('Konten und Kategorien werden geladen...');
+    expect(body).toContain('aria-busy="true"');
+    expect(body).toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
+  });
+
+  it('renders option loading errors without disabling editing', () => {
+    const { body } = renderAddRoute({
+      controller: createMockOptionsController({
+        ...READY_OPTIONS_STATE,
+        operation: 'error',
+        error: { message: 'Failed to load options.' },
+      }),
+    });
+
+    expect(body).toContain('data-testid="add-transfer-form-error"');
+    expect(body).toContain('Failed to load options.');
     expect(body).not.toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
   });
 });

--- a/src/features/app-shell/routes/addTransferOptionsController.test.ts
+++ b/src/features/app-shell/routes/addTransferOptionsController.test.ts
@@ -1,0 +1,102 @@
+// Verifies Add Transfer option loading, mapping, and DB-not-ready behavior.
+import { describe, expect, it, vi } from 'vitest';
+import { DbRuntimeError } from '@db';
+
+import {
+  createAddTransferOptionsController,
+  shouldReloadAddTransferOptionsForSyncState,
+} from './addTransferOptionsController';
+
+describe('createAddTransferOptionsController', () => {
+  it('loads and maps account and category options', async () => {
+    const listAddTransferFromAccountOptions = vi.fn(() => [
+      { accountId: 1, name: 'Income', amountCents: 0, accountTypeId: 1 },
+      { accountId: 10, name: 'Cash', amountCents: 500, accountTypeId: 3 },
+    ]);
+    const listAddTransferToAccountOptions = vi.fn(() => [
+      { accountId: 2, name: 'Spendings', amountCents: 0, accountTypeId: 2 },
+      { accountId: 10, name: 'Cash', amountCents: 500, accountTypeId: 3 },
+    ]);
+    const listAllCategories = vi.fn(() => [
+      { categoryId: 20, name: 'Groceries' },
+      { categoryId: 30, name: 'Rent' },
+    ]);
+    const controller = createAddTransferOptionsController(
+      { listAddTransferFromAccountOptions, listAddTransferToAccountOptions },
+      { listAllCategories },
+    );
+
+    await controller.load();
+
+    expect(controller.getState()).toEqual({
+      operation: 'ready',
+      fromAccountOptions: [
+        { accountId: 1, name: 'Income' },
+        { accountId: 10, name: 'Cash' },
+      ],
+      toAccountOptions: [
+        { accountId: 2, name: 'Spendings' },
+        { accountId: 10, name: 'Cash' },
+      ],
+      categoryOptions: [
+        { categoryId: 20, name: 'Groceries' },
+        { categoryId: 30, name: 'Rent' },
+      ],
+      error: null,
+    });
+    expect(listAddTransferFromAccountOptions).toHaveBeenCalledTimes(1);
+    expect(listAddTransferToAccountOptions).toHaveBeenCalledTimes(1);
+    expect(listAllCategories).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps loading when the DB runtime is not open yet', async () => {
+    const controller = createAddTransferOptionsController(
+      {
+        listAddTransferFromAccountOptions: () => {
+          throw new DbRuntimeError('db_not_open', 'No DB is open.');
+        },
+        listAddTransferToAccountOptions: vi.fn(),
+      },
+      { listAllCategories: vi.fn() },
+    );
+
+    await controller.load();
+
+    expect(controller.getState()).toEqual({
+      operation: 'loading',
+      fromAccountOptions: [],
+      toAccountOptions: [],
+      categoryOptions: [],
+      error: null,
+    });
+  });
+
+  it('surfaces query failures as an error state', async () => {
+    const controller = createAddTransferOptionsController(
+      {
+        listAddTransferFromAccountOptions: () => {
+          throw new Error('query failed');
+        },
+        listAddTransferToAccountOptions: vi.fn(),
+      },
+      { listAllCategories: vi.fn() },
+    );
+
+    await controller.load();
+
+    expect(controller.getState().operation).toBe('error');
+    expect(controller.getState().error?.message).toBe('query failed');
+    expect(controller.getState().fromAccountOptions).toEqual([]);
+    expect(controller.getState().toAccountOptions).toEqual([]);
+    expect(controller.getState().categoryOptions).toEqual([]);
+  });
+
+  it('reloads options only after sync states that can provide an opened DB snapshot', () => {
+    expect(shouldReloadAddTransferOptionsForSyncState('synced')).toBe(true);
+    expect(shouldReloadAddTransferOptionsForSyncState('stale')).toBe(true);
+    expect(shouldReloadAddTransferOptionsForSyncState('offline')).toBe(true);
+    expect(shouldReloadAddTransferOptionsForSyncState('idle')).toBe(false);
+    expect(shouldReloadAddTransferOptionsForSyncState('syncing')).toBe(false);
+    expect(shouldReloadAddTransferOptionsForSyncState('error')).toBe(false);
+  });
+});

--- a/src/features/app-shell/routes/addTransferOptionsController.ts
+++ b/src/features/app-shell/routes/addTransferOptionsController.ts
@@ -1,0 +1,149 @@
+// Loads Add Transfer account and category select options from local SQLite query services.
+import { isDbRuntimeError, type AccountQueryService, type CategoryQueryService } from '@db';
+import type { SyncState } from '@shared';
+
+import type { AddTransferAccountOption, AddTransferCategoryOption } from './addTransferFormState';
+
+export type AddTransferOptionsOperation = 'loading' | 'ready' | 'error';
+
+export interface AddTransferOptionsError {
+  readonly message: string;
+  readonly cause?: unknown;
+}
+
+export interface AddTransferOptionsState {
+  readonly operation: AddTransferOptionsOperation;
+  readonly fromAccountOptions: readonly AddTransferAccountOption[];
+  readonly toAccountOptions: readonly AddTransferAccountOption[];
+  readonly categoryOptions: readonly AddTransferCategoryOption[];
+  readonly error: AddTransferOptionsError | null;
+}
+
+export type AddTransferOptionsStateListener = (state: AddTransferOptionsState) => void;
+
+export interface AddTransferOptionsController {
+  getState(): AddTransferOptionsState;
+  subscribe(listener: AddTransferOptionsStateListener): () => void;
+  load(): Promise<void>;
+}
+
+const INITIAL_STATE: AddTransferOptionsState = {
+  operation: 'loading',
+  fromAccountOptions: [],
+  toAccountOptions: [],
+  categoryOptions: [],
+  error: null,
+};
+
+const toAddTransferOptionsError = (
+  error: unknown,
+  fallbackMessage: string,
+): AddTransferOptionsError => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return { message: error.message, cause: error };
+  }
+
+  return { message: fallbackMessage, cause: error };
+};
+
+const isDbRuntimeNotOpenError = (error: unknown): boolean =>
+  isDbRuntimeError(error) && error.code === 'db_not_open';
+
+export const shouldReloadAddTransferOptionsForSyncState = (syncState: SyncState): boolean =>
+  syncState === 'synced' || syncState === 'stale' || syncState === 'offline';
+
+export const createAddTransferOptionsController = (
+  accountQueryService: Pick<
+    AccountQueryService,
+    'listAddTransferFromAccountOptions' | 'listAddTransferToAccountOptions'
+  >,
+  categoryQueryService: Pick<CategoryQueryService, 'listAllCategories'>,
+): AddTransferOptionsController => {
+  let state: AddTransferOptionsState = INITIAL_STATE;
+  const listeners = new Set<AddTransferOptionsStateListener>();
+
+  const emitState = (): void => {
+    for (const listener of listeners) {
+      listener(state);
+    }
+  };
+
+  const updateState = (patch: Partial<AddTransferOptionsState>): void => {
+    state = { ...state, ...patch };
+    emitState();
+  };
+
+  return {
+    getState(): AddTransferOptionsState {
+      return state;
+    },
+
+    subscribe(listener: AddTransferOptionsStateListener): () => void {
+      listeners.add(listener);
+      listener(state);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    async load(): Promise<void> {
+      updateState({
+        operation: 'loading',
+        fromAccountOptions: [],
+        toAccountOptions: [],
+        categoryOptions: [],
+        error: null,
+      });
+
+      try {
+        const fromAccountOptions = accountQueryService
+          .listAddTransferFromAccountOptions()
+          .map((account) => ({
+            accountId: account.accountId,
+            name: account.name,
+          }));
+        const toAccountOptions = accountQueryService
+          .listAddTransferToAccountOptions()
+          .map((account) => ({
+            accountId: account.accountId,
+            name: account.name,
+          }));
+        const categoryOptions = categoryQueryService.listAllCategories().map((category) => ({
+          categoryId: category.categoryId,
+          name: category.name,
+        }));
+
+        updateState({
+          operation: 'ready',
+          fromAccountOptions,
+          toAccountOptions,
+          categoryOptions,
+          error: null,
+        });
+      } catch (error) {
+        if (isDbRuntimeNotOpenError(error)) {
+          updateState({
+            operation: 'loading',
+            fromAccountOptions: [],
+            toAccountOptions: [],
+            categoryOptions: [],
+            error: null,
+          });
+          return;
+        }
+
+        updateState({
+          operation: 'error',
+          fromAccountOptions: [],
+          toAccountOptions: [],
+          categoryOptions: [],
+          error: toAddTransferOptionsError(
+            error,
+            'Failed to load add-transfer account and category options.',
+          ),
+        });
+      }
+    },
+  };
+};

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -51,6 +51,7 @@
     "categoryPlaceholder": "Keine Kategorie",
     "buyplace": "Einkaufsort",
     "buyplacePlaceholder": "z.B. Supermarkt...",
+    "loadingOptions": "Konten und Kategorien werden geladen...",
     "submit": "Transfer speichern",
     "saving": "Transfer wird gespeichert...",
     "close": "Schließen"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -51,6 +51,7 @@
     "categoryPlaceholder": "No category",
     "buyplace": "Buyplace",
     "buyplacePlaceholder": "e.g. Supermarket...",
+    "loadingOptions": "Loading accounts and categories...",
     "submit": "Save transfer",
     "saving": "Saving transfer...",
     "close": "Close"

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -253,10 +253,14 @@ type MockDbRuntimeAccountRow = {
   readonly accountId: number;
   readonly name: string;
   readonly amountCents: number;
+  readonly accountTypeId?: number | null;
 };
 
 type MockDbRuntimeOptions = {
   readonly accountRows?: readonly MockDbRuntimeAccountRow[];
+  readonly fromAccountOptionRows?: readonly MockDbRuntimeAccountRow[];
+  readonly toAccountOptionRows?: readonly MockDbRuntimeAccountRow[];
+  readonly categoryRows?: readonly { readonly categoryId: number; readonly name: string }[];
   readonly failAccountsQuery?: boolean;
   readonly accountsQueryErrorCode?: string;
   readonly accountsQueryErrorMessage?: string;
@@ -692,6 +696,9 @@ const installMockDbRuntime = async (
 ): Promise<void> => {
   await page.addInitScript((mockOptions: MockDbRuntimeOptions) => {
     const accountRows = mockOptions.accountRows ?? [];
+    const fromAccountOptionRows = mockOptions.fromAccountOptionRows ?? accountRows;
+    const toAccountOptionRows = mockOptions.toAccountOptionRows ?? accountRows;
+    const categoryRows = mockOptions.categoryRows ?? [];
     let isOpen = mockOptions.forceAlwaysOpen ?? false;
     let execCallCount = 0;
     const isAccountsQuery = (sql: string): boolean => {
@@ -702,6 +709,40 @@ const installMockDbRuntime = async (
         normalizedSql.includes('ac_type_id not in (1, 2)')
       );
     };
+    const isAddTransferFromOptionsQuery = (sql: string): boolean => {
+      const normalizedSql = sql.toLowerCase();
+      return (
+        normalizedSql.includes('from account') &&
+        normalizedSql.includes('ac_type_id = 1') &&
+        normalizedSql.includes('case when ac_type_id = 1')
+      );
+    };
+    const isAddTransferToOptionsQuery = (sql: string): boolean => {
+      const normalizedSql = sql.toLowerCase();
+      return (
+        normalizedSql.includes('from account') &&
+        normalizedSql.includes('ac_type_id = 2') &&
+        normalizedSql.includes('case when ac_type_id = 2')
+      );
+    };
+    const isCategoriesQuery = (sql: string): boolean => {
+      const normalizedSql = sql.toLowerCase();
+      return (
+        normalizedSql.includes('from category') &&
+        normalizedSql.includes('order by lower(name) asc')
+      );
+    };
+    const toAccountQueryResult = (rows: readonly MockDbRuntimeAccountRow[]) => [
+      {
+        columns: ['account_id', 'name', 'amount', 'ac_type_id'],
+        values: rows.map((account) => [
+          account.accountId,
+          account.name,
+          account.amountCents,
+          account.accountTypeId ?? null,
+        ]),
+      },
+    ];
 
     (window as Window & { __CONSPECTUS_APP_DB_RUNTIME__?: unknown }).__CONSPECTUS_APP_DB_RUNTIME__ =
       {
@@ -730,6 +771,14 @@ const installMockDbRuntime = async (
             };
           }
 
+          if (isAddTransferFromOptionsQuery(sql)) {
+            return toAccountQueryResult(fromAccountOptionRows);
+          }
+
+          if (isAddTransferToOptionsQuery(sql)) {
+            return toAccountQueryResult(toAccountOptionRows);
+          }
+
           if (isAccountsQuery(sql)) {
             if (mockOptions.failAccountsQuery) {
               throw {
@@ -738,15 +787,14 @@ const installMockDbRuntime = async (
               };
             }
 
+            return toAccountQueryResult(accountRows);
+          }
+
+          if (isCategoriesQuery(sql)) {
             return [
               {
-                columns: ['account_id', 'name', 'amount', 'ac_type_id'],
-                values: accountRows.map((account) => [
-                  account.accountId,
-                  account.name,
-                  account.amountCents,
-                  null,
-                ]),
+                columns: ['category_id', 'name'],
+                values: categoryRows.map((category) => [category.categoryId, category.name]),
               },
             ];
           }
@@ -938,6 +986,19 @@ test('loads a mobile app shell and navigates primary routes', async ({ page }) =
 });
 
 test('renders an editable add transfer bottom sheet on mobile viewports', async ({ page }) => {
+  await installMockDbRuntime(page, {
+    forceAlwaysOpen: true,
+    fromAccountOptionRows: [
+      { accountId: 1, name: 'Primary Income', amountCents: 0, accountTypeId: 1 },
+      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+    ],
+    toAccountOptionRows: [
+      { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+    ],
+    categoryRows: [{ categoryId: 20, name: 'Groceries' }],
+  });
+
   await page.goto(appPath('#/add'));
 
   await expect(page.getByTestId('route-add')).toHaveCount(1);
@@ -975,6 +1036,60 @@ test('renders an editable add transfer bottom sheet on mobile viewports', async 
   await submitButton.scrollIntoViewIfNeeded();
   await expect(submitButton).toBeInViewport();
   await expect(page.getByTestId('add-transfer-buyplace')).toHaveValue('Supermarket');
+});
+
+test('loads add transfer account and category options from the local DB runtime', async ({
+  page,
+}) => {
+  await installMockDbRuntime(page, {
+    forceAlwaysOpen: true,
+    fromAccountOptionRows: [
+      { accountId: 1, name: 'Primary Income', amountCents: 0, accountTypeId: 1 },
+      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+      { accountId: 12, name: 'Wallet', amountCents: 500, accountTypeId: 3 },
+    ],
+    toAccountOptionRows: [
+      { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+      { accountId: 12, name: 'Wallet', amountCents: 500, accountTypeId: 3 },
+    ],
+    categoryRows: [
+      { categoryId: 20, name: 'Groceries' },
+      { categoryId: 30, name: 'Rent' },
+      { categoryId: 40, name: 'Travel' },
+    ],
+  });
+
+  await page.goto(appPath('#/add'));
+
+  const fromAccountOptions = page.getByTestId('add-transfer-from-account').locator('option');
+  await expect(fromAccountOptions).toHaveText([
+    'Select source account',
+    'Primary Income',
+    'Checking',
+    'Wallet',
+  ]);
+
+  const toAccountOptions = page.getByTestId('add-transfer-to-account').locator('option');
+  await expect(toAccountOptions).toHaveText([
+    'Select destination account',
+    'Primary Spendings',
+    'Checking',
+    'Wallet',
+  ]);
+
+  for (const testId of [
+    'add-transfer-category-1',
+    'add-transfer-category-2',
+    'add-transfer-category-3',
+  ]) {
+    await expect(page.getByTestId(testId).locator('option')).toHaveText([
+      'No category',
+      'Groceries',
+      'Rent',
+      'Travel',
+    ]);
+  }
 });
 
 test('renders readable account cards with semantic amount styling on narrow mobile widths', async ({


### PR DESCRIPTION
- Add `listAddTransferFromAccountOptions` and `listAddTransferToAccountOptions` to `AccountQueryService` using custom SQL queries to filter visible accounts.
- Create `AddTransferOptionsController` to coordinate loading options, managing error/success states, and subscribing to DB sync events.
- Update `AddRoute.svelte` to use the options controller and disable controls while loading.
- Add and update tests to cover the controller and components.

[M6-02]
Agent: Gemini

# Pull Request

## Linked Issue (Required)

- Closes #<issue-id>

## Context

- Problem:
- Goal:

## Changes

-

## Test Plan

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test`
- [ ] `npm run build`
- Notes:

## Screenshots

- [ ] UI change: screenshots attached
- [ ] No UI change

## Risk Notes

- User impact:
- Rollback plan:

## QS Checklist

- [ ] Linked issue ID is included in this PR.
- [ ] Lint, typecheck, tests, and build were run and pass.
- [ ] Screenshots are included for UI changes.
- [ ] Risk and rollback notes are documented.
- [ ] No secrets, tokens, or credentials were added to the repository.
- [ ] No breaking path/base URL changes were introduced (must preserve `/conspectus/webapp/` deployment path behavior).

## Merge And Cleanup (PR Path)

- [ ] Required GitHub checks are green.
- [ ] PR will be merged into `main` with `Rebase and merge`.
- [ ] PR will be merged into `main` once checks/review requirements are satisfied.
- [ ] Head branch will be deleted after merge.
- [ ] Linked issue/backlog marker will only be marked done after merge.
