### PR TITLE
feat: [M6-08] Add transfer upload retry UX

### DIFF
--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -503,7 +503,7 @@ An issue is only considered done when:
 - Depends on: `M6-06, M4-02`
 - GitHub: [#70](https://github.com/Jon2050/Conspectus-Mobile/issues/70)
 
-### :green_circle: M6-08 Implement write failure and retry UX
+### :white_check_mark: M6-08 Implement write failure and retry UX
 
 - Label: `feature`
 - Milestone: `M6 - Add Transfer Write Path`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.6.7",
+  "version": "0.6.08",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.6.7",
+      "version": "0.6.08",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.6.7",
+  "version": "0.6.08",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/features/app-shell/components/BottomSheet.svelte
+++ b/src/features/app-shell/components/BottomSheet.svelte
@@ -4,17 +4,29 @@
 
   export let isOpen = false;
   export let title = '';
+  export let canClose = true;
 
   let dialogElement: HTMLDialogElement | null = null;
   const dispatch = createEventDispatcher();
 
   const requestClose = () => {
+    if (!canClose) {
+      return;
+    }
+
     if (dialogElement?.open) {
       dialogElement.close();
     }
   };
 
   const handleDialogClose = () => {
+    if (!canClose) {
+      if (dialogElement !== null && !dialogElement.open) {
+        dialogElement.showModal();
+      }
+      return;
+    }
+
     if (!isOpen) {
       return;
     }

--- a/src/features/app-shell/routes/AddRoute.svelte
+++ b/src/features/app-shell/routes/AddRoute.svelte
@@ -10,23 +10,29 @@
   } from '@db';
   import { appSyncStateStore, type SyncState, type SyncStateStore } from '@shared';
   import BottomSheet from '../components/BottomSheet.svelte';
+  import ProgressIndicator from '../components/ProgressIndicator.svelte';
   import {
     createInitialFormFields,
     NO_CATEGORY_SELECTED,
     type AddTransferFormFields,
   } from './addTransferFormState';
-  import { validateAddTransfer } from './addTransferValidation';
   import {
     createAddTransferOptionsController,
     shouldReloadAddTransferOptionsForSyncState,
     type AddTransferOptionsController,
     type AddTransferOptionsState,
   } from './addTransferOptionsController';
+  import {
+    createAddTransferSaveController,
+    type AddTransferSaveController,
+    type AddTransferSaveState,
+  } from './addTransferSaveController';
 
   export let controller: AddTransferOptionsController = createAddTransferOptionsController(
     appAccountQueryService,
     appCategoryQueryService,
   );
+  export let saveController: AddTransferSaveController = createAddTransferSaveController();
   export let fields: AddTransferFormFields = createInitialFormFields();
   export let isSubmitting = false;
   export let formError: string | null = null;
@@ -34,10 +40,14 @@
 
   let isOpen = true;
   let optionsState: AddTransferOptionsState = controller.getState();
+  let saveState: AddTransferSaveState = saveController.getState();
   let lastObservedSyncState: SyncState = 'idle';
   $: isOptionsLoading = optionsState.operation === 'loading';
-  $: effectiveFormError = formError ?? optionsState.error?.message ?? null;
-  $: controlsAreDisabled = isSubmitting || isOptionsLoading;
+  $: saveIsBusy = saveState.phase === 'local_save' || saveState.phase === 'uploading';
+  $: saveHasPendingUpload = saveState.canRetry || saveState.phase === 'conflict';
+  $: effectiveFormError =
+    formError ?? saveState.errorMessage ?? optionsState.error?.message ?? null;
+  $: controlsAreDisabled = isSubmitting || isOptionsLoading || saveIsBusy || saveHasPendingUpload;
 
   let validationErrors: string[] = [];
 
@@ -47,16 +57,21 @@
     }
   };
 
