### PR TITLE
feat: [M7-01] Build Settings screen sections

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -718,6 +718,13 @@ Substeps:
    - force refresh from OneDrive
 3. Safety notice card:
    - "Do not use mobile app while desktop app is open"
+
+M7-01 implementation clarification:
+
+- `src/features/app-shell/routes/SettingsRoute.svelte` groups account, database, destructive, and build information while preserving the existing rebind and reset flows.
+- Bound-file details come from the persisted binding, and the last-sync timestamp comes from the cached snapshot metadata. Settings refreshes that metadata when the shared sync state reaches `synced` so a completed download is reflected without polling.
+- The dedicated Settings build section reuses the build-time version and deployment timestamp resolution in `src/shared/config/buildInfo.ts`; its injected bundle metadata remains available offline.
+
 4. Error recovery UX:
    - re-login flow
    - stale token handling

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -543,7 +543,7 @@ An issue is only considered done when:
 - Depends on: `M6-01, M6-08, M6-11`
 - GitHub: [#194](https://github.com/Jon2050/Conspectus-Mobile/issues/194)
 
-### :green_circle: M7-01 Build Settings screen sections
+### :white_check_mark: M7-01 Build Settings screen sections
 
 - Label: `feature`
 - Milestone: `M7 - Settings + Recovery`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.6.12",
+  "version": "0.7.01",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.6.12",
+      "version": "0.7.01",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.6.12",
+  "version": "0.7.01",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -497,7 +497,7 @@
           canOpenPanel={addTransferDatabaseIsReady}
         />
       {:else}
-        <SettingsRoute />
+        <SettingsRoute {syncStateStore} />
       {/if}
     </div>
   </main>

--- a/src/features/app-shell/routes/SettingsRoute.svelte
+++ b/src/features/app-shell/routes/SettingsRoute.svelte
@@ -3,9 +3,15 @@
   import { onDestroy, onMount } from 'svelte';
   import { get } from 'svelte/store';
   import type { AuthClient } from '@auth';
-  import type { CacheStore } from '@cache';
   import type { GraphClient, GraphDriveItem } from '@graph';
-  import { appSelectedDriveItemBindingStore } from '@shared';
+  import {
+    appSelectedDriveItemBindingStore,
+    appSyncStateStore,
+    getFallbackBuildInfo,
+    loadBuildInfo,
+    type BuildInfo,
+    type SyncStateStore,
+  } from '@shared';
   import { _ } from 'svelte-i18n';
 
   import {
@@ -23,12 +29,14 @@
     type SettingsLocalDataResetState,
   } from './settingsLocalDataController';
   import { resolveSettingsAuthClient } from './settingsAuthClientResolver';
-  import { resolveSettingsCacheStore } from './settingsCacheStoreResolver';
+  import { resolveSettingsCacheStore, type SettingsCacheStore } from './settingsCacheStoreResolver';
   import { resolveSettingsGraphClient } from './settingsGraphClientResolver';
+  import { formatSettingsTimestampUtc } from './settingsInformation';
 
   export let authClient: AuthClient = resolveSettingsAuthClient();
-  export let cacheStore: Pick<CacheStore, 'clearAll'> = resolveSettingsCacheStore();
+  export let cacheStore: SettingsCacheStore = resolveSettingsCacheStore();
   export let graphClient: GraphClient = resolveSettingsGraphClient();
+  export let syncStateStore: SyncStateStore = appSyncStateStore;
 
   let state: SettingsAuthState = {
     session: {
@@ -56,6 +64,10 @@
     error: null,
   };
   let localDataResetDialogElement: HTMLDialogElement | null = null;
+  let lastSyncAtIso: string | null = null;
+  let syncMetadataRequestId = 0;
+  let loadedSyncMetadataBindingKey: string | null = null;
+  let buildInfo: BuildInfo = getFallbackBuildInfo();
 
   const buildStatusMessage = (nextState: SettingsAuthState): string => {
     if (nextState.operation !== 'idle') {
@@ -208,6 +220,47 @@
     return `${parentPath.endsWith('/') ? parentPath : parentPath + '/'}${name}`;
   };
 
+  const loadLastSyncMetadata = async (
+    isAuthenticated: boolean,
+    binding: SettingsFileBindingState['selectedBinding'],
+  ): Promise<void> => {
+    if (!isAuthenticated || binding === null) {
+      loadedSyncMetadataBindingKey = null;
+      syncMetadataRequestId += 1;
+      lastSyncAtIso = null;
+      return;
+    }
+
+    const bindingKey = `${binding.driveId}:${binding.itemId}`;
+    if (bindingKey === loadedSyncMetadataBindingKey) {
+      return;
+    }
+
+    loadedSyncMetadataBindingKey = bindingKey;
+    const requestId = ++syncMetadataRequestId;
+    try {
+      const snapshot = await cacheStore.readSnapshot(binding);
+      if (requestId === syncMetadataRequestId) {
+        lastSyncAtIso = snapshot?.metadata.lastSyncAtIso ?? null;
+      }
+    } catch {
+      if (requestId === syncMetadataRequestId) {
+        lastSyncAtIso = null;
+      }
+    }
+  };
+
+  $: void loadLastSyncMetadata(state.session.isAuthenticated, bindingState.selectedBinding);
+
+  const unsubscribeSyncState = syncStateStore.subscribe((syncState) => {
+    if (syncState.state !== 'synced') {
+      return;
+    }
+
+    loadedSyncMetadataBindingKey = null;
+    void loadLastSyncMetadata(state.session.isAuthenticated, bindingState.selectedBinding);
+  });
+
   $: if (localDataResetDialogElement !== null) {
     if (localDataResetState.operation === 'idle') {
       if (localDataResetDialogElement.open) {
@@ -220,12 +273,16 @@
 
   onMount(() => {
     void authController.initialize();
+    void loadBuildInfo().then((loadedBuildInfo) => {
+      buildInfo = loadedBuildInfo;
+    });
   });
 
   onDestroy(() => {
     unsubscribe();
     unsubscribeFileBinding();
     unsubscribeLocalDataReset();
+    unsubscribeSyncState();
   });
 </script>
 
@@ -271,7 +328,8 @@
       </p>
     {/if}
 
-    <div class="settings-screen__actions">
+    <h4 class="settings-screen__action-heading">{$_('settings.actions.standard')}</h4>
+    <div class="settings-screen__actions" data-testid="standard-settings-actions">
       <button
         class="app-button app-button--primary"
         type="button"
@@ -309,7 +367,10 @@
       {/if}
     </div>
 
-    <div class="settings-screen__actions">
+    <h4 class="settings-screen__action-heading settings-screen__action-heading--danger">
+      {$_('settings.actions.destructive')}
+    </h4>
+    <div class="settings-screen__actions" data-testid="destructive-settings-actions">
       <button
         class="app-button app-button--danger"
         type="button"
@@ -373,6 +434,14 @@
         <div>
           <dt>{$_('settings.db.summary.dbFile')}</dt>
           <dd>{resolveDbFilePath(bindingState.selectedBinding)}</dd>
+        </div>
+        <div>
+          <dt>{$_('settings.sync.lastSync')}</dt>
+          <dd data-testid="settings-last-sync">
+            {lastSyncAtIso === null
+              ? $_('settings.sync.never')
+              : formatSettingsTimestampUtc(lastSyncAtIso) || $_('settings.sync.unknown')}
+          </dd>
         </div>
       </dl>
     {/if}
@@ -447,7 +516,8 @@
     {/if}
   {/if}
 
-  <div class="settings-screen__actions">
+  <h3 class="settings-screen__subheading">{$_('settings.actions.account')}</h3>
+  <div class="settings-screen__actions" data-testid="account-settings-actions">
     {#if state.session.isAuthenticated}
       <button
         class="app-button app-button--secondary"
@@ -468,6 +538,22 @@
       </button>
     {/if}
   </div>
+
+  <section class="settings-screen__information" data-testid="settings-build-information">
+    <h3 class="settings-screen__subheading">{$_('settings.build.heading')}</h3>
+    <dl class="settings-screen__information-list">
+      <div>
+        <dt>{$_('settings.build.version')}</dt>
+        <dd data-testid="settings-build-version">{buildInfo.version}</dd>
+      </div>
+      <div>
+        <dt>{$_('settings.build.builtReleased')}</dt>
+        <dd data-testid="settings-build-time">
+          {formatSettingsTimestampUtc(buildInfo.buildTimeUtc) || $_('settings.build.unknown')}
+        </dd>
+      </div>
+    </dl>
+  </section>
 </section>
 
 <style>
@@ -513,15 +599,27 @@
     font-size: 0.98rem;
   }
 
+  .settings-screen__action-heading {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+  }
+
+  .settings-screen__action-heading--danger {
+    color: var(--settings-error-color);
+  }
+
   .settings-screen__account-summary,
-  .settings-screen__binding-summary {
+  .settings-screen__binding-summary,
+  .settings-screen__information-list {
     margin: 0;
     display: grid;
     gap: 0.55rem;
   }
 
   .settings-screen__account-summary div,
-  .settings-screen__binding-summary div {
+  .settings-screen__binding-summary div,
+  .settings-screen__information-list div {
     display: grid;
     gap: 0.2rem;
     padding: 0.85rem;
@@ -532,18 +630,26 @@
   }
 
   .settings-screen__account-summary dt,
-  .settings-screen__binding-summary dt {
+  .settings-screen__binding-summary dt,
+  .settings-screen__information-list dt {
     margin: 0;
     font-size: 0.8rem;
     color: var(--text-secondary);
   }
 
   .settings-screen__account-summary dd,
-  .settings-screen__binding-summary dd {
+  .settings-screen__binding-summary dd,
+  .settings-screen__information-list dd {
     margin: 0;
     font-size: 0.95rem;
     color: var(--text-primary);
     word-break: break-word;
+  }
+
+  .settings-screen__information {
+    display: grid;
+    gap: 0.55rem;
+    margin-top: 0.4rem;
   }
 
   .settings-screen__actions {

--- a/src/features/app-shell/routes/SettingsRoute.test.ts
+++ b/src/features/app-shell/routes/SettingsRoute.test.ts
@@ -3,6 +3,18 @@ import { describe, expect, it } from 'vitest';
 import settingsRouteSource from './SettingsRoute.svelte?raw';
 
 describe('SettingsRoute styling', () => {
+  it('renders dedicated metadata and risk-grouped action sections', () => {
+    expect(settingsRouteSource).toContain('data-testid="settings-last-sync"');
+    expect(settingsRouteSource).toContain('data-testid="standard-settings-actions"');
+    expect(settingsRouteSource).toContain('data-testid="destructive-settings-actions"');
+    expect(settingsRouteSource).toContain('data-testid="settings-build-information"');
+    expect(settingsRouteSource).toContain('data-testid="settings-build-version"');
+    expect(settingsRouteSource).toContain('data-testid="settings-build-time"');
+    expect(settingsRouteSource.indexOf('settings-build-information')).toBeGreaterThan(
+      settingsRouteSource.indexOf('destructive-settings-actions'),
+    );
+  });
+
   it('uses theme-aware custom properties for destructive settings surfaces', () => {
     expect(settingsRouteSource).toContain('--settings-error-color:');
     expect(settingsRouteSource).toContain('--settings-error-surface:');

--- a/src/features/app-shell/routes/settingsCacheStoreResolver.test.ts
+++ b/src/features/app-shell/routes/settingsCacheStoreResolver.test.ts
@@ -10,6 +10,7 @@ interface MemoryStorageLike {
 }
 
 const closeAppCacheStoreConnections = vi.fn();
+const appCacheStoreReadSnapshot = vi.fn();
 
 const createMemoryStorage = (initialValues: Record<string, string>): MemoryStorageLike => {
   const values = new Map(Object.entries(initialValues));
@@ -35,6 +36,7 @@ describe('settings cache store resolver', () => {
     vi.unstubAllGlobals();
     vi.clearAllMocks();
     vi.doMock('@cache', () => ({
+      appCacheStore: { readSnapshot: appCacheStoreReadSnapshot },
       closeAppCacheStoreConnections,
     }));
   });
@@ -45,16 +47,34 @@ describe('settings cache store resolver', () => {
 
   it('uses localhost test override cache store when available', async () => {
     const overrideClearAll = vi.fn(async () => {});
+    const overrideReadSnapshot = vi.fn(async () => null);
     vi.stubGlobal('window', {
       location: { hostname: '127.0.0.1' },
-      __CONSPECTUS_CACHE_STORE__: { clearAll: overrideClearAll },
+      __CONSPECTUS_CACHE_STORE__: {
+        clearAll: overrideClearAll,
+        readSnapshot: overrideReadSnapshot,
+      },
     });
 
     const { resolveSettingsCacheStore } = await import('./settingsCacheStoreResolver');
+    const binding = { driveId: 'drive', itemId: 'item', name: 'budget.db', parentPath: '/' };
+    await resolveSettingsCacheStore().readSnapshot(binding);
     await resolveSettingsCacheStore().clearAll();
 
+    expect(overrideReadSnapshot).toHaveBeenCalledWith(binding);
     expect(overrideClearAll).toHaveBeenCalledTimes(1);
     expect(closeAppCacheStoreConnections).not.toHaveBeenCalled();
+  });
+
+  it('reads Settings sync metadata from the app cache store by default', async () => {
+    vi.stubGlobal('window', { location: { hostname: 'jon2050.de' } });
+    const binding = { driveId: 'drive', itemId: 'item', name: 'budget.db', parentPath: '/' };
+    appCacheStoreReadSnapshot.mockResolvedValue(null);
+
+    const { resolveSettingsCacheStore } = await import('./settingsCacheStoreResolver');
+    await resolveSettingsCacheStore().readSnapshot(binding);
+
+    expect(appCacheStoreReadSnapshot).toHaveBeenCalledWith(binding);
   });
 
   it('clears app-owned storage, CacheStorage, and IndexedDB entries by default', async () => {

--- a/src/features/app-shell/routes/settingsCacheStoreResolver.ts
+++ b/src/features/app-shell/routes/settingsCacheStoreResolver.ts
@@ -1,15 +1,18 @@
 // Resolves the cache store used by Settings local-reset actions, with localhost-only test override support.
-import { closeAppCacheStoreConnections, type CacheStore } from '@cache';
+import { appCacheStore, closeAppCacheStoreConnections, type CacheStore } from '@cache';
+
+export type SettingsCacheStore = Pick<CacheStore, 'readSnapshot' | 'clearAll'>;
 
 declare global {
   interface Window {
-    __CONSPECTUS_CACHE_STORE__?: Pick<CacheStore, 'clearAll'>;
+    __CONSPECTUS_CACHE_STORE__?: SettingsCacheStore;
   }
 }
 
 const FALLBACK_INDEXEDDB_DATABASE_NAMES = ['conspectus-mobile-cache', 'conspectus-cache'];
 
-const defaultCacheStore: Pick<CacheStore, 'clearAll'> = {
+const defaultCacheStore: SettingsCacheStore = {
+  readSnapshot: (binding) => appCacheStore.readSnapshot(binding),
   async clearAll(): Promise<void> {
     if (typeof window === 'undefined') {
       return;
@@ -121,7 +124,7 @@ const isLocalCacheMockHost = (): boolean => {
   return window.location.hostname === '127.0.0.1' || window.location.hostname === 'localhost';
 };
 
-export const resolveSettingsCacheStore = (): Pick<CacheStore, 'clearAll'> => {
+export const resolveSettingsCacheStore = (): SettingsCacheStore => {
   if (isLocalCacheMockHost() && window.__CONSPECTUS_CACHE_STORE__ !== undefined) {
     return window.__CONSPECTUS_CACHE_STORE__;
   }

--- a/src/features/app-shell/routes/settingsInformation.test.ts
+++ b/src/features/app-shell/routes/settingsInformation.test.ts
@@ -1,0 +1,16 @@
+// Verifies Settings timestamps are deterministic, UTC-based, and reject invalid metadata.
+import { describe, expect, it } from 'vitest';
+
+import { formatSettingsTimestampUtc } from './settingsInformation';
+
+describe('formatSettingsTimestampUtc', () => {
+  it('formats the supplied metadata timestamp in UTC', () => {
+    expect(formatSettingsTimestampUtc('2026-03-04T12:30:00Z', 'en-GB')).toBe(
+      '4 Mar 2026, 12:30 UTC',
+    );
+  });
+
+  it('returns an empty value for invalid metadata', () => {
+    expect(formatSettingsTimestampUtc('not-a-date', 'en-GB')).toBe('');
+  });
+});

--- a/src/features/app-shell/routes/settingsInformation.ts
+++ b/src/features/app-shell/routes/settingsInformation.ts
@@ -1,0 +1,17 @@
+// Formats stable Settings metadata without deriving timestamps from the device's current time.
+export const formatSettingsTimestampUtc = (
+  timestamp: string,
+  locale?: Intl.LocalesArgument,
+): string => {
+  const date = new Date(timestamp);
+  if (!Number.isFinite(date.getTime())) {
+    return '';
+  }
+
+  return `${new Intl.DateTimeFormat(locale, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'UTC',
+    hour12: false,
+  }).format(date)} UTC`;
+};

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -162,6 +162,22 @@
     "generalActions": {
       "signOut": "Abmelden",
       "signIn": "Mit Microsoft anmelden"
+    },
+    "sync": {
+      "lastSync": "Letzte Synchronisierung",
+      "never": "Noch nicht synchronisiert",
+      "unknown": "Unbekannt"
+    },
+    "actions": {
+      "standard": "Datenbankaktionen",
+      "destructive": "Destruktive Aktionen",
+      "account": "Kontoaktionen"
+    },
+    "build": {
+      "heading": "Build-Informationen",
+      "version": "Version",
+      "builtReleased": "Erstellt / veröffentlicht",
+      "unknown": "Unbekannt"
     }
   },
   "deploymentInfo": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -162,6 +162,22 @@
     "generalActions": {
       "signOut": "Sign out",
       "signIn": "Sign in with Microsoft"
+    },
+    "sync": {
+      "lastSync": "Last sync",
+      "never": "Not synced yet",
+      "unknown": "Unknown"
+    },
+    "actions": {
+      "standard": "Database actions",
+      "destructive": "Destructive actions",
+      "account": "Account actions"
+    },
+    "build": {
+      "heading": "Build information",
+      "version": "Version",
+      "builtReleased": "Built / released",
+      "unknown": "Unknown"
     }
   },
   "deploymentInfo": {

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -681,6 +681,9 @@ const installMockCacheStore = async (
         };
         dbBytes: Uint8Array;
       }) {
+        (
+          window as Window & { __CONSPECTUS_LAST_WRITTEN_SYNC_AT__?: string }
+        ).__CONSPECTUS_LAST_WRITTEN_SYNC_AT__ = snapshot.metadata.lastSyncAtIso;
         storedSnapshots.set(toBindingKey(snapshot.binding), {
           binding: { ...snapshot.binding },
           metadata: { ...snapshot.metadata },
@@ -2058,14 +2061,31 @@ test('triggers a fresh sync after a successful DB file selection', async ({ page
   await page.goto(appPath('#/settings'));
 
   await expect(page.getByText('Cached DB is current with OneDrive.').first()).toBeVisible();
+  const initialLastSync = await page.getByTestId('settings-last-sync').textContent();
+  expect(initialLastSync).toContain('2026');
 
   await page.getByRole('button', { name: 'Change DB file' }).click();
   await page.getByTestId('select-file-file-root-db').click();
 
   await expect(page.getByTestId('binding-status-message')).toContainText('DB file selected.');
   await expect(page.getByText('Cached DB is current with OneDrive.').last()).toBeVisible();
+  const expectedLastSync = await page.evaluate(() => {
+    const timestamp = (window as Window & { __CONSPECTUS_LAST_WRITTEN_SYNC_AT__?: string })
+      .__CONSPECTUS_LAST_WRITTEN_SYNC_AT__;
+    if (timestamp === undefined) {
+      return null;
+    }
+    return `${new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: 'UTC',
+      hour12: false,
+    }).format(new Date(timestamp))} UTC`;
+  });
+  expect(expectedLastSync).not.toBeNull();
+  await expect(page.getByTestId('settings-last-sync')).toHaveText(expectedLastSync ?? '');
 
-  expect(await getCacheReadSnapshotCallCount(page)).toBe(3);
+  expect(await getCacheReadSnapshotCallCount(page)).toBe(6);
   expect(await getGraphMetadataCallCount(page)).toBe(3);
   expect(await getGraphDownloadCallCount(page)).toBe(1);
 });
@@ -2091,7 +2111,7 @@ test('restored binding triggers sync after interactive sign-in without reload', 
   await expect(page.getByTestId('auth-status-message')).toContainText('Signed in.');
   await expect(page.getByText('Downloaded the latest DB from OneDrive.')).toBeVisible();
 
-  expect(await getCacheReadSnapshotCallCount(page)).toBe(1);
+  expect(await getCacheReadSnapshotCallCount(page)).toBe(3);
   expect(await getGraphMetadataCallCount(page)).toBe(1);
   expect(await getGraphDownloadCallCount(page)).toBe(1);
 });
@@ -2329,6 +2349,11 @@ test('allows selecting a OneDrive .db file from the settings browser', async ({ 
   await expect(page.getByTestId('db-file-browser')).toHaveCount(0);
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('budget.db');
   await expect(page.getByTestId('selected-db-file-summary')).toContainText('/Finance');
+  await expect(page.getByTestId('settings-last-sync')).not.toBeEmpty();
+  await expect(page.getByTestId('settings-build-version')).not.toBeEmpty();
+  await expect(page.getByTestId('settings-build-time')).not.toBeEmpty();
+  await page.getByTestId('settings-build-information').scrollIntoViewIfNeeded();
+  await expect(page.getByTestId('settings-build-information')).toBeVisible();
   await expect(page.getByRole('button', { name: 'Change DB file' })).toBeVisible();
 
   await page.getByRole('link', { name: 'Accounts' }).click();


### PR DESCRIPTION
## Summary

- add M7-01 Settings sections for bound database details, cached last-sync metadata, and risk-grouped actions
- add a dedicated bottom build-information section using deterministic bundle/deployment metadata
- refresh displayed sync metadata after completed syncs and cover the behavior on mobile and desktop browser projects

## Acceptance criteria

- [x] Bound OneDrive file details are visible
- [x] Last sync timestamp is sourced from cached sync metadata and refreshes after sync
- [x] App version and build/release timestamp are visible at the bottom of Settings
- [x] Build date comes from bundle/deployment metadata, not device current time
- [x] Actions are grouped by risk level
- [x] Mobile scrolling and existing Settings interactions remain covered

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (416 app tests + 63 script tests)
- `npm run build`
- `npm run test:e2e` (114 tests)
- Local reviewer: APPROVED

Closes #75
