### PR TITLE
feat: [M6-06] Implement DB export after local write

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -641,6 +641,12 @@ M6-05 implementation clarification:
 - Rollback behavior is covered for insert failure, source-account update failure, and destination-account update failure so transfer rows and account balances cannot remain partially applied.
 - DB export, OneDrive upload, cache persistence, retry UX, and conflict handling remain intentionally scoped to the later M6 write-path issues.
 
+M6-06 implementation clarification:
+
+- Transfer save export orchestration is implemented in `src/features/app-shell/transferSaveExportService.ts`.
+- The service composes the committed local SQL write with `BrowserDbRuntime.exportBytes()`, validates that the exported SQLite payload is non-empty, clones it, and hands the bytes to an injected upload boundary.
+- Real OneDrive upload, eTag refresh, cache persistence, retry UX, and conflict handling remain intentionally scoped to the later M6 write-path issues.
+
 Deliverables:
 
 - End-to-end write feature with clear success/error behavior.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -487,7 +487,7 @@ An issue is only considered done when:
 - Depends on: `M6-03, M6-04`
 - GitHub: [#68](https://github.com/Jon2050/Conspectus-Mobile/issues/68)
 
-### :green_circle: M6-06 Implement DB export after successful local write
+### :white_check_mark: M6-06 Implement DB export after successful local write
 
 - Label: `feature`
 - Milestone: `M6 - Add Transfer Write Path`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/features/app-shell/transferSaveExportService.test.ts
+++ b/src/features/app-shell/transferSaveExportService.test.ts
@@ -1,0 +1,194 @@
+// Verifies that transfer saves export committed SQLite bytes before upload handoff.
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createBrowserDbRuntime,
+  createTransferWriteService,
+  DbRuntimeError,
+  TRANSFER_TYPE_INTERN_TRANSFER,
+  type BrowserDbRuntime,
+  type CreateTransferInput,
+  type CreateTransferResult,
+} from '@db';
+
+import { toEpochDay } from '../../shared/testUtils/dateUtils';
+import {
+  createNodeSqlJsRuntimeLoader,
+  loadTransferFixtureBytes,
+} from '../../shared/testUtils/dbIntegration';
+import {
+  createTransferSaveExportService,
+  type DatabaseUploadHandoff,
+} from './transferSaveExportService';
+
+const createRuntimeFromTransferFixture = async (): Promise<BrowserDbRuntime> => {
+  const runtime = createBrowserDbRuntime(createNodeSqlJsRuntimeLoader());
+  await runtime.open(loadTransferFixtureBytes());
+  return runtime;
+};
+
+const createBaseInput = (name: string): CreateTransferInput => ({
+  bookingDateEpochDay: toEpochDay(2024, 5, 12),
+  name,
+  amountCents: 1234,
+  transferTypeId: TRANSFER_TYPE_INTERN_TRANSFER,
+  fromAccountId: 3,
+  toAccountId: 4,
+  categoryIds: [1],
+  buyplace: 'Corner Store',
+});
+
+const countTransfersByName = (runtime: Pick<BrowserDbRuntime, 'exec'>, name: string): number => {
+  const count = runtime.exec('SELECT COUNT(*) FROM transfer WHERE name = ?;', [name])[0]
+    ?.values[0]?.[0];
+
+  if (typeof count !== 'number') {
+    throw new Error(`Expected a numeric transfer count for ${name}.`);
+  }
+
+  return count;
+};
+
+describe('transfer save export service', () => {
+  it('writes locally, exports non-empty bytes, and hands them to upload', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    const writeService = createTransferWriteService(runtime);
+    const uploadedByteSets: Uint8Array[] = [];
+    const uploadHandoff: DatabaseUploadHandoff = {
+      uploadExportedDatabase: vi.fn(async (dbBytes) => {
+        uploadedByteSets.push(dbBytes);
+      }),
+    };
+    const service = createTransferSaveExportService(writeService, runtime, uploadHandoff);
+
+    const result = await service.createTransferAndExport(createBaseInput('Exported write'));
+
+    expect(result.transferId).toBeGreaterThan(3);
+    expect(uploadHandoff.uploadExportedDatabase).toHaveBeenCalledOnce();
+    expect(uploadedByteSets[0]).toBeInstanceOf(Uint8Array);
+    expect(uploadedByteSets[0]?.length).toBeGreaterThan(0);
+    runtime.close();
+  });
+
+  it('runs export and upload only after the local write succeeds', async () => {
+    const calls: string[] = [];
+    const writeService = {
+      createTransfer: vi.fn((input: CreateTransferInput): CreateTransferResult => {
+        calls.push(`write:${input.name}`);
+        return { transferId: 42, persistedAtIso: '2026-06-25T00:00:00.000Z' };
+      }),
+    };
+    const runtime = {
+      exportBytes: vi.fn(() => {
+        calls.push('export');
+        return Uint8Array.from([1, 2, 3]);
+      }),
+    };
+    const uploadHandoff = {
+      uploadExportedDatabase: vi.fn(async () => {
+        calls.push('upload');
+      }),
+    };
+    const service = createTransferSaveExportService(writeService, runtime, uploadHandoff);
+
+    await expect(
+      service.createTransferAndExport(createBaseInput('Ordered write')),
+    ).resolves.toEqual({
+      transferId: 42,
+      persistedAtIso: '2026-06-25T00:00:00.000Z',
+    });
+    expect(calls).toEqual(['write:Ordered write', 'export', 'upload']);
+  });
+
+  it('does not export or upload when the local write fails', async () => {
+    const writeError = new DbRuntimeError('db_query_failed', 'write failed');
+    const writeService = {
+      createTransfer: vi.fn(() => {
+        throw writeError;
+      }),
+    };
+    const runtime = {
+      exportBytes: vi.fn(() => Uint8Array.from([1, 2, 3])),
+    };
+    const uploadHandoff = {
+      uploadExportedDatabase: vi.fn(async () => {}),
+    };
+    const service = createTransferSaveExportService(writeService, runtime, uploadHandoff);
+
+    await expect(service.createTransferAndExport(createBaseInput('Failed write'))).rejects.toBe(
+      writeError,
+    );
+    expect(runtime.exportBytes).not.toHaveBeenCalled();
+    expect(uploadHandoff.uploadExportedDatabase).not.toHaveBeenCalled();
+  });
+
+  it('does not upload when export fails', async () => {
+    const exportError = new DbRuntimeError('db_export_failed', 'export failed');
+    const writeService = {
+      createTransfer: vi.fn(() => ({
+        transferId: 42,
+        persistedAtIso: '2026-06-25T00:00:00.000Z',
+      })),
+    };
+    const runtime = {
+      exportBytes: vi.fn(() => {
+        throw exportError;
+      }),
+    };
+    const uploadHandoff = {
+      uploadExportedDatabase: vi.fn(async () => {}),
+    };
+    const service = createTransferSaveExportService(writeService, runtime, uploadHandoff);
+
+    await expect(service.createTransferAndExport(createBaseInput('Failed export'))).rejects.toBe(
+      exportError,
+    );
+    expect(uploadHandoff.uploadExportedDatabase).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty export before upload handoff', async () => {
+    const writeService = {
+      createTransfer: vi.fn(() => ({
+        transferId: 42,
+        persistedAtIso: '2026-06-25T00:00:00.000Z',
+      })),
+    };
+    const runtime = {
+      exportBytes: vi.fn(() => new Uint8Array()),
+    };
+    const uploadHandoff = {
+      uploadExportedDatabase: vi.fn(async () => {}),
+    };
+    const service = createTransferSaveExportService(writeService, runtime, uploadHandoff);
+
+    await expect(
+      service.createTransferAndExport(createBaseInput('Empty export')),
+    ).rejects.toMatchObject({
+      name: 'DbRuntimeError',
+      code: 'db_export_failed',
+    });
+    expect(uploadHandoff.uploadExportedDatabase).not.toHaveBeenCalled();
+  });
+
+  it('exports bytes that can be opened and include the committed transfer', async () => {
+    const sourceRuntime = await createRuntimeFromTransferFixture();
+    const writeService = createTransferWriteService(sourceRuntime);
+    let uploadedBytes: Uint8Array | null = null;
+    const uploadHandoff: DatabaseUploadHandoff = {
+      uploadExportedDatabase: vi.fn(async (dbBytes) => {
+        uploadedBytes = dbBytes;
+      }),
+    };
+    const service = createTransferSaveExportService(writeService, sourceRuntime, uploadHandoff);
+
+    await service.createTransferAndExport(createBaseInput('Reopen exported write'));
+
+    expect(uploadedBytes).not.toBeNull();
+    const reopenedRuntime = createBrowserDbRuntime(createNodeSqlJsRuntimeLoader());
+    await reopenedRuntime.open(uploadedBytes!);
+
+    expect(countTransfersByName(reopenedRuntime, 'Reopen exported write')).toBe(1);
+    sourceRuntime.close();
+    reopenedRuntime.close();
+  });
+});

