### PR TITLE
fix: [M6-12] Preserve Add Transfer draft data

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -661,6 +661,11 @@ M6-11 implementation clarification:
 - The recovery action downloads and validates the latest OneDrive DB snapshot, writes it to the local cache, explicitly closes and reopens the shared browser DB runtime with the fresh bytes, then allows the user to review and save the transfer again.
 - The Add Transfer route surfaces this as a non-technical conflict dialog with download progress; direct upload retry remains available only for retryable non-conflict upload failures.
 
+M6-12 implementation clarification:
+
+- The app shell owns the in-memory Add Transfer draft and passes it into `AddRoute`, so closing the bottom sheet back to Transfers and reopening Add preserves unsaved form data for the current app session.
+- A completed save/upload still resets the draft before the next transfer entry starts.
+
 Deliverables:
 
 - End-to-end write feature with clear success/error behavior.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -535,6 +535,14 @@ An issue is only considered done when:
 - Depends on: `M6-07, M6-08`
 - GitHub: [#74](https://github.com/Jon2050/Conspectus-Mobile/issues/74)
 
+### :white_check_mark: M6-12 Fix Add Transfer draft persistence after close/reopen
+
+- Label: `bug`
+- Milestone: `M6 - Add Transfer Write Path`
+- Summary: Work includes preserving entered Add Transfer form data when the bottom sheet is closed and reopened in the same app session. It also covers keeping successful save behavior reset for the next transfer.
+- Depends on: `M6-01, M6-08, M6-11`
+- GitHub: [#194](https://github.com/Jon2050/Conspectus-Mobile/issues/194)
+
 ### :green_circle: M7-01 Build Settings screen sections
 
 - Label: `feature`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.6.11",
+      "version": "0.6.12",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.6.11",
+  "version": "0.6.12",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -38,6 +38,10 @@
   import { resolveAppStartupIsOnline } from './startupNetworkStateResolver';
   import { syncSelectedDriveItemBindingStoreAtStartup } from './startupBindingSync';
   import { resolveAppSnapshotValidator } from './snapshotValidatorResolver';
+  import {
+    createInitialFormFields,
+    type AddTransferFormFields,
+  } from './routes/addTransferFormState';
 
   export let routeStore: Readable<AppRouteKey> = createHashRouteStore();
   export let syncStateStore: SyncStateStore = appSyncStateStore;
@@ -49,6 +53,7 @@
   const FOOTER_VISIBILITY_HYSTERESIS_PX = 48;
 
   let currentRoute: AppRouteKey = DEFAULT_ROUTE;
+  let addTransferFields: AddTransferFormFields = createInitialFormFields();
   let appContentElement: HTMLElement | null = null;
   let appContentPageElement: HTMLDivElement | null = null;
   let footerIsVisible = true;
@@ -335,7 +340,7 @@
       {:else if currentRoute === 'transfers'}
         <TransfersRoute />
       {:else if currentRoute === 'add'}
-        <AddRoute />
+        <AddRoute bind:fields={addTransferFields} />
       {:else}
         <SettingsRoute />
       {/if}

--- a/src/features/app-shell/routes/AddRoute.svelte
+++ b/src/features/app-shell/routes/AddRoute.svelte
@@ -137,7 +137,6 @@
   };
 
   const handleReopen = (): void => {
-    fields = createInitialFormFields();
     saveController.reset();
     isOpen = true;
   };

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -1105,6 +1105,54 @@ test('renders an editable add transfer bottom sheet on mobile viewports', async 
   await expect(page.getByTestId('add-transfer-buyplace')).toHaveValue('Supermarket');
 });
 