-  const handleSubmit = (): void => {
-    validationErrors = validateAddTransfer(
-      fields,
-      optionsState.fromAccountOptions,
-      optionsState.toAccountOptions,
-      $_,
-    );
-    if (validationErrors.length > 0) {
-      return;
+  const resetSuccessfulSave = (): void => {
+    if (saveController.getState().phase === 'saved') {
+      fields = createInitialFormFields();
     }
+  };
+
+  const handleSubmit = async (): Promise<void> => {
+    const result = await saveController.submit(fields, optionsState, $_);
+    validationErrors = [...result.validationErrors];
+    resetSuccessfulSave();
+  };
+
+  const handleRetry = async (): Promise<void> => {
+    await saveController.retry($_);
+    resetSuccessfulSave();
   };
 
   const getAccountName = (account: { name: string; accountTypeId: number | null }) => {
@@ -74,6 +89,9 @@
   const unsubscribeController = controller.subscribe((nextState) => {
     optionsState = nextState;
   });
+  const unsubscribeSaveController = saveController.subscribe((nextState) => {
+    saveState = nextState;
+  });
   const unsubscribeSyncState = syncStateStore.subscribe((syncSnapshot) => {
     if (syncSnapshot.state === lastObservedSyncState) {
       return;
@@ -86,6 +104,10 @@
   });
 
   const handleClose = (): void => {
+    if (saveIsBusy || saveController.getState().canRetry) {
+      return;
+    }
+
     isOpen = false;
     if (typeof window !== 'undefined') {
       window.location.hash = '#/transfers';
@@ -94,6 +116,7 @@
 
   const handleReopen = (): void => {
     fields = createInitialFormFields();
+    saveController.reset();
     isOpen = true;
   };
 
@@ -103,6 +126,7 @@
 
   onDestroy(() => {
     unsubscribeController();
+    unsubscribeSaveController();
     unsubscribeSyncState();
   });
 </script>
@@ -120,11 +144,16 @@
     </div>
   {/if}
 
-  <BottomSheet {isOpen} title={$_('addTransfer.title')} on:close={handleClose}>
+  <BottomSheet
+    {isOpen}
+    canClose={!saveIsBusy && !saveState.canRetry}
+    title={$_('addTransfer.title')}
+    on:close={handleClose}
+  >
     <form
       class="add-transfer-form"
       data-testid="add-transfer-form"
-      aria-busy={isSubmitting || isOptionsLoading}
+      aria-busy={isSubmitting || isOptionsLoading || saveIsBusy}
       on:submit|preventDefault={handleSubmit}
       on:input={clearValidation}
       on:change={clearValidation}
@@ -138,6 +167,35 @@
       {#if effectiveFormError !== null}
         <p class="add-transfer-form__error" role="alert" data-testid="add-transfer-form-error">
           {effectiveFormError}
+        </p>
+      {/if}
+
+      {#if saveState.phase === 'local_save'}
+        <p class="add-transfer-form__status" data-testid="add-transfer-local-save-status">
+          {$_('addTransfer.save.localSave')}
+        </p>
+      {/if}
+
+      {#if saveState.phase === 'uploading'}
+        <div class="add-transfer-form__upload" data-testid="add-transfer-upload-status">
+          <p class="add-transfer-form__status">{$_('addTransfer.save.uploading')}</p>
+          {#if saveState.progress !== null}
+            <ProgressIndicator
+              kind="upload"
+              loaded={saveState.progress.loadedBytes}
+              total={saveState.progress.totalBytes}
+            />
+          {/if}
+        </div>
+      {/if}
+
+      {#if saveState.phase === 'saved'}
+        <p
+          class="add-transfer-form__success"
+          role="status"
+          data-testid="add-transfer-success-status"
+        >
+          {$_('addTransfer.save.success')}
         </p>
       {/if}
 
@@ -311,19 +369,31 @@
           type="button"
           class="app-button app-button--secondary add-transfer-form__action"
           data-testid="add-transfer-close"
-          disabled={isSubmitting}
+          disabled={isSubmitting || saveIsBusy || saveState.canRetry}
           on:click={handleClose}
         >
           {$_('addTransfer.close')}
         </button>
-        <button
-          type="submit"
-          class="app-button app-button--primary add-transfer-form__action"
-          data-testid="add-transfer-submit"
-          disabled={controlsAreDisabled}
-        >
-          {isSubmitting ? $_('addTransfer.saving') : $_('addTransfer.submit')}
-        </button>
+        {#if saveState.canRetry}
+          <button
+            type="button"
+            class="app-button app-button--primary add-transfer-form__action"
+            data-testid="add-transfer-retry"
+            disabled={saveIsBusy}
+            on:click={handleRetry}
+          >
+            {$_('addTransfer.save.retry')}
+          </button>
+        {:else}
+          <button
+            type="submit"
+            class="app-button app-button--primary add-transfer-form__action"
+            data-testid="add-transfer-submit"
+            disabled={controlsAreDisabled}
+          >
+            {saveIsBusy || isSubmitting ? $_('addTransfer.saving') : $_('addTransfer.submit')}
+          </button>
+        {/if}
       </div>
     </form>
   </BottomSheet>
@@ -372,11 +442,28 @@
     font-weight: 600;
   }
 
+  .add-transfer-form__success {
+    margin: 0;
+    padding: 0.8rem 0.9rem;
+    border: 1px solid color-mix(in srgb, var(--positive) 45%, transparent);
+    border-radius: var(--radius-md);
+    color: color-mix(in srgb, var(--positive) 76%, black);
+    background: color-mix(in srgb, var(--positive) 10%, var(--surface-strong));
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
   .add-transfer-form__status {
     margin: 0;
     color: var(--text-secondary);
     font-size: 0.9rem;
     font-weight: 600;
+  }
+
+  .add-transfer-form__upload {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
   }
 
   .add-transfer-form__field {

--- a/src/features/app-shell/routes/AddRoute.test.ts
+++ b/src/features/app-shell/routes/AddRoute.test.ts
@@ -7,6 +7,7 @@ import type {
   AddTransferOptionsController,
   AddTransferOptionsState,
 } from './addTransferOptionsController';
+import type { AddTransferSaveController, AddTransferSaveState } from './addTransferSaveController';
 
 const READY_OPTIONS_STATE: AddTransferOptionsState = {
   operation: 'ready',
@@ -27,10 +28,31 @@ const createMockOptionsController = (
   load: async () => {},
 });
 
+const READY_SAVE_STATE: AddTransferSaveState = {
+  phase: 'idle',
+  errorMessage: null,
+  progress: null,
+  canRetry: false,
+};
+
+const createMockSaveController = (
+  state: AddTransferSaveState = READY_SAVE_STATE,
+): AddTransferSaveController => ({
+  getState: () => state,
+  subscribe: (listener) => {
+    listener(state);
+    return () => {};
+  },
+  submit: async () => ({ validationErrors: [] }),
+  retry: async () => {},
+  reset: () => {},
+});
+
 const renderAddRoute = (props: Record<string, unknown> = {}) =>
   render(AddRoute, {
     props: {
       controller: createMockOptionsController(),
+      saveController: createMockSaveController(),
       ...props,
     },
   });
@@ -241,6 +263,82 @@ describe('AddRoute component', () => {
     expect(body).toMatch(/data-testid="add-transfer-name"[^>]*disabled/);
     expect(body).toMatch(/data-testid="add-transfer-buyplace"[^>]*disabled/);
     expect(body).toMatch(/data-testid="add-transfer-close"[^>]*disabled/);
+  });
+
+  it('renders local save status and disables controls while the local write/export runs', () => {
+    const { body } = renderAddRoute({
+      saveController: createMockSaveController({
+        ...READY_SAVE_STATE,
+        phase: 'local_save',
+      }),
+    });
+
+    expect(body).toContain('data-testid="add-transfer-local-save-status"');
+    expect(body).toContain('Transfer wird lokal gespeichert');
+    expect(body).toContain('aria-busy="true"');
+    expect(body).toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
+    expect(body).toMatch(/data-testid="add-transfer-close"[^>]*disabled/);
+  });
+
+  it('renders determinate upload progress while the database upload runs', () => {
+    const { body } = renderAddRoute({
+      saveController: createMockSaveController({
+        ...READY_SAVE_STATE,
+        phase: 'uploading',
+        progress: { loadedBytes: 5120, totalBytes: 10240 },
+      }),
+    });
+
+    expect(body).toContain('data-testid="add-transfer-upload-status"');
+    expect(body).toContain('Aktualisierte Datenbank wird auf OneDrive hochgeladen');
+    expect(body).toContain('data-kind="upload"');
+    expect(body).toContain('value="5120"');
+    expect(body).toContain('max="10240"');
+    expect(body).toContain('5 KB / 10 KB hochgeladen');
+    expect(body).toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
+  });
+
+  it('renders retry action and preserves visible form values after retryable upload failure', () => {
+    const { body } = renderAddRoute({
+      fields: {
+        date: '2024-05-12',
+        name: 'Groceries',
+        amount: '12,34',
+        fromAccountId: null,
+        toAccountId: null,
+        category1Id: -1,
+        category2Id: -1,
+        category3Id: -1,
+        buyplace: 'Market',
+      },
+      saveController: createMockSaveController({
+        ...READY_SAVE_STATE,
+        phase: 'upload_failed',
+        errorMessage: 'Upload failed.',
+        canRetry: true,
+      }),
+    });
+
+    expect(body).toContain('data-testid="add-transfer-form-error"');
+    expect(body).toContain('Upload failed.');
+    expect(body).toContain('data-testid="add-transfer-retry"');
+    expect(body).toContain('Upload wiederholen');
+    expect(body).toContain('value="Groceries"');
+    expect(body).toContain('value="12,34"');
+    expect(body).toContain('value="Market"');
+    expect(body).toMatch(/data-testid="add-transfer-close"[^>]*disabled/);
+  });
+
+  it('renders success status only when the save controller reports a completed upload', () => {
+    const { body } = renderAddRoute({
+      saveController: createMockSaveController({
+        ...READY_SAVE_STATE,
+        phase: 'saved',
+      }),
+    });
+
+    expect(body).toContain('data-testid="add-transfer-success-status"');
+    expect(body).toContain('Transfer gespeichert und hochgeladen.');
   });
 
   it('renders a form-level error without disabling normal editing', () => {

--- a/src/features/app-shell/routes/addTransferSaveController.test.ts
+++ b/src/features/app-shell/routes/addTransferSaveController.test.ts
@@ -1,0 +1,245 @@
+// Verifies Add Transfer save-state orchestration, upload retry behavior, and toast feedback.
+import { describe, expect, it, vi } from 'vitest';
+
+import { DatabaseUploadError } from '../databaseUploadHandoffService';
+import {
+  TransferUploadPendingError,
+  type DatabaseUploadOptions,
+  type TransferSaveExportService,
+} from '../transferSaveExportService';
+import type { CreateTransferInput, CreateTransferResult } from '@db';
+import {
+  createInitialFormFields,
+  NO_CATEGORY_SELECTED,
+  type AddTransferFormFields,
+} from './addTransferFormState';
+import {
+  createAddTransferSaveController,
+  type AddTransferSaveState,
+} from './addTransferSaveController';
+import type { AddTransferOptionsState } from './addTransferOptionsController';
+
+const t = (key: string): string => key;
+
+const READY_OPTIONS: AddTransferOptionsState = {
+  operation: 'ready',
+  fromAccountOptions: [
+    { accountId: 1, name: 'Income', accountTypeId: 1 },
+    { accountId: 3, name: 'Checking', accountTypeId: 3 },
+  ],
+  toAccountOptions: [
+    { accountId: 2, name: 'Spendings', accountTypeId: 2 },
+    { accountId: 4, name: 'Savings', accountTypeId: 3 },
+  ],
+  categoryOptions: [{ categoryId: 7, name: 'Food' }],
+  error: null,
+};
+
+const createValidFields = (): AddTransferFormFields => ({
+  ...createInitialFormFields(),
+  date: '2024-05-12',
+  name: 'Groceries',
+  amount: '12,34',
+  fromAccountId: 3,
+  toAccountId: 4,
+  category1Id: 7,
+  category2Id: NO_CATEGORY_SELECTED,
+  category3Id: NO_CATEGORY_SELECTED,
+  buyplace: 'Market',
+});
+
+const createSaveService = (): TransferSaveExportService => ({
+  createTransferAndExport: vi.fn(async (_input, options) => {
+    options?.onUploadStart?.();
+    options?.onProgress?.({ loadedBytes: 5, totalBytes: 10 });
+    return { transferId: 42, persistedAtIso: '2026-06-25T00:00:00.000Z' };
+  }),
+  retryExportedDatabaseUpload: vi.fn(async (_dbBytes, options) => {
+    options?.onUploadStart?.();
+    options?.onProgress?.({ loadedBytes: 10, totalBytes: 10 });
+  }),
+});
+
+const collectStates = (
+  controller: ReturnType<typeof createAddTransferSaveController>,
+): AddTransferSaveState[] => {
+  const states: AddTransferSaveState[] = [];
+  controller.subscribe((state) => {
+    states.push(state);
+  });
+  return states;
+};
+
+describe('addTransferSaveController', () => {
+  it('returns validation errors without invoking the save service', async () => {
+    const saveService = createSaveService();
+    const toastStore = { show: vi.fn() };
+    const controller = createAddTransferSaveController(saveService, toastStore);
+    const invalidFields = { ...createValidFields(), name: 'No' };
+
+    const result = await controller.submit(invalidFields, READY_OPTIONS, t);
+
+    expect(result.validationErrors).toContain('addTransfer.validation.nameLength');
+    expect(saveService.createTransferAndExport).not.toHaveBeenCalled();
+    expect(toastStore.show).not.toHaveBeenCalled();
+  });
+
+  it('maps validated fields into a transfer input and reports success after upload resolves', async () => {
+    const saveService = createSaveService();
+    const toastStore = { show: vi.fn() };
+    const controller = createAddTransferSaveController(saveService, toastStore);
+    const states = collectStates(controller);
+
+    const result = await controller.submit(createValidFields(), READY_OPTIONS, t);
+
+    expect(result.validationErrors).toEqual([]);
+    expect(saveService.createTransferAndExport).toHaveBeenCalledWith(
+      {
+        bookingDateEpochDay: 19855,
+        name: 'Groceries',
+        amountCents: 1234,
+        transferTypeId: 3,
+        fromAccountId: 3,
+        toAccountId: 4,
+        categoryIds: [7],
+        buyplace: 'Market',
+      },
+      expect.objectContaining({
+        onUploadStart: expect.any(Function),
+        onProgress: expect.any(Function),
+      }),
+    );
+    expect(states.map((state) => state.phase)).toEqual([
+      'idle',
+      'local_save',
+      'uploading',
+      'uploading',
+      'saved',
+    ]);
+    expect(toastStore.show).toHaveBeenCalledWith('addTransfer.save.successToast', 'success');
+  });
+
+  it('does not report success before a slow upload promise resolves', async () => {
+    let resolveUpload: () => void = () => {};
+    const saveService: TransferSaveExportService = {
+      createTransferAndExport: vi.fn(
+        (_input: CreateTransferInput, options?: DatabaseUploadOptions) =>
+          new Promise<CreateTransferResult>((resolve) => {
+            options?.onUploadStart?.();
+            resolveUpload = () =>
+              resolve({ transferId: 42, persistedAtIso: '2026-06-25T00:00:00.000Z' });
+          }),
+      ),
+      retryExportedDatabaseUpload: vi.fn(async () => {}),
+    };
+    const toastStore = { show: vi.fn() };
+    const controller = createAddTransferSaveController(saveService, toastStore);
+
+    const submitPromise = controller.submit(createValidFields(), READY_OPTIONS, t);
+    await Promise.resolve();
+
+    expect(controller.getState().phase).toBe('uploading');
+    expect(toastStore.show).not.toHaveBeenCalled();
+
+    resolveUpload();
+    await submitPromise;
+
+    expect(controller.getState().phase).toBe('saved');
+    expect(toastStore.show).toHaveBeenCalledWith('addTransfer.save.successToast', 'success');
+  });
+
+  it('preserves failed upload state and retries exported bytes without re-submitting fields', async () => {
+    const pendingBytes = Uint8Array.from([1, 2, 3]);
+    const saveService: TransferSaveExportService = {
+      createTransferAndExport: vi.fn(async (_input, options) => {
+        options?.onUploadStart?.();
+        throw new TransferUploadPendingError(
+          {
+            transferResult: { transferId: 42, persistedAtIso: '2026-06-25T00:00:00.000Z' },
+            dbBytes: pendingBytes,
+          },
+          new DatabaseUploadError('upload_failed', 'Network dropped.'),
+        );
+      }),
+      retryExportedDatabaseUpload: vi.fn(async (_dbBytes, options) => {
+        options?.onUploadStart?.();
+      }),
+    };
+    const toastStore = { show: vi.fn() };
+    const controller = createAddTransferSaveController(saveService, toastStore);
+    const fields = createValidFields();
+
+    await controller.submit(fields, READY_OPTIONS, t);
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'upload_failed',
+      errorMessage: 'Network dropped.',
+      canRetry: true,
+    });
+    expect(fields).toEqual(createValidFields());
+
+    await controller.retry(t);
+
+    expect(saveService.createTransferAndExport).toHaveBeenCalledOnce();
+    expect(saveService.retryExportedDatabaseUpload).toHaveBeenCalledWith(
+      pendingBytes,
+      expect.objectContaining({
+        onUploadStart: expect.any(Function),
+        onProgress: expect.any(Function),
+      }),
+    );
+    expect(controller.getState().phase).toBe('saved');
+  });
+
+  it('ignores duplicate submissions while a save is active', async () => {
+    let resolveUpload: () => void = () => {};
+    const saveService: TransferSaveExportService = {
+      createTransferAndExport: vi.fn(
+        (_input: CreateTransferInput, options?: DatabaseUploadOptions) =>
+          new Promise<CreateTransferResult>((resolve) => {
+            options?.onUploadStart?.();
+            resolveUpload = () =>
+              resolve({ transferId: 42, persistedAtIso: '2026-06-25T00:00:00.000Z' });
+          }),
+      ),
+      retryExportedDatabaseUpload: vi.fn(async () => {}),
+    };
+    const controller = createAddTransferSaveController(saveService, { show: vi.fn() });
+
+    const firstSubmit = controller.submit(createValidFields(), READY_OPTIONS, t);
+    await Promise.resolve();
+    await controller.submit(createValidFields(), READY_OPTIONS, t);
+
+    expect(saveService.createTransferAndExport).toHaveBeenCalledOnce();
+
+    resolveUpload();
+    await firstSubmit;
+  });
+
+  it('does not offer direct retry for upload conflicts', async () => {
+    const saveService: TransferSaveExportService = {
+      createTransferAndExport: vi.fn(async (_input, options) => {
+        options?.onUploadStart?.();
+        throw new TransferUploadPendingError(
+          {
+            transferResult: { transferId: 42, persistedAtIso: '2026-06-25T00:00:00.000Z' },
+            dbBytes: Uint8Array.from([1, 2, 3]),
+          },
+          new DatabaseUploadError('conflict', 'OneDrive changed.'),
+        );
+      }),
+      retryExportedDatabaseUpload: vi.fn(async () => {}),
+    };
+    const toastStore = { show: vi.fn() };
+    const controller = createAddTransferSaveController(saveService, toastStore);
+
+    await controller.submit(createValidFields(), READY_OPTIONS, t);
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'conflict',
+      errorMessage: 'OneDrive changed.',
+      canRetry: false,
+    });
+    expect(toastStore.show).toHaveBeenCalledWith('addTransfer.save.conflictToast', 'error');
+  });
+});

--- a/src/features/app-shell/routes/addTransferSaveController.ts
+++ b/src/features/app-shell/routes/addTransferSaveController.ts
@@ -1,0 +1,287 @@
+// Orchestrates Add Transfer submit, upload progress, retry state, and user feedback.
+import { DatabaseUploadError } from '../databaseUploadHandoffService';
+import {
+  createAppTransferSaveExportService,
+  TransferUploadPendingError,
+  type DatabaseUploadProgress,
+  type PendingTransferUpload,
+  type TransferSaveExportService,
+} from '../transferSaveExportService';
+import type { ToastStore } from '@shared';
+import { appToastStore } from '@shared';
+import type { CreateTransferInput } from '@db';
+
+import {
+  isoDateToEpochDay,
+  NO_CATEGORY_SELECTED,
+  type AddTransferAccountOption,
+  type AddTransferFormFields,
+} from './addTransferFormState';
+import type { AddTransferOptionsState } from './addTransferOptionsController';
+import { validateAddTransfer } from './addTransferValidation';
+import { deriveTransferType } from './transferTypeDerivation';
+
+export type AddTransferSavePhase =
+  | 'idle'
+  | 'local_save'
+  | 'uploading'
+  | 'upload_failed'
+  | 'conflict'
+  | 'local_failed'
+  | 'saved';
+
+export interface AddTransferSaveState {
+  readonly phase: AddTransferSavePhase;
+  readonly errorMessage: string | null;
+  readonly progress: DatabaseUploadProgress | null;
+  readonly canRetry: boolean;
+}
+
+export type AddTransferSaveStateListener = (state: AddTransferSaveState) => void;
+export type AddTransferTranslator = (key: string) => string;
+
+export interface AddTransferSubmitResult {
+  readonly validationErrors: readonly string[];
+}
+
+export interface AddTransferSaveController {
+  getState(): AddTransferSaveState;
+  subscribe(listener: AddTransferSaveStateListener): () => void;
+  submit(
+    fields: AddTransferFormFields,
+    optionsState: AddTransferOptionsState,
+    t: AddTransferTranslator,
+  ): Promise<AddTransferSubmitResult>;
+  retry(t: AddTransferTranslator): Promise<void>;
+  reset(): void;
+}
+
+const INITIAL_STATE: AddTransferSaveState = {
+  phase: 'idle',
+  errorMessage: null,
+  progress: null,
+  canRetry: false,
+};
+
+const isBusyPhase = (phase: AddTransferSavePhase): boolean =>
+  phase === 'local_save' || phase === 'uploading';
+
+const parseAmountCents = (amount: string): number =>
+  Math.round(Number.parseFloat(amount.trim().replace(',', '.')) * 100);
+
+const selectedCategoryIds = (fields: AddTransferFormFields): readonly number[] =>
+  [fields.category1Id, fields.category2Id, fields.category3Id].filter(
+    (categoryId) => categoryId !== NO_CATEGORY_SELECTED,
+  );
+
+const findAccount = (
+  accounts: readonly AddTransferAccountOption[],
+  accountId: number | null,
+): AddTransferAccountOption | null =>
+  accountId === null ? null : (accounts.find((account) => account.accountId === accountId) ?? null);
+
+const toCreateTransferInput = (
+  fields: AddTransferFormFields,
+  optionsState: AddTransferOptionsState,
+): CreateTransferInput => {
+  const fromAccount = findAccount(optionsState.fromAccountOptions, fields.fromAccountId);
+  const toAccount = findAccount(optionsState.toAccountOptions, fields.toAccountId);
+
+  if (fromAccount === null || toAccount === null) {
+    throw new Error('Selected transfer accounts are no longer available.');
+  }
+
+  return {
+    bookingDateEpochDay: isoDateToEpochDay(fields.date),
+    name: fields.name.trim(),
+    amountCents: parseAmountCents(fields.amount),
+    transferTypeId: deriveTransferType(fromAccount.accountTypeId, toAccount.accountTypeId),
+    fromAccountId: fromAccount.accountId,
+    toAccountId: toAccount.accountId,
+    categoryIds: selectedCategoryIds(fields),
+    buyplace: fields.buyplace.trim().length > 0 ? fields.buyplace.trim() : null,
+  };
+};
+
+const isRetryableUploadError = (error: TransferUploadPendingError): boolean =>
+  error.cause instanceof DatabaseUploadError ? error.cause.code === 'upload_failed' : true;
+
+const toLocalErrorMessage = (error: unknown, fallbackMessage: string): string =>
+  error instanceof Error && error.message.trim().length > 0 ? error.message : fallbackMessage;
+
+const toUploadErrorMessage = (
+  error: TransferUploadPendingError,
+  fallbackMessage: string,
+): string =>
+  error.cause instanceof Error && error.cause.message.trim().length > 0
+    ? error.cause.message
+    : fallbackMessage;
+
+export const createAddTransferSaveController = (
+  saveService: TransferSaveExportService = createAppTransferSaveExportService(),
+  toastStore: Pick<ToastStore, 'show'> = appToastStore,
+): AddTransferSaveController => {
+  let state = INITIAL_STATE;
+  let pendingUpload: PendingTransferUpload | null = null;
+  const listeners = new Set<AddTransferSaveStateListener>();
+
+  const emitState = (): void => {
+    for (const listener of listeners) {
+      listener(state);
+    }
+  };
+
+  const updateState = (patch: Partial<AddTransferSaveState>): void => {
+    state = { ...state, ...patch };
+    emitState();
+  };
+
+  const setUploadStarted = (): void => {
+    updateState({
+      phase: 'uploading',
+      errorMessage: null,
+      progress: null,
+      canRetry: false,
+    });
+  };
+
+  const setUploadProgress = (progress: DatabaseUploadProgress): void => {
+    updateState({
+      phase: 'uploading',
+      progress,
+    });
+  };
+
+  const setSaved = (t: AddTransferTranslator): void => {
+    pendingUpload = null;
+    updateState({
+      phase: 'saved',
+      errorMessage: null,
+      progress: null,
+      canRetry: false,
+    });
+    toastStore.show(t('addTransfer.save.successToast'), 'success');
+  };
+
+  const setUploadFailure = (error: TransferUploadPendingError, t: AddTransferTranslator): void => {
+    pendingUpload = error.pendingUpload;
+    const canRetry = isRetryableUploadError(error);
+    const phase: AddTransferSavePhase = canRetry ? 'upload_failed' : 'conflict';
+    const message = toUploadErrorMessage(error, t('addTransfer.save.uploadFailed'));
+
+    updateState({
+      phase,
+      errorMessage: message,
+      progress: null,
+      canRetry,
+    });
+
+    toastStore.show(
+      canRetry ? t('addTransfer.save.uploadFailedToast') : t('addTransfer.save.conflictToast'),
+      'error',
+    );
+  };
+
+  return {
+    getState(): AddTransferSaveState {
+      return state;
+    },
+
+    subscribe(listener: AddTransferSaveStateListener): () => void {
+      listeners.add(listener);
+      listener(state);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    async submit(
+      fields: AddTransferFormFields,
+      optionsState: AddTransferOptionsState,
+      t: AddTransferTranslator,
+    ): Promise<AddTransferSubmitResult> {
+      if (isBusyPhase(state.phase)) {
+        return { validationErrors: [] };
+      }
+
+      const validationErrors = validateAddTransfer(
+        fields,
+        optionsState.fromAccountOptions,
+        optionsState.toAccountOptions,
+        t,
+      );
+      if (validationErrors.length > 0) {
+        return { validationErrors };
+      }
+
+      pendingUpload = null;
+      updateState({
+        phase: 'local_save',
+        errorMessage: null,
+        progress: null,
+        canRetry: false,
+      });
+
+      try {
+        await saveService.createTransferAndExport(toCreateTransferInput(fields, optionsState), {
+          onUploadStart: setUploadStarted,
+          onProgress: setUploadProgress,
+        });
+        setSaved(t);
+      } catch (error) {
+        if (error instanceof TransferUploadPendingError) {
+          setUploadFailure(error, t);
+        } else {
+          updateState({
+            phase: 'local_failed',
+            errorMessage: toLocalErrorMessage(error, t('addTransfer.save.localFailed')),
+            progress: null,
+            canRetry: false,
+          });
+          toastStore.show(t('addTransfer.save.localFailedToast'), 'error');
+        }
+      }
+
+      return { validationErrors: [] };
+    },
+
+    async retry(t: AddTransferTranslator): Promise<void> {
+      if (isBusyPhase(state.phase) || pendingUpload === null || !state.canRetry) {
+        return;
+      }
+
+      try {
+        await saveService.retryExportedDatabaseUpload(pendingUpload.dbBytes, {
+          onUploadStart: setUploadStarted,
+          onProgress: setUploadProgress,
+        });
+        setSaved(t);
+      } catch (error) {
+        if (error instanceof DatabaseUploadError && error.code === 'conflict') {
+          updateState({
+            phase: 'conflict',
+            errorMessage: error.message,
+            progress: null,
+            canRetry: false,
+          });
+          toastStore.show(t('addTransfer.save.conflictToast'), 'error');
+          return;
+        }
+
+        updateState({
+          phase: 'upload_failed',
+          errorMessage: toLocalErrorMessage(error, t('addTransfer.save.uploadFailed')),
+          progress: null,
+          canRetry: true,
+        });
+        toastStore.show(t('addTransfer.save.retryFailedToast'), 'error');
+      }
+    },
+
+    reset(): void {
+      pendingUpload = null;
+      updateState(INITIAL_STATE);
+    },
+  };
+};

--- a/src/features/app-shell/transferSaveExportService.test.ts
+++ b/src/features/app-shell/transferSaveExportService.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../../shared/testUtils/dbIntegration';
 import {
   createTransferSaveExportService,
+  TransferUploadPendingError,
   type DatabaseUploadHandoff,
 } from './transferSaveExportService';
 
@@ -116,14 +117,65 @@ describe('transfer save export service', () => {
       }),
     };
     const onProgress = vi.fn();
+    const onUploadStart = vi.fn();
     const service = createTransferSaveExportService(writeService, runtime, uploadHandoff);
 
-    await service.createTransferAndExport(createBaseInput('Progress write'), { onProgress });
-
-    expect(uploadHandoff.uploadExportedDatabase).toHaveBeenCalledWith(Uint8Array.from([1, 2, 3]), {
+    await service.createTransferAndExport(createBaseInput('Progress write'), {
+      onUploadStart,
       onProgress,
     });
+
+    expect(uploadHandoff.uploadExportedDatabase).toHaveBeenCalledWith(Uint8Array.from([1, 2, 3]), {
+      onUploadStart,
+      onProgress,
+    });
+    expect(onUploadStart).toHaveBeenCalledOnce();
     expect(onProgress).toHaveBeenCalledWith({ loadedBytes: 1, totalBytes: 3 });
+  });
+
+  it('preserves committed exported bytes when upload fails so retry does not write again', async () => {
+    const uploadError = new Error('temporary upload failure');
+    const writeService = {
+      createTransfer: vi.fn(() => ({
+        transferId: 42,
+        persistedAtIso: '2026-06-25T00:00:00.000Z',
+      })),
+    };
+    const runtime = {
+      exportBytes: vi.fn(() => Uint8Array.from([1, 2, 3])),
+    };
+    const uploadHandoff: DatabaseUploadHandoff = {
+      uploadExportedDatabase: vi
+        .fn()
+        .mockRejectedValueOnce(uploadError)
+        .mockResolvedValueOnce(undefined),
+    };
+    const service = createTransferSaveExportService(writeService, runtime, uploadHandoff);
+
+    const pendingError = await service
+      .createTransferAndExport(createBaseInput('Retry upload write'))
+      .catch((error: unknown) => error);
+
+    expect(pendingError).toBeInstanceOf(TransferUploadPendingError);
+    const retryError = pendingError as TransferUploadPendingError;
+    expect(pendingError).toMatchObject({
+      pendingUpload: {
+        transferResult: {
+          transferId: 42,
+          persistedAtIso: '2026-06-25T00:00:00.000Z',
+        },
+        dbBytes: Uint8Array.from([1, 2, 3]),
+      },
+      cause: uploadError,
+    });
+    await service.retryExportedDatabaseUpload(retryError.pendingUpload.dbBytes);
+
+    expect(writeService.createTransfer).toHaveBeenCalledOnce();
+    expect(runtime.exportBytes).toHaveBeenCalledOnce();
+    expect(uploadHandoff.uploadExportedDatabase).toHaveBeenLastCalledWith(
+      Uint8Array.from([1, 2, 3]),
+      undefined,
+    );
   });
 
   it('does not export or upload when the local write fails', async () => {

--- a/src/features/app-shell/transferSaveExportService.ts
+++ b/src/features/app-shell/transferSaveExportService.ts
@@ -21,6 +21,7 @@ export interface DatabaseUploadProgress {
 }
 
 export interface DatabaseUploadOptions {
+  readonly onUploadStart?: () => void;
   readonly onProgress?: (progress: DatabaseUploadProgress) => void;
 }
 
@@ -29,6 +30,26 @@ export interface TransferSaveExportService {
     input: CreateTransferInput,
     options?: DatabaseUploadOptions,
   ): Promise<CreateTransferResult>;
+  retryExportedDatabaseUpload(dbBytes: Uint8Array, options?: DatabaseUploadOptions): Promise<void>;
+}
+
+export interface PendingTransferUpload {
+  readonly transferResult: CreateTransferResult;
+  readonly dbBytes: Uint8Array;
+}
+
+export class TransferUploadPendingError extends Error {
+  readonly pendingUpload: PendingTransferUpload;
+  readonly cause?: unknown;
+
+  constructor(pendingUpload: PendingTransferUpload, cause: unknown) {
+    super(cause instanceof Error ? cause.message : 'Uploading the transfer failed.');
+    this.name = 'TransferUploadPendingError';
+    this.pendingUpload = pendingUpload;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
 }
 
 type TransferExportRuntime = Pick<BrowserDbRuntime, 'exportBytes'>;
@@ -61,9 +82,28 @@ export const createTransferSaveExportService = (
     const transferResult = transferWriteService.createTransfer(input);
     const exportedBytes = cloneExportedBytes(resolveTransferExportRuntime(dbRuntime).exportBytes());
 
-    await uploadHandoff.uploadExportedDatabase(exportedBytes, options);
+    try {
+      options?.onUploadStart?.();
+      await uploadHandoff.uploadExportedDatabase(exportedBytes, options);
+    } catch (error) {
+      throw new TransferUploadPendingError(
+        {
+          transferResult,
+          dbBytes: exportedBytes,
+        },
+        error,
+      );
+    }
 
     return transferResult;
+  },
+
+  async retryExportedDatabaseUpload(
+    dbBytes: Uint8Array,
+    options?: DatabaseUploadOptions,
+  ): Promise<void> {
+    options?.onUploadStart?.();
+    await uploadHandoff.uploadExportedDatabase(dbBytes, options);
   },
 });
 

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -55,6 +55,19 @@
     "submit": "Transfer speichern",
     "saving": "Transfer wird gespeichert...",
     "close": "Schließen",
+    "save": {
+      "localSave": "Transfer wird lokal gespeichert und der Datenbank-Upload vorbereitet...",
+      "uploading": "Aktualisierte Datenbank wird auf OneDrive hochgeladen...",
+      "uploadFailed": "Der Upload der Datenbank zu OneDrive ist fehlgeschlagen. Deine Transferdaten bleiben erhalten.",
+      "localFailed": "Der Transfer konnte lokal nicht gespeichert werden. Es wurde nichts hochgeladen.",
+      "retry": "Upload wiederholen",
+      "success": "Transfer gespeichert und hochgeladen.",
+      "successToast": "Transfer gespeichert und hochgeladen.",
+      "uploadFailedToast": "Upload fehlgeschlagen. Wiederhole ihn bei stabiler Verbindung.",
+      "retryFailedToast": "Wiederholung fehlgeschlagen. Die Transferdaten bleiben erhalten.",
+      "localFailedToast": "Transfer konnte lokal nicht gespeichert werden.",
+      "conflictToast": "OneDrive wurde vor Abschluss des Uploads geändert. Aktualisiere vor einem neuen Versuch."
+    },
     "validation": {
       "nameLength": "Beschreibung muss länger als 2 Zeichen sein.",
       "amountPositive": "Betrag muss größer als 0 sein.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -55,6 +55,19 @@
     "submit": "Save transfer",
     "saving": "Saving transfer...",
     "close": "Close",
+    "save": {
+      "localSave": "Saving transfer locally and preparing the database upload...",
+      "uploading": "Uploading updated database to OneDrive...",
+      "uploadFailed": "Uploading the database to OneDrive failed. Your transfer data is still here.",
+      "localFailed": "Saving the transfer locally failed. Nothing was uploaded.",
+      "retry": "Retry upload",
+      "success": "Transfer saved and uploaded.",
+      "successToast": "Transfer saved and uploaded.",
+      "uploadFailedToast": "Upload failed. Retry when the connection is stable.",
+      "retryFailedToast": "Retry failed. The transfer data is still preserved.",
+      "localFailedToast": "Transfer could not be saved locally.",
+      "conflictToast": "OneDrive changed before upload completed. Refresh before trying again."
+    },
     "validation": {
       "nameLength": "Description must be longer than 2 characters.",
       "amountPositive": "Amount must be greater than 0.",


### PR DESCRIPTION
## Summary

Implements M6-08 write failure and retry UX for the Add Transfer flow.

- Adds explicit save phases for local write/export, remote upload, retryable upload failure, conflict, and success.
- Preserves the exported DB snapshot after retryable upload failure so retry uploads the same committed bytes without inserting the transfer again.
- Shows determinate upload progress in the bottom sheet and uses toast feedback for transient failure/retry/success states.
- Blocks duplicate submissions and prevents native bottom-sheet close paths while a save/upload or retryable upload state is active.
- Updates the app version to `0.6.08` and marks M6-08 done in the backlog.

Closes #71

## Acceptance Criteria Mapping

- Retry failed uploads without retyping: pending exported bytes are retained and retried via upload-only path.
- No false success before upload completes: success state/toast is emitted only after upload handoff resolves.
- Determinate upload progress: Add Transfer renders upload progress from the existing upload progress callback.
- Intermediate states distinguished: local save/export and remote upload have separate UI states.
- Duplicate save blocked: controller ignores busy submits and UI disables controls while active.
- Success feedback only after full save/upload: success status and toast are gated on completed upload.

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build` (passes with existing Vite chunk-size warning)
- `npm run test:e2e`
- Reviewer subagent: APPROVED

## Notes

- Assumption: full eTag conflict resolution dialog remains scoped to M6-11; M6-08 only keeps conflict distinct and prevents direct retry.
- The `0.6.08` version follows the issue-delivery prompt format `0.<milestone_number>.<issue_title_number>`.