--- a/src/features/app-shell/transferSaveExportService.ts
+++ b/src/features/app-shell/transferSaveExportService.ts
@@ -1,0 +1,49 @@
+// Coordinates a committed local transfer write with SQLite byte export for upload handoff.
+import {
+  DbRuntimeError,
+  type BrowserDbRuntime,
+  type CreateTransferInput,
+  type CreateTransferResult,
+  type TransferWriteService,
+} from '@db';
+
+export interface DatabaseUploadHandoff {
+  uploadExportedDatabase(dbBytes: Uint8Array): Promise<void>;
+}
+
+export interface TransferSaveExportService {
+  createTransferAndExport(input: CreateTransferInput): Promise<CreateTransferResult>;
+}
+
+type TransferExportRuntime = Pick<BrowserDbRuntime, 'exportBytes'>;
+type TransferExportRuntimeProvider = TransferExportRuntime | (() => TransferExportRuntime);
+
+const resolveTransferExportRuntime = (
+  provider: TransferExportRuntimeProvider,
+): TransferExportRuntime => (typeof provider === 'function' ? provider() : provider);
+
+const cloneExportedBytes = (dbBytes: Uint8Array): Uint8Array => {
+  if (dbBytes.length === 0) {
+    throw new DbRuntimeError(
+      'db_export_failed',
+      'The SQLite database export was empty and cannot be uploaded.',
+    );
+  }
+
+  return new Uint8Array(dbBytes);
+};
+
+export const createTransferSaveExportService = (
+  transferWriteService: Pick<TransferWriteService, 'createTransfer'>,
+  dbRuntime: TransferExportRuntimeProvider,
+  uploadHandoff: DatabaseUploadHandoff,
+): TransferSaveExportService => ({
+  async createTransferAndExport(input: CreateTransferInput): Promise<CreateTransferResult> {
+    const transferResult = transferWriteService.createTransfer(input);
+    const exportedBytes = cloneExportedBytes(resolveTransferExportRuntime(dbRuntime).exportBytes());
+
+    await uploadHandoff.uploadExportedDatabase(exportedBytes);
+
+    return transferResult;
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `transferSaveExportService` to sequence a successful local transfer write before SQLite byte export.
- Validates non-empty exported DB bytes and hands cloned `Uint8Array` bytes to an injectable upload boundary for M6-07.
- Documents the M6-06 implementation boundary and marks M6-06 done in the backlog.

## Acceptance Criteria

- [x] Export runs only after local commit success.
- [x] Export output is usable for upload.

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run test:e2e`
- Reviewer subagent: APPROVED

## Assumptions

- Real OneDrive upload, eTag refresh, cache persistence, retry UX, and conflict handling remain scoped to M6-07 and later M6 issues.
- `package.json` uses semver-normalized `0.6.6`; `npm version 0.6.06` normalizes to this valid semver form.

Closes #69