+test('keeps add transfer draft values after closing and reopening the sheet', async ({ page }) => {
+  await installMockDbRuntime(page, {
+    forceAlwaysOpen: true,
+    fromAccountOptionRows: [
+      { accountId: 1, name: 'Primary Income', amountCents: 0, accountTypeId: 1 },
+      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+    ],
+    toAccountOptionRows: [
+      { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+      { accountId: 12, name: 'Savings', amountCents: 5000, accountTypeId: 3 },
+    ],
+    categoryRows: [
+      { categoryId: 20, name: 'Groceries' },
+      { categoryId: 30, name: 'Travel' },
+      { categoryId: 40, name: 'Rent' },
+    ],
+  });
+
+  await page.goto(appPath('#/add'));
+  await expect(page.getByTestId('add-transfer-form')).toBeVisible();
+
+  await page.getByTestId('add-transfer-date').fill('2024-04-15');
+  await page.getByTestId('add-transfer-name').fill('Draft Transfer');
+  await page.getByTestId('add-transfer-amount').fill('12.34');
+  await page.getByTestId('add-transfer-from-account').selectOption({ label: 'Checking' });
+  await page.getByTestId('add-transfer-to-account').selectOption({ label: 'Savings' });
+  await page.getByTestId('add-transfer-category-1').selectOption({ label: 'Groceries' });
+  await page.getByTestId('add-transfer-category-2').selectOption({ label: 'Travel' });
+  await page.getByTestId('add-transfer-category-3').selectOption({ label: 'Rent' });
+  await page.getByTestId('add-transfer-buyplace').fill('Supermarket');
+
+  await page.getByTestId('add-transfer-close').click();
+  await expect(page).toHaveURL(/#\/transfers$/);
+
+  await page.getByRole('link', { name: 'Add' }).click();
+  await expect(page).toHaveURL(/#\/add$/);
+  await expect(page.getByTestId('add-transfer-form')).toBeVisible();
+  await expect(page.getByTestId('add-transfer-date')).toHaveValue('2024-04-15');
+  await expect(page.getByTestId('add-transfer-name')).toHaveValue('Draft Transfer');
+  await expect(page.getByTestId('add-transfer-amount')).toHaveValue('12.34');
+  await expect(page.getByTestId('add-transfer-from-account')).toHaveValue('11');
+  await expect(page.getByTestId('add-transfer-to-account')).toHaveValue('12');
+  await expect(page.getByTestId('add-transfer-category-1')).toHaveValue('20');
+  await expect(page.getByTestId('add-transfer-category-2')).toHaveValue('30');
+  await expect(page.getByTestId('add-transfer-category-3')).toHaveValue('40');
+  await expect(page.getByTestId('add-transfer-buyplace')).toHaveValue('Supermarket');
+});
+
 test('loads add transfer account and category options from the local DB runtime', async ({
   page,
 }) => {
@@ -2476,6 +2524,10 @@ test('saves transfer happy path, transitions through upload states, and updates 
   await page.getByTestId('add-transfer-submit').click();
 
   await expect(page.locator('.toast-container')).toContainText('Transfer saved and uploaded.');
+  await expect(page.getByTestId('add-transfer-name')).toHaveValue('');
+  await expect(page.getByTestId('add-transfer-amount')).toHaveValue('');
+  await expect(page.getByTestId('add-transfer-from-account')).toHaveValue('');
+  await expect(page.getByTestId('add-transfer-to-account')).toHaveValue('');
 });
 
 test('shows determinate upload progress during slow upload', async ({ page }) => {


### PR DESCRIPTION
# Pull Request

## Linked Issue (Required)

- Closes #194

## Context

- Problem: Add Transfer form fields were owned by the route component, so closing the bottom sheet navigated away to Transfers and discarded unsaved draft data.
- Goal: [M6-12] Preserve entered Add Transfer data when the bottom sheet is closed and reopened in the same app session.

## Changes

- Moved the in-memory Add Transfer draft owner to `AppShell` and passed it into `AddRoute` with two-way binding.
- Stopped clearing draft fields during close/reopen while keeping completed save/upload reset behavior.
- Added E2E coverage for close/reopen draft persistence and save reset behavior.
- Bumped the app version to `0.6.12` and added the M6-12 backlog/architecture notes for #194.

## Test Plan

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run test:e2e`
- Notes: Full local gate passed before push. Build/E2E still emit the existing Vite chunk-size warning only.

## Screenshots

- [ ] UI change: screenshots attached
- [x] No UI change

## Risk Notes

- User impact: Unsaved Add Transfer data now survives accidental bottom-sheet close/reopen during the current app session.
- Rollback plan: Revert this PR to restore the previous route-local draft behavior.
- Assumption: The issue requires same-session draft retention, not persistence across browser reload/app restart.

## QS Checklist

- [x] Linked issue ID is included in this PR.
- [x] Lint, typecheck, tests, and build were run and pass.
- [x] Screenshots are included for UI changes.
- [x] Risk and rollback notes are documented.
- [x] No secrets, tokens, or credentials were added to the repository.
- [x] No breaking path/base URL changes were introduced (must preserve `/conspectus/webapp/` deployment path behavior).

## Merge And Cleanup (PR Path)

- [ ] Required GitHub checks are green.
- [ ] PR will be merged into `main` with `Rebase and merge`.
- [ ] PR will be merged into `main` once checks/review requirements are satisfied.
- [ ] Head branch will be deleted after merge.
- [ ] Linked issue/backlog marker will only be marked done after merge.
