### PR TITLE
feat: [M6-05] Implement SQL write transaction

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -634,6 +634,13 @@ M6-04 implementation clarification:
 - The transfer type ID determination logic is decoupled from UI option lists and explicitly mirrors desktop business logic via `accountTypeId` comparison alone.
 - It resides in `src/features/app-shell/routes/transferTypeDerivation.ts` and gracefully falls back to `INTERN_TRANSFER` (`3`) when incomplete selection states are encountered before form validation.
 
+M6-05 implementation clarification:
+
+- Local transfer persistence is implemented in `src/db/transferWriteService.ts` and exposed through `@db` as `createTransferWriteService`/`appTransferWriteService`.
+- The service performs the desktop-compatible write sequence in one explicit SQLite transaction: insert the `transfer` row, decrement the source account balance, increment the destination account balance, and commit only after all statements succeed.
+- Rollback behavior is covered for insert failure, source-account update failure, and destination-account update failure so transfer rows and account balances cannot remain partially applied.
+- DB export, OneDrive upload, cache persistence, retry UX, and conflict handling remain intentionally scoped to the later M6 write-path issues.
+
 Deliverables:
 
 - End-to-end write feature with clear success/error behavior.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -479,7 +479,7 @@ An issue is only considered done when:
 - Depends on: `M6-02`
 - GitHub: [#67](https://github.com/Jon2050/Conspectus-Mobile/issues/67)
 
-### :green_circle: M6-05 Implement SQL write transaction
+### :white_check_mark: M6-05 Implement SQL write transaction
 
 - Label: `feature`
 - Milestone: `M6 - Add Transfer Write Path`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.6.02",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.6.02",
+      "version": "0.6.5",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.6.195",
+  "version": "0.6.5",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -32,6 +32,11 @@ export {
   type CategoryQueryService,
 } from './categoryQueryService';
 export {
+  appTransferWriteService,
+  createTransferWriteService,
+  type TransferWriteService,
+} from './transferWriteService';
+export {
   appBrowserDbRuntime,
   createBrowserDbRuntime,
   resolveAppBrowserDbRuntime,

--- a/src/db/transferWriteService.test.ts
+++ b/src/db/transferWriteService.test.ts
@@ -1,0 +1,269 @@
+// Verifies atomic SQLite transfer writes and rollback behavior for Add Transfer persistence.
+import { describe, expect, it } from 'vitest';
+
+import {
+  createBrowserDbRuntime,
+  createTransferWriteService,
+  DbRuntimeError,
+  TRANSFER_TYPE_INTERN_TRANSFER,
+  type BrowserDbRuntime,
+  type CreateTransferInput,
+} from './index';
+
+import { toEpochDay } from '../shared/testUtils/dateUtils';
+import {
+  createNodeSqlJsRuntimeLoader,
+  loadTransferFixtureBytes,
+} from '../shared/testUtils/dbIntegration';
+
+interface AccountSnapshot {
+  readonly amountCents: number;
+}
+
+const createRuntimeFromTransferFixture = async (): Promise<BrowserDbRuntime> => {
+  const runtime = createBrowserDbRuntime(createNodeSqlJsRuntimeLoader());
+  await runtime.open(loadTransferFixtureBytes());
+  return runtime;
+};
+
+const getAccountSnapshot = (
+  runtime: Pick<BrowserDbRuntime, 'exec'>,
+  accountId: number,
+): AccountSnapshot => {
+  const amountCents = runtime.exec('SELECT amount FROM account WHERE account_id = ?;', [
+    accountId,
+  ])[0]?.values[0]?.[0];
+
+  if (typeof amountCents !== 'number') {
+    throw new Error(`Expected account ${accountId} to exist in fixture.`);
+  }
+
+  return { amountCents };
+};
+
+const countTransfersByName = (runtime: Pick<BrowserDbRuntime, 'exec'>, name: string): number => {
+  const count = runtime.exec('SELECT COUNT(*) FROM transfer WHERE name = ?;', [name])[0]
+    ?.values[0]?.[0];
+
+  if (typeof count !== 'number') {
+    throw new Error(`Expected a numeric transfer count for ${name}.`);
+  }
+
+  return count;
+};
+
+const getTransferRowById = (runtime: Pick<BrowserDbRuntime, 'exec'>, transferId: number) => {
+  const result = runtime.exec(
+    `
+      SELECT name, from_account, to_account, amount, transfer_type_id,
+             category_1_id, category_2_id, category_3_id, date, buyplace
+      FROM transfer
+      WHERE transfer_id = ?;
+    `,
+    [transferId],
+  );
+
+  return result[0]?.values[0];
+};
+
+const createBaseInput = (name: string): CreateTransferInput => ({
+  bookingDateEpochDay: toEpochDay(2024, 5, 12),
+  name,
+  amountCents: 1234,
+  transferTypeId: TRANSFER_TYPE_INTERN_TRANSFER,
+  fromAccountId: 3,
+  toAccountId: 4,
+  categoryIds: [1],
+  buyplace: 'Corner Store',
+});
+
+const expectDbQueryFailed = (writeCall: () => unknown): void => {
+  try {
+    writeCall();
+    throw new Error('Expected transfer write call to throw DbRuntimeError(db_query_failed).');
+  } catch (error) {
+    expect(error).toBeInstanceOf(DbRuntimeError);
+    expect((error as DbRuntimeError).code).toBe('db_query_failed');
+  }
+};
+
+const expectBalancesAndTransferCountUnchanged = (
+  runtime: Pick<BrowserDbRuntime, 'exec'>,
+  fromBefore: AccountSnapshot,
+  toBefore: AccountSnapshot,
+  transferName: string,
+): void => {
+  expect(getAccountSnapshot(runtime, 3)).toEqual(fromBefore);
+  expect(getAccountSnapshot(runtime, 4)).toEqual(toBefore);
+  expect(countTransfersByName(runtime, transferName)).toBe(0);
+};
+
+describe('transfer write service', () => {
+  it('creates a transfer and updates source and destination balances atomically', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    const service = createTransferWriteService(runtime);
+    const fromBefore = getAccountSnapshot(runtime, 3);
+    const toBefore = getAccountSnapshot(runtime, 4);
+
+    const result = service.createTransfer(createBaseInput('Fixture write'));
+
+    expect(result.transferId).toBeGreaterThan(3);
+    expect(Date.parse(result.persistedAtIso)).not.toBeNaN();
+    expect(getTransferRowById(runtime, result.transferId)).toEqual([
+      'Fixture write',
+      3,
+      4,
+      1234,
+      TRANSFER_TYPE_INTERN_TRANSFER,
+      1,
+      null,
+      null,
+      toEpochDay(2024, 5, 12),
+      'Corner Store',
+    ]);
+    expect(getAccountSnapshot(runtime, 3).amountCents).toBe(fromBefore.amountCents - 1234);
+    expect(getAccountSnapshot(runtime, 4).amountCents).toBe(toBefore.amountCents + 1234);
+    runtime.close();
+  });
+
+  it('persists nullable category and buyplace fields', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    const service = createTransferWriteService(runtime);
+
+    const result = service.createTransfer({
+      ...createBaseInput('Nullable write'),
+      categoryIds: [],
+      buyplace: '   ',
+    });
+
+    expect(getTransferRowById(runtime, result.transferId)).toEqual([
+      'Nullable write',
+      3,
+      4,
+      1234,
+      TRANSFER_TYPE_INTERN_TRANSFER,
+      null,
+      null,
+      null,
+      toEpochDay(2024, 5, 12),
+      null,
+    ]);
+    runtime.close();
+  });
+
+  it('persists three categories in positional order', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    const service = createTransferWriteService(runtime);
+
+    const result = service.createTransfer({
+      ...createBaseInput('Category write'),
+      categoryIds: [1, 2, 3],
+    });
+
+    expect(getTransferRowById(runtime, result.transferId)?.slice(5, 8)).toEqual([1, 2, 3]);
+    runtime.close();
+  });
+
+  it('rolls back when the transfer insert fails', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    const service = createTransferWriteService(runtime);
+    const fromBefore = getAccountSnapshot(runtime, 3);
+    const toBefore = getAccountSnapshot(runtime, 4);
+
+    expectDbQueryFailed(() =>
+      service.createTransfer({
+        ...createBaseInput('Invalid insert write'),
+        transferTypeId: 999,
+      }),
+    );
+
+    expectBalancesAndTransferCountUnchanged(runtime, fromBefore, toBefore, 'Invalid insert write');
+    runtime.close();
+  });
+
+  it('rolls back when the source account update fails after insert', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    runtime.exec(`
+      CREATE TRIGGER fail_source_account_update
+      BEFORE UPDATE ON account
+      WHEN OLD.account_id = 3
+      BEGIN
+        SELECT RAISE(ABORT, 'source update failed');
+      END;
+    `);
+    const service = createTransferWriteService(runtime);
+    const fromBefore = getAccountSnapshot(runtime, 3);
+    const toBefore = getAccountSnapshot(runtime, 4);
+
+    expectDbQueryFailed(() => service.createTransfer(createBaseInput('Source failure write')));
+
+    expectBalancesAndTransferCountUnchanged(runtime, fromBefore, toBefore, 'Source failure write');
+    runtime.close();
+  });
+
+  it('rolls back when the destination account update fails after source balance changes', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    runtime.exec(`
+      CREATE TRIGGER fail_destination_account_update
+      BEFORE UPDATE ON account
+      WHEN OLD.account_id = 4
+      BEGIN
+        SELECT RAISE(ABORT, 'destination update failed');
+      END;
+    `);
+    const service = createTransferWriteService(runtime);
+    const fromBefore = getAccountSnapshot(runtime, 3);
+    const toBefore = getAccountSnapshot(runtime, 4);
+
+    expectDbQueryFailed(() => service.createTransfer(createBaseInput('Destination failure write')));
+
+    expectBalancesAndTransferCountUnchanged(
+      runtime,
+      fromBefore,
+      toBefore,
+      'Destination failure write',
+    );
+    runtime.close();
+  });
+
+  it('resolves a runtime provider on each write call', () => {
+    const calls: string[] = [];
+    const firstRuntime = {
+      exec: (sql: string) => {
+        calls.push(`first:${sql.trim()}`);
+        return sql.includes('last_insert_rowid')
+          ? [{ columns: ['transfer_id'], values: [[11]] }]
+          : [];
+      },
+    };
+    const secondRuntime = {
+      exec: (sql: string) => {
+        calls.push(`second:${sql.trim()}`);
+        return sql.includes('last_insert_rowid')
+          ? [{ columns: ['transfer_id'], values: [[12]] }]
+          : [];
+      },
+    };
+    const runtimes = [firstRuntime, secondRuntime];
+    const service = createTransferWriteService(() => runtimes.shift() ?? secondRuntime);
+
+    expect(service.createTransfer(createBaseInput('First')).transferId).toBe(11);
+    expect(service.createTransfer(createBaseInput('Second')).transferId).toBe(12);
+    expect(calls.filter((call) => call.startsWith('first:BEGIN'))).toHaveLength(1);
+    expect(calls.filter((call) => call.startsWith('second:BEGIN'))).toHaveLength(1);
+  });
+
+  it('preserves deterministic closed-runtime failures', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    const service = createTransferWriteService(runtime);
+    runtime.close();
+
+    try {
+      service.createTransfer(createBaseInput('Closed runtime write'));
+      throw new Error('Expected transfer write to fail when runtime is closed.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(DbRuntimeError);
+      expect((error as DbRuntimeError).code).toBe('db_not_open');
+    }
+  });
+});

