### PR TITLE
feat: [M6-09] Block write flow while offline

### DIFF
--- a/commit.txt
+++ b/commit.txt
@@ -1,0 +1,3 @@
+feat: [M6-09] block write flow while offline
+
+Agent: Antigravity

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -455,7 +455,7 @@ An issue is only considered done when:
 - Depends on: `M5-06`
 - GitHub: [#64](https://github.com/Jon2050/Conspectus-Mobile/issues/64)
 
-### :green_circle: M6-02 Implement account/category options loading for form
+### :white_check_mark: M6-02 Implement account/category options loading for form
 
 - Label: `feature`
 - Milestone: `M6 - Add Transfer Write Path`
@@ -463,7 +463,7 @@ An issue is only considered done when:
 - Depends on: `M5-01`
 - GitHub: [#65](https://github.com/Jon2050/Conspectus-Mobile/issues/65)
 
-### :green_circle: M6-03 Implement transfer validation rules
+### :white_check_mark: M6-03 Implement transfer validation rules
 
 - Label: `feature`
 - Milestone: `M6 - Add Transfer Write Path`
@@ -511,7 +511,7 @@ An issue is only considered done when:
 - Depends on: `M6-07`
 - GitHub: [#71](https://github.com/Jon2050/Conspectus-Mobile/issues/71)
 
-### :green_circle: M6-09 Block write flow while offline
+### :white_check_mark: M6-09 Block write flow while offline
 
 - Label: `feature`
 - Milestone: `M6 - Add Transfer Write Path`

--- a/docs/prompts/Task-Prompt-Template.md
+++ b/docs/prompts/Task-Prompt-Template.md
@@ -1,4 +1,4 @@
-Task: Implement issue `M6-04` end-to-end with full verification.
+Task: Implement issue `M6-09` end-to-end with full verification.
 
 ## Non-negotiable rules:
 
@@ -22,7 +22,7 @@ Always print in which step you are!
    - `docs/Architecture-and-Implementation-Plan.md`
    - `docs/Conspectus-Desktop-Info.md`
    - `docs/GitHub-Issues-MVP-Backlog.md`
-     Then locate `M6-04` and extract implementation steps, acceptance criteria, and dependencies/constraints from GitHub. Also from the comments on GitHub.
+     Then locate `M6-09` and extract implementation steps, acceptance criteria, and dependencies/constraints from GitHub. Also from the comments on GitHub.
 2. Plan with one planning subagent. Refine until concrete, testable, and mapped from each acceptance criterion to file-level code/test changes. Make clear, that the planning subagent should not write any code, just the plan.
 3. Create/use a dedicated issue branch with a proper name containing the milestone and issue number (e.g., `feature/M6-03-localize-formatting` or `bug/M6-03-fix-locale`).
    3.1. Increase the app version in `package.json` to `0.<milestone_number>.<issue_title_number>`. (e.g. `0.6.03` for issue `M6-03`)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.6.08",
+  "version": "0.6.09",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,13 @@
+Closes #72
+
+**Implementation:**
+
+- Creates a `networkStateStore` to reactively track `navigator.onLine`.
+- Modifies `AddRoute.svelte` to show an offline warning and disable submit/retry buttons.
+- Blocks offline submission at the logic layer in `addTransferSaveController.ts` by passing `isOffline` from UI.
+- Updates the backlog status for `M6-09` to done.
+
+**Validation:**
+
+- Local checks passed (`npm run lint`, `npm run typecheck`, `npm run test`, `npm run build`, `npm run test:e2e`).
+- Code review subagent approved changes after refactoring to remove global window coupling.

--- a/src/features/app-shell/routes/AddRoute.svelte
+++ b/src/features/app-shell/routes/AddRoute.svelte
@@ -8,7 +8,13 @@
     PRIMARY_INCOME_ACCOUNT_TYPE_ID,
     PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID,
   } from '@db';
-  import { appSyncStateStore, type SyncState, type SyncStateStore } from '@shared';
+  import {
+    appSyncStateStore,
+    appNetworkStateStore,
+    type SyncState,
+    type SyncStateStore,
+    type NetworkStateStore,
+  } from '@shared';
   import BottomSheet from '../components/BottomSheet.svelte';
   import ProgressIndicator from '../components/ProgressIndicator.svelte';
   import {
@@ -37,17 +43,20 @@
   export let isSubmitting = false;
   export let formError: string | null = null;
   export let syncStateStore: SyncStateStore = appSyncStateStore;
+  export let networkStateStore: NetworkStateStore = appNetworkStateStore;
 
   let isOpen = true;
   let optionsState: AddTransferOptionsState = controller.getState();
   let saveState: AddTransferSaveState = saveController.getState();
   let lastObservedSyncState: SyncState = 'idle';
+  $: isOffline = !$networkStateStore;
   $: isOptionsLoading = optionsState.operation === 'loading';
   $: saveIsBusy = saveState.phase === 'local_save' || saveState.phase === 'uploading';
   $: saveHasPendingUpload = saveState.canRetry || saveState.phase === 'conflict';
   $: effectiveFormError =
     formError ?? saveState.errorMessage ?? optionsState.error?.message ?? null;
   $: controlsAreDisabled = isSubmitting || isOptionsLoading || saveIsBusy || saveHasPendingUpload;
+  $: submitIsDisabled = controlsAreDisabled || isOffline;
 
   let validationErrors: string[] = [];
 
@@ -64,13 +73,13 @@
   };
 
   const handleSubmit = async (): Promise<void> => {
-    const result = await saveController.submit(fields, optionsState, $_);
+    const result = await saveController.submit(fields, optionsState, $_, isOffline);
     validationErrors = [...result.validationErrors];
     resetSuccessfulSave();
   };
 
   const handleRetry = async (): Promise<void> => {
-    await saveController.retry($_);
+    await saveController.retry($_, isOffline);
     resetSuccessfulSave();
   };
 
@@ -167,6 +176,12 @@
       {#if effectiveFormError !== null}
         <p class="add-transfer-form__error" role="alert" data-testid="add-transfer-form-error">
           {effectiveFormError}
+        </p>
+      {/if}
+
+      {#if isOffline}
+        <p class="add-transfer-form__error" role="alert" data-testid="add-transfer-offline-warning">
+          {$_('addTransfer.offlineWarning')}
         </p>
       {/if}
 
@@ -379,7 +394,7 @@
             type="button"
             class="app-button app-button--primary add-transfer-form__action"
             data-testid="add-transfer-retry"
-            disabled={saveIsBusy}
+            disabled={saveIsBusy || isOffline}
             on:click={handleRetry}
           >
             {$_('addTransfer.save.retry')}
@@ -389,7 +404,7 @@
             type="submit"
             class="app-button app-button--primary add-transfer-form__action"
             data-testid="add-transfer-submit"
-            disabled={controlsAreDisabled}
+            disabled={submitIsDisabled}
           >
             {saveIsBusy || isSubmitting ? $_('addTransfer.saving') : $_('addTransfer.submit')}
           </button>

--- a/src/features/app-shell/routes/AddRoute.test.ts
+++ b/src/features/app-shell/routes/AddRoute.test.ts
@@ -387,4 +387,19 @@ describe('AddRoute component', () => {
     const { body } = renderAddRoute();
     expect(body).not.toContain('data-testid="add-transfer-validation-error"');
   });
+
+  it('renders an offline warning and disables submit/retry when offline', () => {
+    const { body } = renderAddRoute({
+      networkStateStore: {
+        subscribe: (cb: (v: boolean) => void) => {
+          cb(false);
+          return () => {};
+        },
+      },
+    });
+
+    expect(body).toContain('data-testid="add-transfer-offline-warning"');
+    expect(body).toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
+    expect(body).not.toMatch(/data-testid="add-transfer-name"[^>]*disabled/);
+  });
 });

--- a/src/features/app-shell/routes/addTransferSaveController.test.ts
+++ b/src/features/app-shell/routes/addTransferSaveController.test.ts
@@ -242,4 +242,19 @@ describe('addTransferSaveController', () => {
     });
     expect(toastStore.show).toHaveBeenCalledWith('addTransfer.save.conflictToast', 'error');
   });
