### PR TITLE
fix: refresh mobile sync and transfer cards

### DIFF
--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -165,6 +165,50 @@
     }
   });
 
+  let foregroundSyncIsQueued = false;
+
+  const flushQueuedForegroundSync = (): void => {
+    foregroundSyncIsQueued = false;
+
+    queueMicrotask(() => {
+      if (
+        !appShellIsMounted ||
+        document.visibilityState !== 'visible' ||
+        get(syncStateStore).state === 'syncing'
+      ) {
+        return;
+      }
+
+      void performSync(get(appSelectedDriveItemBindingStore));
+    });
+  };
+
+  const unsubscribeQueuedForegroundSync = syncStateStore.subscribe((syncSnapshot) => {
+    if (!foregroundSyncIsQueued || syncSnapshot.state === 'syncing') {
+      return;
+    }
+
+    if (syncSnapshot.state === 'synced') {
+      flushQueuedForegroundSync();
+      return;
+    }
+
+    foregroundSyncIsQueued = false;
+  });
+
+  const handleDocumentVisibilityChange = (): void => {
+    if (!hasPerformedInitialSync || document.visibilityState !== 'visible') {
+      return;
+    }
+
+    if (get(syncStateStore).state === 'syncing') {
+      foregroundSyncIsQueued = true;
+      return;
+    }
+
+    void performSync(get(appSelectedDriveItemBindingStore));
+  };
+
   const logStartupFreshnessDecision = (
     decision: StartupFreshnessDecision,
     bindingName: string | null,
@@ -260,6 +304,7 @@
     appShellIsMounted = true;
     let isMounted = true;
     syncStateStore.reset();
+    document.addEventListener('visibilitychange', handleDocumentVisibilityChange);
 
     void (async () => {
       try {
@@ -294,6 +339,7 @@
       if (timerId !== null) {
         window.clearTimeout(timerId);
       }
+      document.removeEventListener('visibilitychange', handleDocumentVisibilityChange);
       disconnectFooterVisibilityTracking();
     };
   });
@@ -318,6 +364,7 @@
   onDestroy(() => {
     unsubscribe();
     unsubscribeSelectedBinding();
+    unsubscribeQueuedForegroundSync();
     resolveAppDbRuntime().close();
     disconnectFooterVisibilityTracking();
   });

--- a/src/features/app-shell/routes/TransfersRoute.svelte
+++ b/src/features/app-shell/routes/TransfersRoute.svelte
@@ -248,7 +248,7 @@
                     <h3 class="transfer-card__name">
                       {#if transfer.buyplace}<span class="transfer-card__buyplace-prefix"
                           >({transfer.buyplace})
-                        </span>
+                        </span>&nbsp;
                       {/if}{transfer.name}
                     </h3>
                   </div>
@@ -419,7 +419,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.08rem;
-    padding: 0.4rem 0.75rem 0.1rem;
+    padding: 0.4rem 0.75rem;
     border-radius: var(--radius-lg);
     background: var(--surface-strong);
     box-shadow: var(--shadow-sm);

--- a/src/features/app-shell/routes/TransfersRoute.test.ts
+++ b/src/features/app-shell/routes/TransfersRoute.test.ts
@@ -91,7 +91,8 @@ describe('TransfersRoute', () => {
 
     expect(body).toContain('AUSGABEN');
     expect(body).toContain('EINNAHMEN');
-    expect(body.indexOf('(Local Market)')).toBeLessThan(body.indexOf('Test Transfer'));
+    expect(body).toContain('(Local Market)</span>\u00a0');
+    expect(body).toContain('Test Transfer');
     expect(body).not.toContain('Ort:');
     expect(body).not.toContain('Original From Name');
     expect(body).not.toContain('Original To Name');

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -223,6 +223,7 @@ type MockGraphClientOptions = {
   readonly downloadDelayMs?: number;
   readonly extraRootDbFileCount?: number;
   readonly metadataETag?: string;
+  readonly metadataETagSequence?: readonly string[];
   readonly metadataLastModifiedDateTime?: string;
   readonly downloadBytes?: readonly number[];
   readonly metadataErrorSequence?: readonly MockGraphError[];
@@ -366,6 +367,7 @@ const installMockGraphClient = async (
     let getFileMetadataCallCount = 0;
     let downloadFileCallCount = 0;
     let uploadFileCallCount = 0;
+    const metadataETagSequence = [...(mockOptions.metadataETagSequence ?? [])];
     const metadataErrorSequence = [...(mockOptions.metadataErrorSequence ?? [])];
     const downloadErrorSequence = [...(mockOptions.downloadErrorSequence ?? [])];
     const uploadErrorSequence = [...(mockOptions.uploadErrorSequence ?? [])];
@@ -475,7 +477,7 @@ const installMockGraphClient = async (
         }
 
         return {
-          eTag: mockOptions.metadataETag ?? '"etag-1"',
+          eTag: metadataETagSequence.shift() ?? mockOptions.metadataETag ?? '"etag-1"',
           sizeBytes: defaultDownloadBytes.length,
           lastModifiedDateTime: mockOptions.metadataLastModifiedDateTime ?? '2026-03-09T10:15:00Z',
           downloadUrl: 'https://download.example.com/conspectus.db',
@@ -1451,6 +1453,39 @@ test('reuses the cached DB on startup when the OneDrive eTag is unchanged', asyn
   expect(await getGraphDownloadCallCount(page)).toBe(0);
 });
 
+test('refreshes the selected DB when the PWA returns to the foreground', async ({ page }) => {
+  await installMockAuthClient(page, {
+    startAuthenticated: true,
+  });
+  await installMockGraphClient(page, {
+    metadataETagSequence: ['"etag-1"', '"etag-2"'],
+    downloadBytes: createSqliteBytes([9, 8, 7, 6]),
+  });
+  await installMockCacheStore(page, {
+    startupSnapshot: {
+      metadata: {
+        eTag: '"etag-1"',
+      },
+      dbBytes: createSqliteBytes([1, 1, 1, 1]),
+    },
+  });
+  await installPersistedBinding(page);
+  await installMockStartupNetworkState(page, true);
+
+  await page.goto(appPath('#/accounts'));
+
+  await expect(page.getByText('Cached DB is current with OneDrive.')).toBeVisible();
+  expect(await getGraphMetadataCallCount(page)).toBe(1);
+
+  await page.evaluate(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+
+  await expect.poll(() => getGraphMetadataCallCount(page)).toBe(2);
+  await expect(page.getByText('Downloaded the latest DB from OneDrive.')).toBeVisible();
+  expect(await getGraphDownloadCallCount(page)).toBe(1);
+});
+
 test('shows syncing state and toast feedback while the startup freshness check is running', async ({
   page,
 }) => {
@@ -2086,7 +2121,11 @@ test('loads transfers from real DB bytes and navigates months to see fixture dat
 
   await expect(monthLabel).toHaveAttribute('data-month-key', '2024-04');
   await expect(page.getByTestId('transfer-card-2')).toBeVisible();
-  await expect(page.getByTestId('transfer-card-3')).toBeVisible();
+  const categorylessTransferCard = page.getByTestId('transfer-card-3');
+  await expect(categorylessTransferCard).toBeVisible();
+  expect(
+    await categorylessTransferCard.evaluate((card) => window.getComputedStyle(card).paddingBottom),
+  ).toBe('6.4px');
 
   await page.getByTestId('transfers-month-previous-button').click();
   await expect(monthLabel).toHaveAttribute('data-month-key', '2024-03');
@@ -2660,6 +2699,40 @@ test('shows determinate upload progress during slow upload', async ({ page }) =>
   await expect(page.locator('.toast-container')).toContainText('Transfer saved and uploaded.', {
     timeout: 15000,
   });
+});
+
+test('defers foreground refresh until an active upload completes', async ({ page }) => {
+  await seedAndBindTestDb(page, {
+    metadataETag: '"etag-2"',
+    uploadDelayMs: 2000,
+  });
+  await page.goto(appPath('#/add'));
+  await expect(page.getByTestId('add-transfer-date')).toBeVisible();
+
+  await page.getByTestId('add-transfer-name').fill('Foreground Upload Transfer');
+  await page.getByTestId('add-transfer-amount').pressSequentially('100');
+  await page.getByTestId('add-transfer-from-account').selectOption({ label: 'Girokonto' });
+  await page.getByTestId('add-transfer-to-account').selectOption({ label: 'Kreditkarte' });
+  await page.getByTestId('add-transfer-submit').click();
+
+  await expect(
+    page.getByTestId('add-transfer-upload-status').getByTestId('progress-indicator'),
+  ).toBeVisible();
+  const metadataCallsBeforeForegroundEvent = await getGraphMetadataCallCount(page);
+
+  await page.evaluate(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+
+  await page.waitForTimeout(250);
+  expect(await getGraphMetadataCallCount(page)).toBe(metadataCallsBeforeForegroundEvent);
+
+  await expect(page.locator('.toast-container')).toContainText('Transfer saved and uploaded.', {
+    timeout: 15000,
+  });
+  await expect
+    .poll(() => getGraphMetadataCallCount(page))
+    .toBe(metadataCallsBeforeForegroundEvent + 1);
 });
 
 test('handles transient upload failure and allows retry without data loss', async ({ page }) => {


### PR DESCRIPTION
# Pull Request

## Linked Issue

- Manual task; no linked GitHub issue by instruction.

## Context

- Problem: Transfer cards joined the optional shop name to the description, category-less cards lacked bottom spacing, and a resumed mobile PWA did not refresh its selected OneDrive database until an incidental later sync.
- Goal: Restore readable transfer cards and run the established eTag freshness flow when the PWA returns to the foreground without racing active database operations.

## Changes

- Added a visible separator after the optional shop name and consistent transfer-card bottom padding.
- Reused the existing startup freshness flow on `visibilitychange` to refresh the selected database after PWA foreground resume.
- Deferred foreground refresh while upload or conflict recovery is active, releasing it only after a successful sync.
- Added component and browser regressions for display spacing, category-less card padding, foreground freshness, and foreground during upload.

## Test Plan

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run test:e2e` (112 tests on Chromium and Pixel 5)

## Screenshots

- [ ] UI change: no separate screenshot artifact attached; browser regression coverage verifies the rendered transfer-card spacing.

## Risk Notes

- User impact: Resumed mobile sessions refresh through the existing eTag/cache path after an in-progress sync safely completes.
- Rollback plan: Revert commit `a3cd716`.

## QS Checklist

- [x] This is a manual task with no linked issue or backlog update.
- [x] Lint, typecheck, tests, build, and E2E tests were run and pass.
- [x] Risk and rollback notes are documented.
- [x] No secrets, tokens, or credentials were added to the repository.
- [x] No breaking path/base URL changes were introduced; `/conspectus/webapp/` behavior is unchanged.

## Merge And Cleanup

- [ ] Required GitHub checks are green.
- [ ] PR will be merged into `main` with Rebase and merge after checks are green.
- [ ] Head branch will be deleted after merge.