--- a/src/db/transferWriteService.ts
+++ b/src/db/transferWriteService.ts
@@ -1,0 +1,126 @@
+// Implements desktop-compatible transfer creation as one atomic SQLite transaction.
+import type { QueryExecResult, SqlValue } from 'sql.js';
+
+import { resolveAppBrowserDbRuntime } from './browserDbRuntime';
+import { DbRuntimeError, toDbRuntimeError } from './dbRuntimeErrors';
+import type { BrowserDbRuntime, CreateTransferInput, CreateTransferResult } from './types';
+
+const INSERT_TRANSFER_SQL = `
+  INSERT INTO transfer (
+    name, from_account, to_account, amount, transfer_type_id,
+    category_1_id, category_2_id, category_3_id, date, buyplace
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+`;
+
+const UPDATE_SOURCE_ACCOUNT_SQL = `
+  UPDATE account SET amount = amount - ? WHERE account_id = ?;
+`;
+
+const UPDATE_DESTINATION_ACCOUNT_SQL = `
+  UPDATE account SET amount = amount + ? WHERE account_id = ?;
+`;
+
+const LAST_INSERT_ROW_ID_SQL = 'SELECT last_insert_rowid() AS transfer_id;';
+
+const normalizeOptionalText = (value: string | null): string | null => {
+  if (value === null) {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length === 0 ? null : trimmedValue;
+};
+
+const normalizeCategoryIds = (
+  categoryIds: readonly number[],
+): readonly [number | null, number | null, number | null] => [
+  categoryIds[0] ?? null,
+  categoryIds[1] ?? null,
+  categoryIds[2] ?? null,
+];
+
+const readLastInsertRowId = (results: readonly QueryExecResult[]): number => {
+  const transferId = results[0]?.values[0]?.[0];
+
+  if (typeof transferId !== 'number' || !Number.isSafeInteger(transferId)) {
+    throw new DbRuntimeError(
+      'db_query_failed',
+      'Failed to read the inserted transfer ID from the local SQLite database.',
+    );
+  }
+
+  return transferId;
+};
+
+export interface TransferWriteService {
+  createTransfer(input: CreateTransferInput): CreateTransferResult;
+}
+
+type TransferWriteRuntime = Pick<BrowserDbRuntime, 'exec'>;
+type TransferWriteRuntimeProvider = TransferWriteRuntime | (() => TransferWriteRuntime);
+
+const resolveTransferWriteRuntime = (
+  provider: TransferWriteRuntimeProvider,
+): TransferWriteRuntime => (typeof provider === 'function' ? provider() : provider);
+
+const rollbackOpenTransaction = (runtime: TransferWriteRuntime): void => {
+  try {
+    runtime.exec('ROLLBACK;');
+  } catch {
+    // Preserve the original write failure; rollback errors are secondary.
+  }
+};
+
+export const createTransferWriteService = (
+  dbRuntime: TransferWriteRuntimeProvider,
+): TransferWriteService => ({
+  createTransfer(input: CreateTransferInput): CreateTransferResult {
+    const runtime = resolveTransferWriteRuntime(dbRuntime);
+    let transactionStarted = false;
+    let transactionCommitted = false;
+
+    try {
+      const [category1Id, category2Id, category3Id] = normalizeCategoryIds(input.categoryIds);
+      const buyplace = normalizeOptionalText(input.buyplace);
+      const insertParams: SqlValue[] = [
+        input.name,
+        input.fromAccountId,
+        input.toAccountId,
+        input.amountCents,
+        input.transferTypeId,
+        category1Id,
+        category2Id,
+        category3Id,
+        input.bookingDateEpochDay,
+        buyplace,
+      ];
+
+      runtime.exec('BEGIN IMMEDIATE TRANSACTION;');
+      transactionStarted = true;
+
+      runtime.exec(INSERT_TRANSFER_SQL, insertParams);
+      const transferId = readLastInsertRowId(runtime.exec(LAST_INSERT_ROW_ID_SQL));
+      runtime.exec(UPDATE_SOURCE_ACCOUNT_SQL, [input.amountCents, input.fromAccountId]);
+      runtime.exec(UPDATE_DESTINATION_ACCOUNT_SQL, [input.amountCents, input.toAccountId]);
+      runtime.exec('COMMIT;');
+      transactionCommitted = true;
+
+      return {
+        transferId,
+        persistedAtIso: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (transactionStarted && !transactionCommitted) {
+        rollbackOpenTransaction(runtime);
+      }
+
+      throw toDbRuntimeError(
+        error,
+        'db_query_failed',
+        'Failed to create transfer in the local SQLite database.',
+      );
+    }
+  },
+});
+
+export const appTransferWriteService = createTransferWriteService(resolveAppBrowserDbRuntime);

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -47,6 +47,7 @@ export interface CreateTransferInput {
   readonly bookingDateEpochDay: number;
   readonly name: string;
   readonly amountCents: number;
+  readonly transferTypeId: number;
   readonly fromAccountId: number;
   readonly toAccountId: number;
   readonly categoryIds: readonly number[];


### PR DESCRIPTION
## Summary

Implements M6-05 / #68 by adding a DB-layer write service for local transfer creation.

## Acceptance Criteria Mapping

- Inserts the transfer row through parameterized SQL.
- Updates the source account by `-amount` and destination account by `+amount` in one explicit SQLite transaction.
- Rolls back on insert, source-update, or destination-update failure so transfer rows and account balances remain consistent.

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`

`npm run test:e2e` was not run because M6-05 adds an unmounted DB write service and does not change browser-visible behavior.

Closes #68
