### PR TITLE
feat: [M6-04] Implement transfer type derivation logic

### DIFF
--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -471,7 +471,7 @@ An issue is only considered done when:
 - Depends on: `M6-01, M6-02`
 - GitHub: [#66](https://github.com/Jon2050/Conspectus-Mobile/issues/66)
 
-### :green_circle: M6-04 Implement transfer type derivation logic
+### :white_check_mark: M6-04 Implement transfer type derivation logic
 
 - Label: `feature`
 - Milestone: `M6 - Add Transfer Write Path`

--- a/docs/prompts/Task-Prompt-Template.md
+++ b/docs/prompts/Task-Prompt-Template.md
@@ -1,4 +1,4 @@
-Task: Implement issue `M6-03` end-to-end with full verification.
+Task: Implement issue `M6-04` end-to-end with full verification.
 
 ## Non-negotiable rules:
 
@@ -22,7 +22,7 @@ Always print in which step you are!
    - `docs/Architecture-and-Implementation-Plan.md`
    - `docs/Conspectus-Desktop-Info.md`
    - `docs/GitHub-Issues-MVP-Backlog.md`
-     Then locate `M6-03` and extract implementation steps, acceptance criteria, and dependencies/constraints from GitHub. Also from the comments on GitHub.
+     Then locate `M6-04` and extract implementation steps, acceptance criteria, and dependencies/constraints from GitHub. Also from the comments on GitHub.
 2. Plan with one planning subagent. Refine until concrete, testable, and mapped from each acceptance criterion to file-level code/test changes. Make clear, that the planning subagent should not write any code, just the plan.
 3. Create/use a dedicated issue branch with a proper name containing the milestone and issue number (e.g., `feature/M6-03-localize-formatting` or `bug/M6-03-fix-locale`).
    3.1. Increase the app version in `package.json` to `0.<milestone_number>.<issue_title_number>`. (e.g. `0.6.03` for issue `M6-03`)
@@ -76,5 +76,3 @@ Always print in which step you are!
 5. **Documentation:** Code must be self-explanatory. Add meaningful inline comments only for complex or non-obvious logic. Every file should start with a short description of what the file does and why it is needed.
 6. **Testing:** All new or changed behavior must be accompanied by appropriate, passing tests. Tests should verify real functionality, cover important edge cases and failure scenarios, and provide meaningful regression protection.
 7. **Contextual Alignment:** Before coding, verify that prerequisites from previous tasks are complete. Ensure your implementation serves as a solid foundation for related upcoming issues in the backlog.
-
-Please include the changes in the Task-Prompt-Template.md into the commit aswell.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.6.03",
+  "version": "0.6.04",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,6 +3,9 @@ export type { BindParams, QueryExecResult, SqlValue } from 'sql.js';
 export {
   PRIMARY_INCOME_ACCOUNT_TYPE_ID,
   PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID,
+  TRANSFER_TYPE_STD_EXPENSE,
+  TRANSFER_TYPE_STD_EARNING,
+  TRANSFER_TYPE_INTERN_TRANSFER,
   type AccountRecord,
   type BrowserDbRuntime,
   type BrowserDbRuntimeOpenOptions,

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -4,6 +4,10 @@ import type { BindParams, QueryExecResult } from 'sql.js';
 export const PRIMARY_INCOME_ACCOUNT_TYPE_ID = 1;
 export const PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID = 2;
 
+export const TRANSFER_TYPE_STD_EXPENSE = 1;
+export const TRANSFER_TYPE_STD_EARNING = 2;
+export const TRANSFER_TYPE_INTERN_TRANSFER = 3;
+
 export interface BrowserDbRuntime {
   open(snapshotBytes: Uint8Array, options?: BrowserDbRuntimeOpenOptions): Promise<void>;
   close(): void;

--- a/src/features/app-shell/routes/transferTypeDerivation.test.ts
+++ b/src/features/app-shell/routes/transferTypeDerivation.test.ts
@@ -1,0 +1,54 @@
+// Unit tests for the transfer type derivation logic.
+import { describe, it, expect } from 'vitest';
+import { deriveTransferType } from './transferTypeDerivation';
+import {
+  PRIMARY_INCOME_ACCOUNT_TYPE_ID,
+  PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID,
+  TRANSFER_TYPE_STD_EXPENSE,
+  TRANSFER_TYPE_STD_EARNING,
+  TRANSFER_TYPE_INTERN_TRANSFER,
+} from '@db';
+
+describe('deriveTransferType', () => {
+  it('returns STD_EXPENSE if `to` account is primary income', () => {
+    expect(deriveTransferType(null, PRIMARY_INCOME_ACCOUNT_TYPE_ID)).toBe(
+      TRANSFER_TYPE_STD_EXPENSE,
+    );
+  });
+
+  it('returns STD_EXPENSE if `to` account is primary spendings', () => {
+    expect(deriveTransferType(null, PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID)).toBe(
+      TRANSFER_TYPE_STD_EXPENSE,
+    );
+  });
+
+  it('returns STD_EARNING if `to` is non-primary and `from` is primary income', () => {
+    expect(deriveTransferType(PRIMARY_INCOME_ACCOUNT_TYPE_ID, null)).toBe(
+      TRANSFER_TYPE_STD_EARNING,
+    );
+  });
+
+  it('returns STD_EARNING if `to` is non-primary and `from` is primary spendings', () => {
+    expect(deriveTransferType(PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID, null)).toBe(
+      TRANSFER_TYPE_STD_EARNING,
+    );
+  });
+
+  it('returns STD_EXPENSE if both `to` and `from` are primary (to wins)', () => {
+    expect(
+      deriveTransferType(PRIMARY_INCOME_ACCOUNT_TYPE_ID, PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID),
+    ).toBe(TRANSFER_TYPE_STD_EXPENSE);
+  });
+
+  it('returns INTERN_TRANSFER if neither `from` nor `to` is primary', () => {
+    expect(deriveTransferType(null, null)).toBe(TRANSFER_TYPE_INTERN_TRANSFER);
+  });
+
+  it('returns INTERN_TRANSFER if inputs are undefined', () => {
+    expect(deriveTransferType(undefined, undefined)).toBe(TRANSFER_TYPE_INTERN_TRANSFER);
+  });
+
+  it('returns INTERN_TRANSFER if inputs are non-primary numbers', () => {
+    expect(deriveTransferType(999, 888)).toBe(TRANSFER_TYPE_INTERN_TRANSFER);
+  });
+});

--- a/src/features/app-shell/routes/transferTypeDerivation.ts
+++ b/src/features/app-shell/routes/transferTypeDerivation.ts
@@ -1,0 +1,32 @@
+// Implements the business logic to derive the transfer type ID based on the selected accounts.
+import {
+  PRIMARY_INCOME_ACCOUNT_TYPE_ID,
+  PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID,
+  TRANSFER_TYPE_STD_EXPENSE,
+  TRANSFER_TYPE_STD_EARNING,
+  TRANSFER_TYPE_INTERN_TRANSFER,
+} from '@db';
+
+/**
+ * Derives the transfer type ID based on the desktop rules:
+ * - If receiving account (`to`) is primary -> STD_EXPENSE (1)
+ * - Else if spending account (`from`) is primary -> STD_EARNING (2)
+ * - Else -> INTERN_TRANSFER (3)
+ */
+export function deriveTransferType(
+  fromAccountTypeId: number | null | undefined,
+  toAccountTypeId: number | null | undefined,
+): number {
+  const isPrimary = (typeId: number | null | undefined) =>
+    typeId === PRIMARY_INCOME_ACCOUNT_TYPE_ID || typeId === PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID;
+
+  if (isPrimary(toAccountTypeId)) {
+    return TRANSFER_TYPE_STD_EXPENSE;
+  }
+
+  if (isPrimary(fromAccountTypeId)) {
+    return TRANSFER_TYPE_STD_EARNING;
+  }
+
+  return TRANSFER_TYPE_INTERN_TRANSFER;
+}


### PR DESCRIPTION
Closes #67

Implemented transfer type derivation using pure ID-based lookup rules to align perfectly with the desktop logic. The derivation logic keeps a strong Separation of Concerns (SoC) by accepting account type IDs, and is comprehensively tested for all condition branches.