### PR TITLE
feat: [M6-07] Implement If-Match Graph upload handoff

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -647,6 +647,13 @@ M6-06 implementation clarification:
 - The service composes the committed local SQL write with `BrowserDbRuntime.exportBytes()`, validates that the exported SQLite payload is non-empty, clones it, and hands the bytes to an injected upload boundary.
 - Real OneDrive upload, eTag refresh, cache persistence, retry UX, and conflict handling remain intentionally scoped to the later M6 write-path issues.
 
+M6-07 implementation clarification:
+
+- Graph-backed upload orchestration is implemented in `src/features/app-shell/databaseUploadHandoffService.ts` and composed into the real save/export service through `createAppTransferSaveExportService`.
+- The upload handoff reads the current cached eTag for the selected OneDrive file, calls the existing `GraphClient.uploadFile` path with that eTag as the `If-Match` precondition, and refreshes cached DB bytes plus sync metadata with the returned eTag after successful upload.
+- Upload progress is forwarded through both the save/export service callback contract and `SyncStateStore` upload progress updates so later UI work can render determinate upload feedback without adding a second upload path.
+- Precondition conflicts remain a distinct orchestration error (`DatabaseUploadError` with `code: 'conflict'`) and mark sync state stale for the dedicated conflict-recovery UX work in later M6 issues.
+
 Deliverables:
 
 - End-to-end write feature with clear success/error behavior.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -495,7 +495,7 @@ An issue is only considered done when:
 - Depends on: `M6-05`
 - GitHub: [#69](https://github.com/Jon2050/Conspectus-Mobile/issues/69)
 
-### :green_circle: M6-07 Implement Graph upload with `If-Match` eTag
+### :white_check_mark: M6-07 Implement Graph upload with `If-Match` eTag
 
 - Label: `feature`
 - Milestone: `M6 - Add Transfer Write Path`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.6.6",
+  "version": "0.6.7",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/features/app-shell/databaseUploadHandoffService.test.ts
+++ b/src/features/app-shell/databaseUploadHandoffService.test.ts
@@ -1,0 +1,206 @@
+// Verifies OneDrive upload orchestration for exported SQLite snapshots and sync metadata.
+import { get } from 'svelte/store';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CacheStore, CachedDatabaseSnapshot } from '@cache';
+import type { DriveItemBinding, GraphClient } from '@graph';
+import { createSyncStateStore } from '@shared';
+
+import {
+  createDatabaseUploadHandoffService,
+  DatabaseUploadError,
+} from './databaseUploadHandoffService';
+
+const DRIVE_ITEM_BINDING: DriveItemBinding = {
+  driveId: 'drive-1',
+  itemId: 'item-1',
+  name: 'conspectus.db',
+  parentPath: '/Documents',
+};
+
+const createSnapshot = (
+  overrides: Partial<CachedDatabaseSnapshot> = {},
+): CachedDatabaseSnapshot => ({
+  binding: DRIVE_ITEM_BINDING,
+  metadata: {
+    eTag: '"etag-1"',
+    lastSyncAtIso: '2026-03-11T09:45:00.000Z',
+  },
+  dbBytes: Uint8Array.from([1, 2, 3]),
+  ...overrides,
+});
+
+const createGraphClient = (): Pick<GraphClient, 'uploadFile'> => ({
+  uploadFile: vi.fn(async () => ({
+    eTag: '"etag-2"',
+    sizeBytes: 4,
+    lastModifiedDateTime: '2026-03-11T10:00:00Z',
+  })),
+});
+
+const createCacheStore = (
+  snapshot: CachedDatabaseSnapshot | null,
+): Pick<CacheStore, 'readSnapshot' | 'writeSnapshot'> => ({
+  readSnapshot: vi.fn(async () => snapshot),
+  writeSnapshot: vi.fn(async () => {}),
+});
+
+describe('database upload handoff service', () => {
+  it('uploads exported bytes with the cached eTag and refreshes cached sync metadata', async () => {
+    const graphClient = createGraphClient();
+    const cacheStore = createCacheStore(createSnapshot());
+    const syncStateStore = createSyncStateStore({ state: 'synced' });
+    const exportedBytes = Uint8Array.from([9, 8, 7, 6]);
+    const service = createDatabaseUploadHandoffService(
+      graphClient,
+      cacheStore,
+      () => DRIVE_ITEM_BINDING,
+      syncStateStore,
+      { now: () => new Date('2026-03-11T10:15:00.000Z') },
+    );
+
+    await service.uploadExportedDatabase(exportedBytes);
+
+    expect(cacheStore.readSnapshot).toHaveBeenCalledWith(DRIVE_ITEM_BINDING);
+    expect(graphClient.uploadFile).toHaveBeenCalledWith(
+      DRIVE_ITEM_BINDING,
+      exportedBytes,
+      '"etag-1"',
+      expect.any(Function),
+    );
+    expect(cacheStore.writeSnapshot).toHaveBeenCalledWith({
+      binding: DRIVE_ITEM_BINDING,
+      metadata: {
+        eTag: '"etag-2"',
+        lastSyncAtIso: '2026-03-11T10:15:00.000Z',
+      },
+      dbBytes: exportedBytes,
+    });
+    expect(get(syncStateStore)).toMatchObject({
+      state: 'synced',
+      branch: 'uploading_database',
+      progress: null,
+    });
+  });
+
+  it('forwards Graph upload progress through the sync store and caller callback', async () => {
+    const graphClient = createGraphClient();
+    const cacheStore = createCacheStore(createSnapshot());
+    const syncStateStore = createSyncStateStore();
+    const progressUpdates: Array<{ loadedBytes: number; totalBytes: number | null }> = [];
+    vi.mocked(graphClient.uploadFile).mockImplementation(
+      async (_binding, _bytes, _expectedETag, onProgress) => {
+        onProgress?.(25, 100);
+        expect(get(syncStateStore).progress).toEqual({
+          loaded: 25,
+          total: 100,
+          kind: 'upload',
+        });
+        onProgress?.(50, null);
+        expect(get(syncStateStore).progress).toEqual({
+          loaded: 50,
+          total: null,
+          kind: 'upload',
+        });
+
+        return {
+          eTag: '"etag-2"',
+          sizeBytes: 4,
+          lastModifiedDateTime: '2026-03-11T10:00:00Z',
+        };
+      },
+    );
+    const service = createDatabaseUploadHandoffService(
+      graphClient,
+      cacheStore,
+      () => DRIVE_ITEM_BINDING,
+      syncStateStore,
+    );
+
+    await service.uploadExportedDatabase(Uint8Array.from([1, 2, 3]), {
+      onProgress: (progress) => progressUpdates.push(progress),
+    });
+
+    expect(progressUpdates).toEqual([
+      { loadedBytes: 25, totalBytes: 100 },
+      { loadedBytes: 50, totalBytes: null },
+    ]);
+  });
+
+  it('surfaces eTag conflicts without rewriting the cache', async () => {
+    const graphClient = createGraphClient();
+    const cacheStore = createCacheStore(createSnapshot());
+    const syncStateStore = createSyncStateStore();
+    const conflict = {
+      code: 'conflict',
+      status: 412,
+      message: 'The selected OneDrive file changed on OneDrive. Refresh and try again.',
+    };
+    vi.mocked(graphClient.uploadFile).mockRejectedValueOnce(conflict);
+    const service = createDatabaseUploadHandoffService(
+      graphClient,
+      cacheStore,
+      () => DRIVE_ITEM_BINDING,
+      syncStateStore,
+    );
+
+    await expect(service.uploadExportedDatabase(Uint8Array.from([1, 2, 3]))).rejects.toMatchObject({
+      name: 'DatabaseUploadError',
+      code: 'conflict',
+      cause: conflict,
+    });
+
+    expect(cacheStore.writeSnapshot).not.toHaveBeenCalled();
+    expect(get(syncStateStore)).toMatchObject({
+      state: 'stale',
+      branch: 'upload_conflict',
+    });
+  });
+
+  it('fails before upload when no selected binding is available', async () => {
+    const graphClient = createGraphClient();
+    const cacheStore = createCacheStore(createSnapshot());
+    const syncStateStore = createSyncStateStore();
+    const service = createDatabaseUploadHandoffService(
+      graphClient,
+      cacheStore,
+      () => null,
+      syncStateStore,
+    );
+
+    await expect(service.uploadExportedDatabase(Uint8Array.from([1, 2, 3]))).rejects.toBeInstanceOf(
+      DatabaseUploadError,
+    );
+
+    expect(graphClient.uploadFile).not.toHaveBeenCalled();
+    expect(cacheStore.writeSnapshot).not.toHaveBeenCalled();
+    expect(get(syncStateStore)).toMatchObject({
+      state: 'error',
+      branch: 'upload_failed',
+    });
+  });
+
+  it('fails before upload when cached eTag metadata is missing', async () => {
+    const graphClient = createGraphClient();
+    const cacheStore = createCacheStore(null);
+    const syncStateStore = createSyncStateStore();
+    const service = createDatabaseUploadHandoffService(
+      graphClient,
+      cacheStore,
+      () => DRIVE_ITEM_BINDING,
+      syncStateStore,
+    );
+
+    await expect(service.uploadExportedDatabase(Uint8Array.from([1, 2, 3]))).rejects.toMatchObject({
+      name: 'DatabaseUploadError',
+      code: 'missing_cached_snapshot',
+    });
+
+    expect(graphClient.uploadFile).not.toHaveBeenCalled();
+    expect(cacheStore.writeSnapshot).not.toHaveBeenCalled();
+    expect(get(syncStateStore)).toMatchObject({
+      state: 'error',
+      branch: 'upload_failed',
+    });
+  });
+});