+
+  it('returns empty validation errors and blocks submit when isOffline is true', async () => {
+    const saveService = createSaveService();
+    const controller = createAddTransferSaveController(saveService, { show: vi.fn() });
+    const result = await controller.submit(createValidFields(), READY_OPTIONS, t, true);
+    expect(result.validationErrors).toEqual([]);
+    expect(saveService.createTransferAndExport).not.toHaveBeenCalled();
+  });
+
+  it('blocks retry when isOffline is true', async () => {
+    const saveService = createSaveService();
+    const controller = createAddTransferSaveController(saveService, { show: vi.fn() });
+    await controller.retry(t, true);
+    expect(saveService.retryExportedDatabaseUpload).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/app-shell/routes/addTransferSaveController.ts
+++ b/src/features/app-shell/routes/addTransferSaveController.ts
@@ -51,8 +51,9 @@ export interface AddTransferSaveController {
     fields: AddTransferFormFields,
     optionsState: AddTransferOptionsState,
     t: AddTransferTranslator,
+    isOffline?: boolean,
   ): Promise<AddTransferSubmitResult>;
-  retry(t: AddTransferTranslator): Promise<void>;
+  retry(t: AddTransferTranslator, isOffline?: boolean): Promise<void>;
   reset(): void;
 }
 
@@ -200,7 +201,12 @@ export const createAddTransferSaveController = (
       fields: AddTransferFormFields,
       optionsState: AddTransferOptionsState,
       t: AddTransferTranslator,
+      isOffline: boolean = false,
     ): Promise<AddTransferSubmitResult> {
+      if (isOffline) {
+        return { validationErrors: [] };
+      }
+
       if (isBusyPhase(state.phase)) {
         return { validationErrors: [] };
       }
@@ -246,7 +252,11 @@ export const createAddTransferSaveController = (
       return { validationErrors: [] };
     },
 
-    async retry(t: AddTransferTranslator): Promise<void> {
+    async retry(t: AddTransferTranslator, isOffline: boolean = false): Promise<void> {
+      if (isOffline) {
+        return;
+      }
+
       if (isBusyPhase(state.phase) || pendingUpload === null || !state.canRetry) {
         return;
       }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -38,6 +38,7 @@
   },
   "addTransfer": {
     "title": "Neuer Transfer",
+    "offlineWarning": "Du musst online sein, um einen Transfer hinzuzufügen.",
     "date": "Datum",
     "name": "Beschreibung",
     "namePlaceholder": "z.B. Einkauf, Miete...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -38,6 +38,7 @@
   },
   "addTransfer": {
     "title": "New Transfer",
+    "offlineWarning": "You must be online to add a transfer.",
     "date": "Date",
     "name": "Description",
     "namePlaceholder": "e.g. Groceries, Rent...",

--- a/src/shared/state/index.ts
+++ b/src/shared/state/index.ts
@@ -1,3 +1,4 @@
 export * from './syncStateStore';
 export * from './selectedDriveItemBindingStore';
 export * from './toastStore';
+export * from './networkStateStore';

--- a/src/shared/state/networkStateStore.test.ts
+++ b/src/shared/state/networkStateStore.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+describe('networkStateStore', () => {
+  let appNetworkStateStore: typeof import('./networkStateStore').appNetworkStateStore;
+  let listeners: Record<string, () => void> = {};
+
+  beforeEach(async () => {
+    listeners = {};
+    vi.stubGlobal('window', {
+      navigator: { onLine: true },
+      addEventListener: (evt: string, cb: () => void) => {
+        listeners[evt] = cb;
+      },
+      removeEventListener: (evt: string) => {
+        delete listeners[evt];
+      },
+      dispatchEvent: (evt: Event) => {
+        listeners[evt.type]?.();
+      },
+    });
+    vi.resetModules();
+    const module = await import('./networkStateStore');
+    appNetworkStateStore = module.appNetworkStateStore;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('initializes with current navigator.onLine state', () => {
+    expect(get(appNetworkStateStore)).toBe(true);
+  });
+
+  it('updates state when online and offline events fire', () => {
+    const unsubscribe = appNetworkStateStore.subscribe(() => {});
+
+    window.dispatchEvent(new Event('offline'));
+    expect(get(appNetworkStateStore)).toBe(false);
+
+    window.dispatchEvent(new Event('online'));
+    expect(get(appNetworkStateStore)).toBe(true);
+
+    unsubscribe();
+  });
+});

--- a/src/shared/state/networkStateStore.ts
+++ b/src/shared/state/networkStateStore.ts
@@ -1,0 +1,25 @@
+import { readable, type Readable } from 'svelte/store';
+
+export type NetworkStateStore = Readable<boolean>;
+
+const isBrowser = typeof window !== 'undefined';
+
+export const appNetworkStateStore: NetworkStateStore = readable(
+  isBrowser ? window.navigator.onLine : true,
+  (set) => {
+    if (!isBrowser) {
+      return () => {};
+    }
+
+    const setOnline = () => set(true);
+    const setOffline = () => set(false);
+
+    window.addEventListener('online', setOnline);
+    window.addEventListener('offline', setOffline);
+
+    return () => {
+      window.removeEventListener('online', setOnline);
+      window.removeEventListener('offline', setOffline);
+    };
+  },
+);


### PR DESCRIPTION
Closes #72

**Implementation:**

- Creates a `networkStateStore` to reactively track `navigator.onLine`.
- Modifies `AddRoute.svelte` to show an offline warning and disable submit/retry buttons.
- Blocks offline submission at the logic layer in `addTransferSaveController.ts` by passing `isOffline` from UI.
- Updates the backlog status for `M6-09` to done.

**Validation:**

- Local checks passed (`npm run lint`, `npm run typecheck`, `npm run test`, `npm run build`, `npm run test:e2e`).
- Code review subagent approved changes after refactoring to remove global window coupling.