--- a/src/features/app-shell/databaseUploadHandoffService.ts
+++ b/src/features/app-shell/databaseUploadHandoffService.ts
@@ -1,0 +1,151 @@
+// Uploads exported SQLite snapshots to OneDrive and refreshes local cache metadata.
+import { get, type Readable } from 'svelte/store';
+import type { CacheStore } from '@cache';
+import type { DriveItemBinding, GraphClient } from '@graph';
+import { appSelectedDriveItemBindingStore, appSyncStateStore, type SyncStateStore } from '@shared';
+
+import { resolveAppCacheStore } from './cacheStoreResolver';
+import { resolveAppGraphClient } from './graphClientResolver';
+import type { DatabaseUploadHandoff, DatabaseUploadOptions } from './transferSaveExportService';
+
+export type DatabaseUploadErrorCode =
+  | 'missing_binding'
+  | 'missing_cached_snapshot'
+  | 'conflict'
+  | 'upload_failed';
+
+export class DatabaseUploadError extends Error {
+  readonly code: DatabaseUploadErrorCode;
+  readonly cause?: unknown;
+
+  constructor(code: DatabaseUploadErrorCode, message: string, cause?: unknown) {
+    super(message);
+    this.name = 'DatabaseUploadError';
+    this.code = code;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+export interface CreateDatabaseUploadHandoffServiceOptions {
+  readonly now?: () => Date;
+  readonly uploadingMessage?: string;
+  readonly uploadedMessage?: string;
+  readonly conflictMessage?: string;
+  readonly failureMessage?: string;
+}
+
+type BindingProvider = Readable<DriveItemBinding | null> | (() => DriveItemBinding | null);
+
+const DEFAULT_UPLOAD_PROGRESS_BRANCH = 'uploading_database';
+const DEFAULT_UPLOAD_CONFLICT_BRANCH = 'upload_conflict';
+const DEFAULT_UPLOAD_FAILED_BRANCH = 'upload_failed';
+
+const resolveBinding = (provider: BindingProvider): DriveItemBinding | null =>
+  typeof provider === 'function' ? provider() : get(provider);
+
+const isGraphConflict = (error: unknown): boolean =>
+  typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 'conflict';
+
+const toUploadError = (error: unknown, conflictMessage: string, failureMessage: string): Error => {
+  if (error instanceof DatabaseUploadError) {
+    return error;
+  }
+
+  if (isGraphConflict(error)) {
+    return new DatabaseUploadError('conflict', conflictMessage, error);
+  }
+
+  return new DatabaseUploadError('upload_failed', failureMessage, error);
+};
+
+export const createDatabaseUploadHandoffService = (
+  graphClient: Pick<GraphClient, 'uploadFile'>,
+  cacheStore: Pick<CacheStore, 'readSnapshot' | 'writeSnapshot'>,
+  bindingProvider: BindingProvider,
+  syncStateStore: SyncStateStore = appSyncStateStore,
+  options: CreateDatabaseUploadHandoffServiceOptions = {},
+): DatabaseUploadHandoff => {
+  const now = options.now ?? (() => new Date());
+  const uploadingMessage = options.uploadingMessage ?? 'Uploading database to OneDrive...';
+  const uploadedMessage = options.uploadedMessage ?? 'Database uploaded to OneDrive.';
+  const conflictMessage =
+    options.conflictMessage ??
+    'The OneDrive database changed before upload completed. Refresh before trying again.';
+  const failureMessage =
+    options.failureMessage ?? 'Uploading the database to OneDrive failed. Try again.';
+
+  return {
+    async uploadExportedDatabase(
+      dbBytes: Uint8Array,
+      uploadOptions?: DatabaseUploadOptions,
+    ): Promise<void> {
+      const binding = resolveBinding(bindingProvider);
+
+      if (binding === null) {
+        const error = new DatabaseUploadError(
+          'missing_binding',
+          'Cannot upload the database because no OneDrive file is selected.',
+        );
+        syncStateStore.setError(error.message, { branch: DEFAULT_UPLOAD_FAILED_BRANCH });
+        throw error;
+      }
+
+      syncStateStore.setSyncing(uploadingMessage, { branch: DEFAULT_UPLOAD_PROGRESS_BRANCH });
+
+      try {
+        const currentSnapshot = await cacheStore.readSnapshot(binding);
+        if (currentSnapshot === null) {
+          throw new DatabaseUploadError(
+            'missing_cached_snapshot',
+            'Cannot upload the database because no cached OneDrive metadata is available.',
+          );
+        }
+
+        const uploadResult = await graphClient.uploadFile(
+          binding,
+          dbBytes,
+          currentSnapshot.metadata.eTag,
+          (loadedBytes, totalBytes) => {
+            syncStateStore.updateProgress(loadedBytes, totalBytes, 'upload');
+            uploadOptions?.onProgress?.({ loadedBytes, totalBytes });
+          },
+        );
+
+        await cacheStore.writeSnapshot({
+          binding,
+          metadata: {
+            eTag: uploadResult.eTag,
+            lastSyncAtIso: now().toISOString(),
+          },
+          dbBytes,
+        });
+
+        syncStateStore.setSynced(uploadedMessage, { branch: DEFAULT_UPLOAD_PROGRESS_BRANCH });
+      } catch (error) {
+        const uploadError = toUploadError(error, conflictMessage, failureMessage);
+
+        if (
+          uploadError instanceof DatabaseUploadError &&
+          uploadError.code === 'missing_cached_snapshot'
+        ) {
+          syncStateStore.setError(uploadError.message, { branch: DEFAULT_UPLOAD_FAILED_BRANCH });
+        } else if (uploadError instanceof DatabaseUploadError && uploadError.code === 'conflict') {
+          syncStateStore.setStale(uploadError.message, { branch: DEFAULT_UPLOAD_CONFLICT_BRANCH });
+        } else {
+          syncStateStore.setError(uploadError.message, { branch: DEFAULT_UPLOAD_FAILED_BRANCH });
+        }
+
+        throw uploadError;
+      }
+    },
+  };
+};
+
+export const createAppDatabaseUploadHandoffService = (): DatabaseUploadHandoff =>
+  createDatabaseUploadHandoffService(
+    resolveAppGraphClient(),
+    resolveAppCacheStore(),
+    appSelectedDriveItemBindingStore,
+  );

--- a/src/features/app-shell/transferSaveExportService.test.ts
+++ b/src/features/app-shell/transferSaveExportService.test.ts
@@ -100,6 +100,32 @@ describe('transfer save export service', () => {
     expect(calls).toEqual(['write:Ordered write', 'export', 'upload']);
   });
 
+  it('passes upload progress options to the upload handoff', async () => {
+    const writeService = {
+      createTransfer: vi.fn(() => ({
+        transferId: 42,
+        persistedAtIso: '2026-06-25T00:00:00.000Z',
+      })),
+    };
+    const runtime = {
+      exportBytes: vi.fn(() => Uint8Array.from([1, 2, 3])),
+    };
+    const uploadHandoff: DatabaseUploadHandoff = {
+      uploadExportedDatabase: vi.fn(async (_dbBytes, options) => {
+        options?.onProgress?.({ loadedBytes: 1, totalBytes: 3 });
+      }),
+    };
+    const onProgress = vi.fn();
+    const service = createTransferSaveExportService(writeService, runtime, uploadHandoff);
+
+    await service.createTransferAndExport(createBaseInput('Progress write'), { onProgress });
+
+    expect(uploadHandoff.uploadExportedDatabase).toHaveBeenCalledWith(Uint8Array.from([1, 2, 3]), {
+      onProgress,
+    });
+    expect(onProgress).toHaveBeenCalledWith({ loadedBytes: 1, totalBytes: 3 });
+  });
+
   it('does not export or upload when the local write fails', async () => {
     const writeError = new DbRuntimeError('db_query_failed', 'write failed');
     const writeService = {

--- a/src/features/app-shell/transferSaveExportService.ts
+++ b/src/features/app-shell/transferSaveExportService.ts
@@ -1,18 +1,34 @@
 // Coordinates a committed local transfer write with SQLite byte export for upload handoff.
 import {
+  appTransferWriteService,
   DbRuntimeError,
+  resolveAppBrowserDbRuntime,
   type BrowserDbRuntime,
   type CreateTransferInput,
   type CreateTransferResult,
   type TransferWriteService,
 } from '@db';
 
+import { createAppDatabaseUploadHandoffService } from './databaseUploadHandoffService';
+
 export interface DatabaseUploadHandoff {
-  uploadExportedDatabase(dbBytes: Uint8Array): Promise<void>;
+  uploadExportedDatabase(dbBytes: Uint8Array, options?: DatabaseUploadOptions): Promise<void>;
+}
+
+export interface DatabaseUploadProgress {
+  readonly loadedBytes: number;
+  readonly totalBytes: number | null;
+}
+
+export interface DatabaseUploadOptions {
+  readonly onProgress?: (progress: DatabaseUploadProgress) => void;
 }
 
 export interface TransferSaveExportService {
-  createTransferAndExport(input: CreateTransferInput): Promise<CreateTransferResult>;
+  createTransferAndExport(
+    input: CreateTransferInput,
+    options?: DatabaseUploadOptions,
+  ): Promise<CreateTransferResult>;
 }
 
 type TransferExportRuntime = Pick<BrowserDbRuntime, 'exportBytes'>;
@@ -38,12 +54,22 @@ export const createTransferSaveExportService = (
   dbRuntime: TransferExportRuntimeProvider,
   uploadHandoff: DatabaseUploadHandoff,
 ): TransferSaveExportService => ({
-  async createTransferAndExport(input: CreateTransferInput): Promise<CreateTransferResult> {
+  async createTransferAndExport(
+    input: CreateTransferInput,
+    options?: DatabaseUploadOptions,
+  ): Promise<CreateTransferResult> {
     const transferResult = transferWriteService.createTransfer(input);
     const exportedBytes = cloneExportedBytes(resolveTransferExportRuntime(dbRuntime).exportBytes());
 
-    await uploadHandoff.uploadExportedDatabase(exportedBytes);
+    await uploadHandoff.uploadExportedDatabase(exportedBytes, options);
 
     return transferResult;
   },
 });
+
+export const createAppTransferSaveExportService = (): TransferSaveExportService =>
+  createTransferSaveExportService(
+    appTransferWriteService,
+    resolveAppBrowserDbRuntime,
+    createAppDatabaseUploadHandoffService(),
+  );


### PR DESCRIPTION
## Summary

- Adds the M6-07 Graph-backed database upload handoff for exported SQLite bytes.
- Uses the cached OneDrive eTag as the `If-Match` precondition and refreshes cache metadata from the upload result.
- Threads upload progress through the real save/export orchestration and sync state store.
- Surfaces precondition conflicts as a distinct upload error for downstream recovery UX.

## Acceptance Criteria

- [x] Successful writes upload exported DB bytes with `If-Match` and refresh local eTag/sync metadata.
- [x] Conflict responses are surfaced clearly for downstream recovery UX.
- [x] Real save/upload orchestration exposes upload progress for determinate UI feedback.
- [x] Reuses existing `@graph` upload-progress plumbing.

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run test:e2e`

Closes #70
