### PR TITLE
fix: [M7-08] Disable stale database fallback and persist sync indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Provide fast mobile access to a personal Conspectus SQLite database stored in On
 - View transfers for a selected month (default: current month).
 - Swipe to previous/next month.
 - Add a new transfer.
-- Offline viewing from cached last synced data.
+- Online read access with eTag-verified cached snapshot reuse.
 
 ## Non-Goals (MVP)
 
 - No backend server.
 - No desktop app changes.
 - No DB migrations in PWA.
-- No offline transfer creation.
+- No offline database viewing or transfer creation.
 
 ## Tech Direction
 

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -32,7 +32,7 @@ Canonical sections by topic:
 - Hosting: `https://jon2050.de/conspectus/webapp` (HTTPS available).
 - OneDrive file selection: ask once, store binding locally.
 - Settings must include local reset/rebind option.
-- Offline mode: **viewing only** using cached last DB.
+- Offline database viewing and editing: **not supported**; Settings remains available for recovery.
 - Offline add transfer: **not supported**.
 - File transport: raw `.db` only.
 - Keep source code small and simple.
@@ -88,7 +88,7 @@ Rationale:
 5. `Local Cache Module`
 
 - Persist DB blob + metadata (`eTag`, file IDs, last sync).
-- Provide offline read when network unavailable.
+- Retain DB bytes for eTag-verified online reuse only; never provide offline or stale fallback reads.
 
 6. `App State Module`
 
@@ -118,6 +118,10 @@ Read flow on app startup:
 3. Fetch file metadata (including `eTag`).
 4. If cached blob exists and eTag unchanged, load cached DB.
 5. Else download full DB, cache it, and load it.
+
+Startup fails closed when connectivity, authentication, metadata retrieval, or snapshot download
+fails. Cached database bytes are never opened for offline or stale fallback viewing. Settings remains
+accessible so the user can re-authenticate, rebind, or reset local data.
 
 Cache loss is non-critical: if the local IndexedDB cache is evicted (e.g. by iOS after inactivity), the app simply re-downloads the DB from OneDrive on next online startup. No data is lost because OneDrive is always the authoritative source.
 
@@ -409,9 +413,9 @@ Exit criteria:
 
 ---
 
-## Milestone 4: Sync Engine + Local Cache (Offline Read)
+## Milestone 4: Sync Engine + Local Cache (Verified Online Read)
 
-Goal: robust online/offline read behavior with minimal traffic.
+Goal: robust verified-online read behavior with minimal traffic.
 
 Substeps:
 
@@ -426,7 +430,7 @@ Substeps:
 5. Implement startup decision tree:
    - online + unchanged => cached DB
    - online + changed => download
-   - offline => cached DB if present
+   - offline => terminal connection-required error
 6. Add sync state UI:
    - synced
    - stale
@@ -458,8 +462,8 @@ M4-03 implementation clarification:
 M4-04 implementation clarification:
 
 - Startup freshness resolution is implemented in `src/features/app-shell/startupFreshnessService.ts` and invoked during app-shell startup from `src/features/app-shell/AppShell.svelte`.
-- The service emits deterministic result branches for the core decision tree: no binding, online unchanged (`eTag` match), online changed (`eTag` mismatch => re-download), offline with cache, and offline without cache.
-- When startup metadata refresh or snapshot download fails while a cached snapshot exists, the current implementation resolves a `stale` startup state and continues with the cached bytes instead of clearing auth/binding state.
+- The service emits deterministic result branches for the core decision tree: no binding, online unchanged (`eTag` match), online changed (`eTag` mismatch => re-download), and offline unsupported regardless of cache presence.
+- Startup metadata, authentication, and snapshot download failures resolve to a terminal error and close the DB runtime even when cached bytes exist; only a successful online eTag match may reuse cached DB bytes.
 - Development-only telemetry for startup freshness branches is emitted from `AppShell.svelte` so branch selection and fallback/error outcomes remain inspectable without adding production logging noise.
 
 M4-05 implementation clarification:
@@ -474,14 +478,14 @@ M4-06 implementation clarification:
 - Transient startup sync retries are implemented inside `src/features/app-shell/startupFreshnessService.ts`, not in UI code, so metadata refresh and fresh-snapshot download both share the same capped exponential backoff behavior.
 - Retryability is intentionally narrow: only normalized Graph `network_error` failures are retried; auth, permission, not-found, conflict, and local snapshot validation failures still fail fast on the first attempt.
 - The default startup retry policy is 3 total attempts with a `250ms` base delay capped at `1000ms`; when retries are exhausted, the final failure preserves the normalized `network_error` identity for later handling and surfaces actionable user messaging.
-- When retries are exhausted but a cached snapshot already exists, startup still resolves to the existing `stale` branch and continues with the cached DB instead of discarding readable local data.
+- When retries are exhausted, startup resolves to a terminal error and does not open cached DB bytes.
 - Browser snapshot downloads use `@microsoft.graph.downloadUrl` from the metadata response instead of the Graph `/content` redirect endpoint, because the redirect path can fail under browser CORS handling while the preauthenticated download URL avoids that failure mode.
 
 M4-07 implementation clarification:
 
 - Sync/cache regression coverage is split intentionally across service-level Vitest tests in `src/features/app-shell/startupFreshnessService.test.ts` and browser-level Playwright scenarios in `tests/e2e/app-shell.spec.ts`.
-- The automated coverage now includes the full startup decision matrix plus retry exhaustion behavior for both metadata refresh and fresh-snapshot download branches, including cached stale fallback and terminal error outcomes.
-- Offline startup behavior remains covered in Playwright for both cache-hit and cache-miss paths so CI catches regressions in the app-shell orchestration, not only in isolated service mocks.
+- The automated coverage now includes the full startup decision matrix plus retry exhaustion behavior for both metadata refresh and fresh-snapshot download branches, including terminal errors when cached bytes exist.
+- Offline startup behavior remains covered in Playwright for both cache-present and cache-missing paths; both must fail closed without opening database bytes.
 
 M4-08 implementation clarification:
 
@@ -492,12 +496,12 @@ M4-08 implementation clarification:
 
 Deliverables:
 
-- Reliable DB availability for read-only mode offline.
+- Reliable online DB availability with verified cache reuse.
 - Minimal repeated data transfers.
 
 Exit criteria:
 
-- Airplane mode still shows cached accounts/transfers.
+- Airplane mode shows a connection-required error while Settings remains accessible.
 - Online resume refreshes when eTag changed.
 
 ---
@@ -725,6 +729,12 @@ M7-01 implementation clarification:
 - Bound-file details come from the persisted binding, and the last-sync timestamp comes from the cached snapshot metadata. Settings refreshes that metadata when the shared sync state reaches `synced` so a completed download is reflected without polling.
 - The dedicated Settings build section reuses the build-time version and deployment timestamp resolution in `src/shared/config/buildInfo.ts`; its injected bundle metadata remains available offline.
 
+M7-08 implementation clarification:
+
+- Startup database access now fails closed when offline or when authentication, OneDrive metadata, or snapshot download fails; cached bytes are reused only after a successful online eTag match.
+- Terminal startup decisions close the browser DB runtime, and Accounts/Transfers show the persistent sync error instead of stale rows or misleading empty states.
+- Startup toast and progress feedback remain visible for the full sync attempt, including an indeterminate metadata-check phase, while Settings stays accessible for re-authentication and file recovery.
+
 4. Error recovery UX:
    - re-login flow
    - stale token handling
@@ -803,7 +813,7 @@ Exit criteria:
 - File binding and app restart persistence.
 - View accounts and month transfers.
 - Add transfer happy path and failure/retry path.
-- Offline startup with cache.
+- Offline startup failure with and without cached bytes.
 
 ## 6.3 Test Data and Fixtures
 
@@ -859,7 +869,7 @@ Hard gates before release:
 - No client secret in frontend code.
 - HTTPS-only deployment.
 - MFA recommended/required on both Microsoft accounts.
-- Store only minimal local metadata and cached DB necessary for offline read.
+- Store only minimal local metadata and cached DB bytes necessary for eTag-verified online reuse.
 - Provide explicit logout and local reset options.
 
 ---
@@ -994,7 +1004,7 @@ MVP deliverables:
 1. Installable PWA on iOS/Android.
 2. Early integrated deployment on `jon2050.de/conspectus/webapp/` for device testing.
 3. OneDrive-authenticated access to selected SQLite DB.
-4. Cached offline viewing.
+4. eTag-verified cached database reuse during online startup.
 5. Accounts view.
 6. Month-based transfers view with swipe.
 7. Add-transfer write flow with desktop-compatible DB updates.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -599,6 +599,14 @@ An issue is only considered done when:
 - Depends on: `M7-04, M7-05`
 - GitHub: [#81](https://github.com/Jon2050/Conspectus-Mobile/issues/81)
 
+### :white_check_mark: M7-08 Disable stale database fallback and persist sync indicators
+
+- Label: `bug`
+- Milestone: `M7 - Settings + Recovery`
+- Summary: Work disables offline and failed-sync database cache fallback, keeps startup sync feedback visible for the full attempt, and surfaces persistent sync errors on Accounts and Transfers while Settings remains available for recovery.
+- Depends on: `M4-04, M4-05, M4-07, M4-08, M7-01`
+- GitHub: [#211](https://github.com/Jon2050/Conspectus-Mobile/issues/211)
+
 ### :green_circle: M8-01 Implement CSP and security headers for PWA path
 
 - Label: `security`
@@ -643,7 +651,7 @@ An issue is only considered done when:
 
 - Label: `test`
 - Milestone: `M8 - Hardening + QA + Release`
-- Summary: Work includes flows: login, bind file, read accounts/transfers, add transfer, retry and offline-read smoke scenario. It also covers flaky-test mitigation and retries policy.
+- Summary: Work includes flows: login, bind file, read accounts/transfers, add transfer, retry and offline-startup failure smoke scenario. It also covers flaky-test mitigation and retries policy.
 - Depends on: `M6-10, M7-07`
 - GitHub: [#87](https://github.com/Jon2050/Conspectus-Mobile/issues/87)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.7.01",
+  "version": "0.7.08",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.7.01",
+      "version": "0.7.08",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.7.01",
+  "version": "0.7.08",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/cache/README.md
+++ b/src/cache/README.md
@@ -4,7 +4,7 @@ Responsibility:
 
 - Persist and load local database cache and sync metadata.
 - Encapsulate IndexedDB/Dexie schema and migrations.
-- Provide cache invalidation and reset behavior.
+- Provide cache invalidation and reset behavior without exposing snapshots for offline viewing.
 
 Dependency boundaries:
 
@@ -34,4 +34,5 @@ Migration strategy:
 M4 implementation target:
 
 - Keep Dexie schema details private behind `CacheStore`.
-- Expose deterministic cache behavior for online/offline startup decisions.
+- Expose deterministic cache behavior for eTag-verified online startup decisions; connectivity or
+  sync failures must not open cached database bytes.

--- a/src/features/app-shell/AppShell.lifecycle.test.ts
+++ b/src/features/app-shell/AppShell.lifecycle.test.ts
@@ -1,0 +1,14 @@
+// Guards the AppShell source contract that releases persistent startup feedback on teardown.
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const APP_SHELL_SOURCE = readFileSync(new URL('./AppShell.svelte', import.meta.url), 'utf8');
+
+describe('AppShell lifecycle', () => {
+  it('clears the startup sync toast from the registered destroy callback', () => {
+    expect(APP_SHELL_SOURCE).toMatch(
+      /onDestroy\(\(\) => \{\s*clearStartupSyncToast\(syncStateStore\);/u,
+    );
+  });
+});

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -34,6 +34,7 @@
     applyStartupDbRuntimeError,
     applyUnexpectedStartupSyncError,
     beginStartupSync,
+    clearStartupSyncToast,
     updateStartupSyncProgress,
   } from './startupSyncStateController';
   import { syncDbRuntimeForStartupDecision } from './startupDbRuntimeSync';
@@ -124,6 +125,7 @@
 
   const performSync = async (binding: DriveItemBinding | null): Promise<void> => {
     const syncId = ++currentSyncId;
+    clearStartupSyncToast(syncStateStore);
     syncStateStore.reset();
     const dbRuntime = resolveAppDbRuntime();
 
@@ -201,6 +203,7 @@
     if (hasPerformedInitialSync) {
       void performSync(binding);
     } else {
+      clearStartupSyncToast(syncStateStore);
       syncStateStore.reset();
     }
   });
@@ -402,6 +405,7 @@
   });
 
   onDestroy(() => {
+    clearStartupSyncToast(syncStateStore);
     unsubscribe();
     unsubscribeAddTransferSaveController();
     unsubscribeSelectedBinding();
@@ -466,12 +470,13 @@
     </section>
   {/if}
 
-  {#if $syncStateStore.state === 'syncing' && $syncStateStore.progress !== null}
+  {#if $syncStateStore.state === 'syncing'}
     <section class="startup-sync-progress" data-testid="startup-sync-progress">
       <ProgressIndicator
-        loaded={$syncStateStore.progress.loaded}
-        total={$syncStateStore.progress.total}
-        kind={$syncStateStore.progress.kind}
+        loaded={$syncStateStore.progress?.loaded ?? 0}
+        total={$syncStateStore.progress?.total ?? null}
+        kind={$syncStateStore.progress?.kind ?? 'download'}
+        statusText={$syncStateStore.progress === null ? $syncStateStore.message : null}
       />
     </section>
   {/if}
@@ -486,9 +491,9 @@
       {#if showLoadingPlaceholder}
         <LoadingPlaceholder />
       {:else if currentRoute === 'accounts'}
-        <AccountsRoute />
+        <AccountsRoute {syncStateStore} />
       {:else if currentRoute === 'transfers'}
-        <TransfersRoute />
+        <TransfersRoute {syncStateStore} />
       {:else if currentRoute === 'add'}
         <AddRoute
           bind:fields={addTransferFields}

--- a/src/features/app-shell/AppShell.test.ts
+++ b/src/features/app-shell/AppShell.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from 'vitest';
 import { readable } from 'svelte/store';
 import { render } from 'svelte/server';
-import { formatBuildInfoLabel, getFallbackBuildInfo } from '@shared';
+import { createSyncStateStore, formatBuildInfoLabel, getFallbackBuildInfo } from '@shared';
 
 import AppShell from './AppShell.svelte';
 import { APP_ROUTES, type AppRouteKey } from './hashRouting';
@@ -99,5 +99,24 @@ describe('AppShell component', () => {
     expect(body).toContain('data-testid="pending-transfer-review"');
     expect(body).toContain('data-testid="pending-transfer-retry"');
     expect(body).toContain('Transfersynchronisierung benötigt Aufmerksamkeit');
+  });
+
+  it('renders indeterminate progress throughout the startup metadata check', () => {
+    const syncStateStore = createSyncStateStore({
+      state: 'syncing',
+      message: 'Checking OneDrive database freshness...',
+    });
+    const { body } = render(AppShell, {
+      props: {
+        routeStore: readable<AppRouteKey>('settings'),
+        showLoadingPlaceholder: false,
+        syncStateStore,
+      },
+    });
+
+    expect(body).toContain('data-testid="startup-sync-progress"');
+    expect(body).toContain('data-testid="progress-bar"');
+    expect(body).toContain('Checking OneDrive database freshness...');
+    expect(body).not.toMatch(/<progress[^>]*\svalue=/u);
   });
 });

--- a/src/features/app-shell/components/ProgressIndicator.svelte
+++ b/src/features/app-shell/components/ProgressIndicator.svelte
@@ -1,12 +1,15 @@
+<!-- Renders determinate byte progress or an indeterminate status for active sync operations. -->
 <script lang="ts">
   import { _ } from 'svelte-i18n';
 
   export let loaded: number;
   export let total: number | null;
   export let kind: 'download' | 'upload';
+  export let statusText: string | null = null;
 
   $: progressText =
-    total !== null
+    statusText ??
+    (total !== null
       ? $_(`appShell.${kind}Progress`, {
           values: {
             loaded: Math.round(loaded / 1024),
@@ -15,7 +18,7 @@
         })
       : $_(`appShell.${kind}edKb`, {
           values: { kb: Math.round(loaded / 1024) },
-        });
+        }));
 </script>
 
 <div class="progress-indicator" data-testid="progress-indicator" data-kind={kind}>

--- a/src/features/app-shell/routes/AccountsRoute.svelte
+++ b/src/features/app-shell/routes/AccountsRoute.svelte
@@ -3,7 +3,12 @@
   import { onDestroy, onMount } from 'svelte';
   import { get } from 'svelte/store';
   import { appAccountQueryService } from '@db';
-  import { appSyncStateStore, type SyncState, formatAmountDisplay } from '@shared';
+  import {
+    appSyncStateStore,
+    type SyncState,
+    type SyncStateStore,
+    formatAmountDisplay,
+  } from '@shared';
   import { _, locale } from 'svelte-i18n';
 
   import SkeletonCard from '../components/SkeletonCard.svelte';
@@ -13,32 +18,34 @@
     type AccountsRouteState,
   } from './accountsRouteController';
 
+  export let syncStateStore: SyncStateStore = appSyncStateStore;
   export let controller: AccountsRouteController =
     createAccountsRouteController(appAccountQueryService);
 
   let state: AccountsRouteState = controller.getState();
-  let lastObservedSyncState: SyncState = get(appSyncStateStore).state;
+  let lastObservedSyncState: SyncState = get(syncStateStore).state;
+
+  const loadForSyncState = (): void => {
+    const syncSnapshot = get(syncStateStore);
+    void controller.load(syncSnapshot.state === 'error' ? syncSnapshot.message : null);
+  };
 
   const unsubscribeController = controller.subscribe((nextState) => {
     state = nextState;
   });
-  const unsubscribeSyncState = appSyncStateStore.subscribe((syncSnapshot) => {
+  const unsubscribeSyncState = syncStateStore.subscribe((syncSnapshot) => {
     if (syncSnapshot.state === lastObservedSyncState) {
       return;
     }
 
     lastObservedSyncState = syncSnapshot.state;
-    if (
-      syncSnapshot.state === 'synced' ||
-      syncSnapshot.state === 'stale' ||
-      syncSnapshot.state === 'offline'
-    ) {
-      void controller.load();
+    if (syncSnapshot.state === 'synced' || syncSnapshot.state === 'error') {
+      loadForSyncState();
     }
   });
 
   onMount(() => {
-    void controller.load();
+    loadForSyncState();
   });
 
   onDestroy(() => {

--- a/src/features/app-shell/routes/TransfersRoute.svelte
+++ b/src/features/app-shell/routes/TransfersRoute.svelte
@@ -5,6 +5,7 @@
   import {
     appSyncStateStore,
     type SyncState,
+    type SyncStateStore,
     formatEpochDayToDate,
     formatAmountDisplay,
   } from '@shared';
@@ -33,6 +34,7 @@
   const SWIPE_DRAG_LOCK_THRESHOLD_PX = 10;
   const SWIPE_DRAG_MAX_OFFSET_PX = 56;
 
+  export let syncStateStore: SyncStateStore = appSyncStateStore;
   export let controller: TransfersRouteController = createTransfersRouteController(
     appTransferMonthQueryService,
     appAccountQueryService,
@@ -45,30 +47,33 @@
   let swipeDragOffsetX = 0;
   let swipeLockedHorizontally = false;
   let state: TransfersRouteState = controller.getState();
-  let lastObservedSyncState: SyncState = get(appSyncStateStore).state;
+  let lastObservedSyncState: SyncState = get(syncStateStore).state;
 
   $: monthKey = toMonthKey(monthAnchorEpochDay);
   $: monthLabel = formatMonthLabel(monthAnchorEpochDay, $locale);
 
   $: {
-    void controller.load(monthAnchorEpochDay);
+    const syncSnapshot = get(syncStateStore);
+    void controller.load(
+      monthAnchorEpochDay,
+      syncSnapshot.state === 'error' ? syncSnapshot.message : null,
+    );
   }
 
   const unsubscribeController = controller.subscribe((nextState) => {
     state = nextState;
   });
 
-  const unsubscribeSyncState = appSyncStateStore.subscribe((syncSnapshot) => {
+  const unsubscribeSyncState = syncStateStore.subscribe((syncSnapshot) => {
     if (syncSnapshot.state === lastObservedSyncState) {
       return;
     }
     lastObservedSyncState = syncSnapshot.state;
-    if (
-      syncSnapshot.state === 'synced' ||
-      syncSnapshot.state === 'stale' ||
-      syncSnapshot.state === 'offline'
-    ) {
-      void controller.load(monthAnchorEpochDay);
+    if (syncSnapshot.state === 'synced' || syncSnapshot.state === 'error') {
+      void controller.load(
+        monthAnchorEpochDay,
+        syncSnapshot.state === 'error' ? syncSnapshot.message : null,
+      );
     }
   });
 

--- a/src/features/app-shell/routes/accountsRouteController.test.ts
+++ b/src/features/app-shell/routes/accountsRouteController.test.ts
@@ -97,7 +97,7 @@ describe('accounts route controller', () => {
     });
   });
 
-  it('treats a db_not_open query failure as an actionable empty state', async () => {
+  it('treats a db_not_open query failure as an empty state without a sync error', async () => {
     const listVisibleNonPrimaryAccounts = vi.fn(() => {
       throw new DbRuntimeError('db_not_open', 'SQLite runtime is not open.');
     });
@@ -109,6 +109,22 @@ describe('accounts route controller', () => {
       operation: 'empty',
       accounts: [],
       error: null,
+    });
+  });
+
+  it('surfaces the startup sync error without querying stale account data', async () => {
+    const listVisibleNonPrimaryAccounts = vi.fn(() => [
+      { accountId: 12, name: 'Stale account', amountCents: 1250, accountTypeId: null },
+    ]);
+    const controller = createAccountsRouteController({ listVisibleNonPrimaryAccounts });
+
+    await controller.load('Connection is required to load the database.');
+
+    expect(listVisibleNonPrimaryAccounts).not.toHaveBeenCalled();
+    expect(controller.getState()).toEqual({
+      operation: 'error',
+      accounts: [],
+      error: { message: 'Connection is required to load the database.' },
     });
   });
 

--- a/src/features/app-shell/routes/accountsRouteController.ts
+++ b/src/features/app-shell/routes/accountsRouteController.ts
@@ -27,7 +27,7 @@ export type AccountsRouteStateListener = (state: AccountsRouteState) => void;
 export interface AccountsRouteController {
   getState(): AccountsRouteState;
   subscribe(listener: AccountsRouteStateListener): () => void;
-  load(): Promise<void>;
+  load(syncErrorMessage?: string | null): Promise<void>;
 }
 
 const INITIAL_STATE: AccountsRouteState = {
@@ -108,12 +108,21 @@ export const createAccountsRouteController = (
       };
     },
 
-    async load(): Promise<void> {
+    async load(syncErrorMessage: string | null = null): Promise<void> {
       updateState({
         operation: 'loading',
         accounts: [],
         error: null,
       });
+
+      if (syncErrorMessage !== null && syncErrorMessage.trim().length > 0) {
+        updateState({
+          operation: 'error',
+          accounts: [],
+          error: { message: syncErrorMessage },
+        });
+        return;
+      }
 
       try {
         const accounts = accountQueryService.listVisibleNonPrimaryAccounts().map(toRouteAccount);

--- a/src/features/app-shell/routes/transfersRouteController.test.ts
+++ b/src/features/app-shell/routes/transfersRouteController.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the transfers route controller.
  * Ensures the controller coordinates multiple query services to correctly assemble the state for the transfers view.
  */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createTransfersRouteController } from './transfersRouteController';
 import {
   DbRuntimeError,
@@ -82,7 +82,7 @@ describe('createTransfersRouteController', () => {
     ]);
   });
 
-  it('treats a DB runtime not-open error as an empty state', async () => {
+  it('treats a DB runtime not-open error as an empty state without a sync error', async () => {
     const controller = createTransfersRouteController(
       {
         listTransfersByMonth: () => {
@@ -99,6 +99,24 @@ describe('createTransfersRouteController', () => {
       operation: 'empty',
       transfers: [],
       error: null,
+    });
+  });
+
+  it('surfaces the startup sync error without querying stale transfer data', async () => {
+    const listTransfersByMonth = vi.fn(() => []);
+    const controller = createTransfersRouteController(
+      { listTransfersByMonth },
+      { listAllAccounts: () => [] },
+      { listAllCategories: () => [] },
+    );
+
+    await controller.load(19800, 'Connection is required to load the database.');
+
+    expect(listTransfersByMonth).not.toHaveBeenCalled();
+    expect(controller.getState()).toEqual({
+      operation: 'error',
+      transfers: [],
+      error: { message: 'Connection is required to load the database.' },
     });
   });
 

--- a/src/features/app-shell/routes/transfersRouteController.ts
+++ b/src/features/app-shell/routes/transfersRouteController.ts
@@ -41,7 +41,7 @@ export type TransfersRouteStateListener = (state: TransfersRouteState) => void;
 export interface TransfersRouteController {
   getState(): TransfersRouteState;
   subscribe(listener: TransfersRouteStateListener): () => void;
-  load(monthAnchorEpochDay: number): Promise<void>;
+  load(monthAnchorEpochDay: number, syncErrorMessage?: string | null): Promise<void>;
 }
 
 const INITIAL_STATE: TransfersRouteState = {
@@ -92,12 +92,21 @@ export const createTransfersRouteController = (
       };
     },
 
-    async load(monthAnchorEpochDay: number): Promise<void> {
+    async load(monthAnchorEpochDay: number, syncErrorMessage: string | null = null): Promise<void> {
       updateState({
         operation: 'loading',
         transfers: [],
         error: null,
       });
+
+      if (syncErrorMessage !== null && syncErrorMessage.trim().length > 0) {
+        updateState({
+          operation: 'error',
+          transfers: [],
+          error: { message: syncErrorMessage },
+        });
+        return;
+      }
 
       try {
         const rawTransfers = transferMonthQueryService.listTransfersByMonth(monthAnchorEpochDay);

--- a/src/features/app-shell/startupDbRuntimeSync.test.ts
+++ b/src/features/app-shell/startupDbRuntimeSync.test.ts
@@ -34,17 +34,17 @@ const createReadyDecision = (): StartupFreshnessDecision => ({
 });
 
 describe('startup db runtime sync', () => {
-  it('closes the runtime for non-ready startup decisions', async () => {
+  it('closes the runtime for an offline startup failure', async () => {
     const dbRuntime = createDbRuntimeMock();
     const decision: StartupFreshnessDecision = {
       kind: 'error',
-      branch: 'online_metadata_failed',
+      branch: 'offline_unsupported',
       syncState: 'error',
       snapshot: null,
       failure: {
-        code: 'metadata_fetch_failed',
-        message: 'Metadata failed',
-        cause: new Error('Metadata failed'),
+        code: 'offline_unsupported',
+        message: 'Connection is required to load the database.',
+        cause: new Error('Connection is required to load the database.'),
       },
     };
 

--- a/src/features/app-shell/startupFreshnessService.test.ts
+++ b/src/features/app-shell/startupFreshnessService.test.ts
@@ -114,42 +114,24 @@ describe('startup freshness service', () => {
     expect(snapshotService.downloadAndCacheSnapshot).not.toHaveBeenCalled();
   });
 
-  it('uses the cached snapshot while offline', async () => {
-    const cachedSnapshot = createSnapshot();
+  it('fails fast while offline without reading a cached snapshot', async () => {
     const graphClient = createGraphClient(createMetadata());
-    const cacheStore = createCacheStore(cachedSnapshot);
-    const snapshotService = createSnapshotService(createSnapshot());
-    const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService);
-
-    await expect(service.resolve(DRIVE_ITEM_BINDING, false)).resolves.toEqual({
-      kind: 'ready',
-      branch: 'offline_cached',
-      syncState: 'offline',
-      snapshot: cachedSnapshot,
-      failure: null,
-    });
-
-    expect(graphClient.getFileMetadata).not.toHaveBeenCalled();
-    expect(snapshotService.downloadAndCacheSnapshot).not.toHaveBeenCalled();
-  });
-
-  it('fails deterministically when offline without a cached snapshot', async () => {
-    const graphClient = createGraphClient(createMetadata());
-    const cacheStore = createCacheStore(null);
+    const cacheStore = createCacheStore(createSnapshot());
     const snapshotService = createSnapshotService(createSnapshot());
     const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService);
 
     await expect(service.resolve(DRIVE_ITEM_BINDING, false)).resolves.toMatchObject({
       kind: 'error',
-      branch: 'offline_missing_cache',
+      branch: 'offline_unsupported',
       syncState: 'error',
       snapshot: null,
       failure: {
-        code: 'offline_cache_missing',
-        message: 'No cached OneDrive database is available while offline.',
+        code: 'offline_unsupported',
+        message: 'Connection is required to load the database.',
       },
     });
 
+    expect(cacheStore.readSnapshot).not.toHaveBeenCalled();
     expect(graphClient.getFileMetadata).not.toHaveBeenCalled();
     expect(snapshotService.downloadAndCacheSnapshot).not.toHaveBeenCalled();
   });
@@ -212,7 +194,7 @@ describe('startup freshness service', () => {
     );
   });
 
-  it('falls back to the cached snapshot as stale when metadata refresh fails online', async () => {
+  it('fails when metadata refresh fails online even if a cached snapshot exists', async () => {
     const cachedSnapshot = createSnapshot();
     const graphClient = createGraphClient(new Error('Graph metadata request failed.'));
     const cacheStore = createCacheStore(cachedSnapshot);
@@ -220,10 +202,10 @@ describe('startup freshness service', () => {
     const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService);
 
     await expect(service.resolve(DRIVE_ITEM_BINDING, true)).resolves.toMatchObject({
-      kind: 'ready',
-      branch: 'online_metadata_failed_cached',
-      syncState: 'stale',
-      snapshot: cachedSnapshot,
+      kind: 'error',
+      branch: 'online_metadata_failed',
+      syncState: 'error',
+      snapshot: null,
       failure: {
         code: 'metadata_fetch_failed',
         message: 'Graph metadata request failed.',
@@ -253,7 +235,7 @@ describe('startup freshness service', () => {
     expect(snapshotService.downloadAndCacheSnapshot).not.toHaveBeenCalled();
   });
 
-  it('surfaces session-expired fallback details when metadata refresh fails with an auth error and cached data exists', async () => {
+  it('surfaces a session-expired terminal error when metadata refresh fails with cached data', async () => {
     const cachedSnapshot = createSnapshot();
     const graphClient = createGraphClient(
       createGraphError(
@@ -267,10 +249,10 @@ describe('startup freshness service', () => {
     const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService);
 
     await expect(service.resolve(DRIVE_ITEM_BINDING, true)).resolves.toMatchObject({
-      kind: 'ready',
-      branch: 'online_auth_expired_cached',
-      syncState: 'stale',
-      snapshot: cachedSnapshot,
+      kind: 'error',
+      branch: 'online_auth_expired',
+      syncState: 'error',
+      snapshot: null,
       failure: {
         code: 'auth_expired',
         message: 'Authentication is required to access the selected OneDrive file.',
@@ -314,7 +296,7 @@ describe('startup freshness service', () => {
     expect(snapshotService.downloadAndCacheSnapshot).not.toHaveBeenCalled();
   });
 
-  it('falls back to the cached snapshot as stale when downloading a fresh snapshot fails online', async () => {
+  it('fails when downloading a fresh snapshot fails even if a cached snapshot exists', async () => {
     const cachedSnapshot = createSnapshot({
       metadata: {
         eTag: '"etag-old"',
@@ -327,10 +309,10 @@ describe('startup freshness service', () => {
     const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService);
 
     await expect(service.resolve(DRIVE_ITEM_BINDING, true)).resolves.toMatchObject({
-      kind: 'ready',
-      branch: 'online_download_failed_cached',
-      syncState: 'stale',
-      snapshot: cachedSnapshot,
+      kind: 'error',
+      branch: 'online_download_failed',
+      syncState: 'error',
+      snapshot: null,
       failure: {
         code: 'snapshot_download_failed',
         message: 'Fresh snapshot download failed.',
@@ -338,7 +320,7 @@ describe('startup freshness service', () => {
     });
   });
 
-  it('keeps the cached snapshot and marks the session as expired when downloading a fresh snapshot fails with an auth error', async () => {
+  it('returns a session-expired error when download auth fails with cached data', async () => {
     const cachedSnapshot = createSnapshot({
       metadata: {
         eTag: '"etag-old"',
@@ -357,10 +339,10 @@ describe('startup freshness service', () => {
     const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService);
 
     await expect(service.resolve(DRIVE_ITEM_BINDING, true)).resolves.toMatchObject({
-      kind: 'ready',
-      branch: 'online_auth_expired_cached',
-      syncState: 'stale',
-      snapshot: cachedSnapshot,
+      kind: 'error',
+      branch: 'online_auth_expired',
+      syncState: 'error',
+      snapshot: null,
       failure: {
         code: 'auth_expired',
         message: 'Authentication is required to access the selected OneDrive file.',
@@ -490,7 +472,7 @@ describe('startup freshness service', () => {
     expect(waitFor).toHaveBeenNthCalledWith(2, 500);
   });
 
-  it('keeps the cached snapshot as stale after transient download failures exhaust retries', async () => {
+  it('returns an error after transient download failures exhaust retries with cached data', async () => {
     const cachedSnapshot = createSnapshot({
       metadata: {
         eTag: '"etag-old"',
@@ -512,10 +494,10 @@ describe('startup freshness service', () => {
     });
 
     await expect(service.resolve(DRIVE_ITEM_BINDING, true)).resolves.toMatchObject({
-      kind: 'ready',
-      branch: 'online_download_failed_cached',
-      syncState: 'stale',
-      snapshot: cachedSnapshot,
+      kind: 'error',
+      branch: 'online_download_failed',
+      syncState: 'error',
+      snapshot: null,
       failure: {
         code: 'snapshot_download_failed',
         message:
@@ -642,7 +624,7 @@ describe('startup freshness service', () => {
     expect(snapshotService.downloadAndCacheSnapshot).not.toHaveBeenCalled();
   });
 
-  it('keeps the cached snapshot as stale after transient metadata failures exhaust retries', async () => {
+  it('returns an error after transient metadata failures exhaust retries with cached data', async () => {
     const cachedSnapshot = createSnapshot();
     const graphClient = createGraphClient(
       createGraphError('network_error', 'Temporary metadata outage.', 503),
@@ -659,10 +641,10 @@ describe('startup freshness service', () => {
     });
 
     await expect(service.resolve(DRIVE_ITEM_BINDING, true)).resolves.toMatchObject({
-      kind: 'ready',
-      branch: 'online_metadata_failed_cached',
-      syncState: 'stale',
-      snapshot: cachedSnapshot,
+      kind: 'error',
+      branch: 'online_metadata_failed',
+      syncState: 'error',
+      snapshot: null,
       failure: {
         code: 'metadata_fetch_failed',
         message:

--- a/src/features/app-shell/startupFreshnessService.ts
+++ b/src/features/app-shell/startupFreshnessService.ts
@@ -9,17 +9,13 @@ export type StartupFreshnessBranch =
   | 'no_binding'
   | 'online_unchanged'
   | 'online_changed'
-  | 'offline_cached'
-  | 'offline_missing_cache'
-  | 'online_metadata_failed_cached'
+  | 'offline_unsupported'
   | 'online_metadata_failed'
-  | 'online_download_failed_cached'
   | 'online_download_failed'
-  | 'online_auth_expired_cached'
   | 'online_auth_expired';
 
 export type StartupFreshnessFailureCode =
-  | 'offline_cache_missing'
+  | 'offline_unsupported'
   | 'metadata_fetch_failed'
   | 'snapshot_download_failed'
   | 'auth_expired';
@@ -45,21 +41,15 @@ export interface StartupFreshnessSkippedDecision extends StartupFreshnessBaseDec
 
 export interface StartupFreshnessReadyDecision extends StartupFreshnessBaseDecision {
   readonly kind: 'ready';
-  readonly branch:
-    | 'online_unchanged'
-    | 'online_changed'
-    | 'offline_cached'
-    | 'online_metadata_failed_cached'
-    | 'online_download_failed_cached'
-    | 'online_auth_expired_cached';
-  readonly syncState: 'synced' | 'offline' | 'stale';
+  readonly branch: 'online_unchanged' | 'online_changed';
+  readonly syncState: 'synced';
   readonly snapshot: CachedDatabaseSnapshot;
 }
 
 export interface StartupFreshnessErrorDecision extends StartupFreshnessBaseDecision {
   readonly kind: 'error';
   readonly branch:
-    | 'offline_missing_cache'
+    | 'offline_unsupported'
     | 'online_metadata_failed'
     | 'online_download_failed'
     | 'online_auth_expired';
@@ -250,31 +240,21 @@ export const createStartupFreshnessService = (
       };
     }
 
-    const cachedSnapshot = await cacheStore.readSnapshot(binding);
-
     if (!isOnline) {
-      if (cachedSnapshot !== null) {
-        return {
-          kind: 'ready',
-          branch: 'offline_cached',
-          syncState: 'offline',
-          snapshot: cachedSnapshot,
-          failure: null,
-        };
-      }
-
       return {
         kind: 'error',
-        branch: 'offline_missing_cache',
+        branch: 'offline_unsupported',
         syncState: 'error',
         snapshot: null,
         failure: createFailure(
-          'offline_cache_missing',
-          new Error('No cached OneDrive database is available while offline.'),
-          'No cached OneDrive database is available while offline.',
+          'offline_unsupported',
+          new Error('Connection is required to load the database.'),
+          'Connection is required to load the database.',
         ),
       };
     }
+
+    const cachedSnapshot = await cacheStore.readSnapshot(binding);
 
     try {
       const retryOptions = normalizeRetryOptions(options.retry);
@@ -317,16 +297,6 @@ export const createStartupFreshnessService = (
 
         const failure = createFailure(failureCode, error, fallbackMessage);
 
-        if (cachedSnapshot !== null) {
-          return {
-            kind: 'ready',
-            branch: isAuthError ? 'online_auth_expired_cached' : 'online_download_failed_cached',
-            syncState: 'stale',
-            snapshot: cachedSnapshot,
-            failure,
-          };
-        }
-
         return {
           kind: 'error',
           branch: isAuthError ? 'online_auth_expired' : 'online_download_failed',
@@ -343,16 +313,6 @@ export const createStartupFreshnessService = (
         : 'Failed to refresh the selected OneDrive database metadata.';
 
       const failure = createFailure(failureCode, error, fallbackMessage);
-
-      if (cachedSnapshot !== null) {
-        return {
-          kind: 'ready',
-          branch: isAuthError ? 'online_auth_expired_cached' : 'online_metadata_failed_cached',
-          syncState: 'stale',
-          snapshot: cachedSnapshot,
-          failure,
-        };
-      }
 
       return {
         kind: 'error',

--- a/src/features/app-shell/startupSyncStateController.test.ts
+++ b/src/features/app-shell/startupSyncStateController.test.ts
@@ -9,6 +9,7 @@ import {
   applyStartupFreshnessDecision,
   applyUnexpectedStartupSyncError,
   beginStartupSync,
+  clearStartupSyncToast,
   updateStartupSyncProgress,
 } from './startupSyncStateController';
 
@@ -16,6 +17,7 @@ import type { StartupFreshnessDecision } from './startupFreshnessService';
 
 const createToastStore = () => ({
   show: vi.fn(() => 'toast-id'),
+  remove: vi.fn(),
 });
 
 describe('startupSyncStateController', () => {
@@ -31,7 +33,22 @@ describe('startupSyncStateController', () => {
       branch: null,
       progress: null,
     });
-    expect(toastStore.show).toHaveBeenCalledWith('Synchronisiere mit OneDrive...', 'info', 2800);
+    expect(toastStore.show).toHaveBeenCalledWith('Synchronisiere mit OneDrive...', 'info', 0);
+  });
+
+  it('replaces and explicitly clears the persistent startup toast', () => {
+    const store = createSyncStateStore();
+    const toastStore = createToastStore();
+
+    beginStartupSync(store, toastStore);
+    beginStartupSync(store, toastStore);
+
+    expect(toastStore.remove).toHaveBeenCalledTimes(1);
+    expect(toastStore.remove).toHaveBeenLastCalledWith('toast-id');
+
+    clearStartupSyncToast(store);
+
+    expect(toastStore.remove).toHaveBeenCalledTimes(2);
   });
 
   it('updates progress in the store when startup sync progress changes', () => {
@@ -85,6 +102,7 @@ describe('startupSyncStateController', () => {
       'success',
       3200,
     );
+    expect(toastStore.remove).toHaveBeenCalledWith('toast-id');
   });
 
   it('applies a successful online unchanged decision and surfaces a success toast', () => {
@@ -126,153 +144,40 @@ describe('startupSyncStateController', () => {
       'success',
       3200,
     );
+    expect(toastStore.remove).toHaveBeenCalledWith('toast-id');
   });
 
-  it('applies an offline cached decision and surfaces an info toast', () => {
+  it('applies offline startup failure as an actionable error', () => {
     const store = createSyncStateStore();
     const toastStore = createToastStore();
     const decision: StartupFreshnessDecision = {
-      kind: 'ready',
-      branch: 'offline_cached',
-      syncState: 'offline',
-      snapshot: {
-        binding: {
-          driveId: 'drive-123',
-          itemId: 'item-456',
-          name: 'conspectus.db',
-          parentPath: '/',
-        },
-        metadata: {
-          eTag: '"etag-1"',
-          lastSyncAtIso: '2026-03-11T10:45:00.000Z',
-        },
-        dbBytes: Uint8Array.from([1, 2, 3, 4]),
-      },
-      failure: null,
-    };
-
-    beginStartupSync(store, toastStore);
-    toastStore.show.mockClear();
-
-    applyStartupFreshnessDecision(store, decision, toastStore);
-
-    expect(get(store)).toEqual({
-      state: 'offline',
-      message: 'Offline-Modus nutzt die zuletzt zwischengespeicherte DB.',
-      branch: 'offline_cached',
-      progress: null,
-    });
-    expect(toastStore.show).toHaveBeenCalledWith(
-      'Offline-Modus nutzt die zuletzt zwischengespeicherte DB.',
-      'info',
-      3200,
-    );
-  });
-
-  it('applies stale cached fallback decisions and surfaces a warning toast', () => {
-    const store = createSyncStateStore({
-      state: 'syncing',
-      message: 'Suche nach DB-Updates auf OneDrive...',
-    });
-    const toastStore = createToastStore();
-    const decision: StartupFreshnessDecision = {
-      kind: 'ready',
-      branch: 'online_metadata_failed_cached',
-      syncState: 'stale',
-      snapshot: {
-        binding: {
-          driveId: 'drive-123',
-          itemId: 'item-456',
-          name: 'conspectus.db',
-          parentPath: '/',
-        },
-        metadata: {
-          eTag: '"etag-1"',
-          lastSyncAtIso: '2026-03-11T09:45:00.000Z',
-        },
-        dbBytes: Uint8Array.from([1, 2, 3, 4]),
-      },
+      kind: 'error',
+      branch: 'offline_unsupported',
+      syncState: 'error',
+      snapshot: null,
       failure: {
-        code: 'metadata_fetch_failed',
-        message:
-          'Unable to refresh the selected OneDrive database metadata after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again.',
-        cause: {
-          code: 'network_error',
-          status: 503,
-        },
+        code: 'offline_unsupported',
+        message: 'Connection is required to load the database.',
+        cause: new Error('Connection is required to load the database.'),
       },
     };
 
     applyStartupFreshnessDecision(store, decision, toastStore);
 
-    expect(get(store)).toEqual({
-      state: 'stale',
-      message:
-        'Unable to refresh the selected OneDrive database metadata after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again. Nutze vorerst die zwischengespeicherte DB.',
-      branch: 'online_metadata_failed_cached',
-      progress: null,
+    expect(get(store)).toMatchObject({
+      state: 'error',
+      message: 'Connection is required to load the database.',
+      branch: 'offline_unsupported',
     });
     expect(toastStore.show).toHaveBeenCalledWith(
-      'Unable to refresh the selected OneDrive database metadata after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again. Nutze vorerst die zwischengespeicherte DB.',
-      'warning',
-      4200,
-    );
-  });
-
-  it('applies auth-expired fallback decisions with the cached-db warning message', () => {
-    const store = createSyncStateStore({
-      state: 'syncing',
-      message: 'Suche nach DB-Updates auf OneDrive...',
-    });
-    const toastStore = createToastStore();
-    const decision: StartupFreshnessDecision = {
-      kind: 'ready',
-      branch: 'online_auth_expired_cached',
-      syncState: 'stale',
-      snapshot: {
-        binding: {
-          driveId: 'drive-123',
-          itemId: 'item-456',
-          name: 'conspectus.db',
-          parentPath: '/',
-        },
-        metadata: {
-          eTag: '"etag-1"',
-          lastSyncAtIso: '2026-03-11T09:45:00.000Z',
-        },
-        dbBytes: Uint8Array.from([1, 2, 3, 4]),
-      },
-      failure: {
-        code: 'auth_expired',
-        message: 'Your session has expired. Please sign in again to sync with OneDrive.',
-        cause: {
-          code: 'unauthorized',
-          status: 401,
-        },
-      },
-    };
-
-    applyStartupFreshnessDecision(store, decision, toastStore);
-
-    expect(get(store)).toEqual({
-      state: 'stale',
-      message:
-        'Your session has expired. Please sign in again to sync with OneDrive. Nutze vorerst die zwischengespeicherte DB.',
-      branch: 'online_auth_expired_cached',
-      progress: null,
-    });
-    expect(toastStore.show).toHaveBeenCalledWith(
-      'Your session has expired. Please sign in again to sync with OneDrive. Nutze vorerst die zwischengespeicherte DB.',
-      'warning',
-      4200,
+      'Connection is required to load the database.',
+      'error',
+      5000,
     );
   });
 
   it('applies auth-expired terminal decisions as actionable errors', () => {
-    const store = createSyncStateStore({
-      state: 'syncing',
-      message: 'Suche nach DB-Updates auf OneDrive...',
-    });
+    const store = createSyncStateStore();
     const toastStore = createToastStore();
     const decision: StartupFreshnessDecision = {
       kind: 'error',
@@ -289,6 +194,8 @@ describe('startupSyncStateController', () => {
       },
     };
 
+    beginStartupSync(store, toastStore);
+    toastStore.show.mockClear();
     applyStartupFreshnessDecision(store, decision, toastStore);
 
     expect(get(store)).toEqual({
@@ -302,13 +209,14 @@ describe('startupSyncStateController', () => {
       'error',
       5000,
     );
+    expect(toastStore.remove).toHaveBeenCalledWith('toast-id');
   });
 
   it('resets to idle when the startup decision is skipped', () => {
     const store = createSyncStateStore({
-      state: 'offline',
-      message: 'Offline-Modus nutzt die zuletzt zwischengespeicherte DB.',
-      branch: 'offline_cached',
+      state: 'error',
+      message: 'Connection is required to load the database.',
+      branch: 'offline_unsupported',
     });
     const toastStore = createToastStore();
     const decision: StartupFreshnessDecision = {
@@ -331,12 +239,11 @@ describe('startupSyncStateController', () => {
   });
 
   it('applies unexpected startup errors and surfaces an error toast', () => {
-    const store = createSyncStateStore({
-      state: 'syncing',
-      message: 'Suche nach DB-Updates auf OneDrive...',
-    });
+    const store = createSyncStateStore();
     const toastStore = createToastStore();
 
+    beginStartupSync(store, toastStore);
+    toastStore.show.mockClear();
     applyUnexpectedStartupSyncError(
       store,
       'Start-Synchronisation unerwartet fehlgeschlagen. Bitte prüfe die Browser-Konsole und versuche es erneut.',
@@ -355,15 +262,15 @@ describe('startupSyncStateController', () => {
       'error',
       5000,
     );
+    expect(toastStore.remove).toHaveBeenCalledWith('toast-id');
   });
 
   it('maps deterministic db runtime open errors into startup sync error state', () => {
-    const store = createSyncStateStore({
-      state: 'syncing',
-      message: 'Suche nach DB-Updates auf OneDrive...',
-    });
+    const store = createSyncStateStore();
     const toastStore = createToastStore();
 
+    beginStartupSync(store, toastStore);
+    toastStore.show.mockClear();
     applyStartupDbRuntimeError(store, new DbRuntimeError('db_open_failed'), toastStore);
 
     expect(get(store)).toEqual({
@@ -378,6 +285,7 @@ describe('startupSyncStateController', () => {
       'error',
       5000,
     );
+    expect(toastStore.remove).toHaveBeenCalledWith('toast-id');
   });
 
   it('falls back to a deterministic generic message for unknown db runtime failures', () => {

--- a/src/features/app-shell/startupSyncStateController.ts
+++ b/src/features/app-shell/startupSyncStateController.ts
@@ -8,6 +8,7 @@ import { _ } from 'svelte-i18n';
 
 interface ToastStoreLike {
   show(message: string, type?: ToastType, durationMs?: number): string;
+  remove(id: string): void;
 }
 
 const STARTUP_SYNCING_MESSAGE = 'sync.startup.checking';
@@ -23,10 +24,12 @@ const STARTUP_DB_RUNTIME_FAILURE_MESSAGES: Record<DbRuntimeErrorCode, string> = 
   db_export_failed: 'sync.dbRuntimeError.exportFailed',
 };
 
-const buildCachedFallbackMessage = (failure: StartupFreshnessDecision['failure']): string =>
-  failure === null
-    ? get(_)('sync.startup.cachedFallback')
-    : get(_)('sync.startup.cachedFallbackPrefix', { values: { message: failure.message } });
+interface ActiveStartupToast {
+  readonly id: string;
+  readonly store: ToastStoreLike;
+}
+
+const activeStartupToasts = new WeakMap<SyncStateStore, ActiveStartupToast>();
 
 const buildStartupSyncMessage = (decision: StartupFreshnessDecision): string | null => {
   switch (decision.branch) {
@@ -36,14 +39,8 @@ const buildStartupSyncMessage = (decision: StartupFreshnessDecision): string | n
       return get(_)('sync.startup.onlineUnchanged');
     case 'online_changed':
       return get(_)('sync.startup.onlineChanged');
-    case 'offline_cached':
-      return get(_)('sync.startup.offlineCached');
-    case 'online_auth_expired_cached':
-    case 'online_metadata_failed_cached':
-    case 'online_download_failed_cached':
-      return buildCachedFallbackMessage(decision.failure);
     case 'online_auth_expired':
-    case 'offline_missing_cache':
+    case 'offline_unsupported':
     case 'online_metadata_failed':
     case 'online_download_failed':
       return decision.failure.message;
@@ -66,16 +63,8 @@ const showDecisionToast = (
     case 'online_changed':
       toastStore.show(message, 'success', 3200);
       return;
-    case 'offline_cached':
-      toastStore.show(message, 'info', 3200);
-      return;
-    case 'online_auth_expired_cached':
-    case 'online_metadata_failed_cached':
-    case 'online_download_failed_cached':
-      toastStore.show(message, 'warning', 4200);
-      return;
     case 'online_auth_expired':
-    case 'offline_missing_cache':
+    case 'offline_unsupported':
     case 'online_metadata_failed':
     case 'online_download_failed':
       toastStore.show(message, 'error', 5000);
@@ -89,8 +78,20 @@ export const beginStartupSync = (
   syncStateStore: SyncStateStore,
   toastStore: ToastStoreLike = appToastStore,
 ): void => {
+  clearStartupSyncToast(syncStateStore);
   syncStateStore.setSyncing(get(_)(STARTUP_SYNCING_MESSAGE));
-  toastStore.show(get(_)(STARTUP_SYNCING_TOAST_MESSAGE), 'info', 2800);
+  const id = toastStore.show(get(_)(STARTUP_SYNCING_TOAST_MESSAGE), 'info', 0);
+  activeStartupToasts.set(syncStateStore, { id, store: toastStore });
+};
+
+export const clearStartupSyncToast = (syncStateStore: SyncStateStore): void => {
+  const activeToast = activeStartupToasts.get(syncStateStore);
+  if (activeToast === undefined) {
+    return;
+  }
+
+  activeStartupToasts.delete(syncStateStore);
+  activeToast.store.remove(activeToast.id);
 };
 
 export const updateStartupSyncProgress = (
@@ -106,6 +107,7 @@ export const applyStartupFreshnessDecision = (
   decision: StartupFreshnessDecision,
   toastStore: ToastStoreLike = appToastStore,
 ): void => {
+  clearStartupSyncToast(syncStateStore);
   const message = buildStartupSyncMessage(decision);
 
   switch (decision.syncState) {
@@ -114,16 +116,6 @@ export const applyStartupFreshnessDecision = (
       return;
     case 'synced':
       syncStateStore.setSynced(message ?? get(_)('sync.startup.completed'), {
-        branch: decision.branch,
-      });
-      break;
-    case 'stale':
-      syncStateStore.setStale(message ?? get(_)('sync.startup.stale'), {
-        branch: decision.branch,
-      });
-      break;
-    case 'offline':
-      syncStateStore.setOffline(message ?? get(_)('sync.startup.offlineActive'), {
         branch: decision.branch,
       });
       break;
@@ -142,6 +134,7 @@ export const applyUnexpectedStartupSyncError = (
   message: string,
   toastStore: ToastStoreLike = appToastStore,
 ): void => {
+  clearStartupSyncToast(syncStateStore);
   syncStateStore.setError(message);
   toastStore.show(message, 'error', 5000);
 };
@@ -151,6 +144,7 @@ export const applyStartupDbRuntimeError = (
   error: unknown,
   toastStore: ToastStoreLike = appToastStore,
 ): void => {
+  clearStartupSyncToast(syncStateStore);
   const message = get(_)(
     isDbRuntimeError(error)
       ? STARTUP_DB_RUNTIME_FAILURE_MESSAGES[error.code]
@@ -164,6 +158,7 @@ export const applyStartupDbRuntimeError = (
 
 export const startupSyncStateController = {
   beginStartupSync,
+  clearStartupSyncToast,
   updateStartupSyncProgress,
   applyStartupFreshnessDecision,
   applyStartupDbRuntimeError,

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -199,12 +199,7 @@
       "toastSyncing": "Synchronisiere mit OneDrive...",
       "onlineUnchanged": "Zwischengespeicherte DB ist aktuell",
       "onlineChanged": "Neueste DB von OneDrive heruntergeladen.",
-      "offlineCached": "Offline-Modus nutzt die zuletzt zwischengespeicherte DB.",
-      "cachedFallback": "Nutze die letzte zwischengespeicherte DB, da die Aktualisierung fehlgeschlagen ist.",
-      "cachedFallbackPrefix": "{message} Nutze vorerst die zwischengespeicherte DB.",
       "completed": "DB-Synchronisation abgeschlossen.",
-      "stale": "Zwischengespeicherte DB ist veraltet.",
-      "offlineActive": "Offline-Modus ist aktiv.",
       "failed": "Start-Synchronisation fehlgeschlagen.",
       "failedUnexpected": "Start-Synchronisation unerwartet fehlgeschlagen. Bitte prüfe die Browser-Konsole und versuche es erneut."
     },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -199,12 +199,7 @@
       "toastSyncing": "Syncing with OneDrive in the background...",
       "onlineUnchanged": "Cached DB is current with OneDrive.",
       "onlineChanged": "Downloaded the latest DB from OneDrive.",
-      "offlineCached": "Offline mode using the last cached DB.",
-      "cachedFallback": "Using the last cached DB because refreshing from OneDrive failed.",
-      "cachedFallbackPrefix": "{message} Using the last cached DB for now.",
       "completed": "DB sync completed.",
-      "stale": "Cached DB is stale.",
-      "offlineActive": "Offline mode is active.",
       "failed": "Startup sync failed.",
       "failedUnexpected": "Startup sync failed unexpectedly. Check the browser console and retry."
     },

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -1632,7 +1632,7 @@ test('shows syncing state and toast feedback while the startup freshness check i
     startAuthenticated: true,
   });
   await installMockGraphClient(page, {
-    metadataDelayMs: 1_500,
+    metadataDelayMs: 3_500,
     metadataETag: '"etag-1"',
   });
   await installMockCacheStore(page, {
@@ -1649,8 +1649,16 @@ test('shows syncing state and toast feedback while the startup freshness check i
   await page.goto(appPath('#/accounts'));
 
   await expect(page.getByText('Syncing with OneDrive in the background...')).toBeVisible();
+  await expect(page.getByTestId('startup-sync-progress')).toBeVisible();
+  await expect(page.getByTestId('progress-bar')).not.toHaveAttribute('value', /.+/u);
+
+  await page.waitForTimeout(3_000);
+  await expect(page.getByText('Syncing with OneDrive in the background...')).toBeVisible();
+  await expect(page.getByTestId('startup-sync-progress')).toBeVisible();
 
   await expect(page.getByText('Cached DB is current with OneDrive.')).toBeVisible();
+  await expect(page.getByText('Syncing with OneDrive in the background...')).toHaveCount(0);
+  await expect(page.getByTestId('startup-sync-progress')).toHaveCount(0);
 });
 
 test('shows download progress feedback during slow startup sync', async ({ page }) => {
@@ -1727,7 +1735,7 @@ test('retries transient startup metadata failures before settling on the cached 
   expect(await getGraphDownloadCallCount(page)).toBe(0);
 });
 
-test('keeps the cached DB as stale when transient startup metadata failures exhaust retries', async ({
+test('rejects cached account data when transient startup metadata failures exhaust retries', async ({
   page,
 }) => {
   await installMockAuthClient(page, {
@@ -1748,18 +1756,25 @@ test('keeps the cached DB as stale when transient startup metadata failures exha
       dbBytes: createSqliteBytes([3, 3, 3, 3]),
     },
   });
+  await installMockDbRuntime(page, {
+    accountRows: [
+      { accountId: 99, name: 'Stale cached account', amountCents: 999_999, accountTypeId: 3 },
+    ],
+  });
   await installPersistedBinding(page);
   await installMockStartupNetworkState(page, true);
 
   await page.goto(appPath('#/accounts'));
 
-  await expect(
-    page.getByText(
-      'Unable to refresh the selected OneDrive database metadata after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again. Using the last cached DB for now.',
-    ),
-  ).toBeVisible();
+  await expect(page.getByTestId('accounts-route-status')).toHaveAttribute('role', 'alert');
+  await expect(page.getByTestId('accounts-route-status')).toContainText(
+    'Unable to refresh the selected OneDrive database metadata after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again.',
+  );
+  await expect(page.getByTestId('accounts-route-cards')).toHaveCount(0);
+  await expect(page.getByText('Stale cached account')).toHaveCount(0);
   expect(await getGraphMetadataCallCount(page)).toBe(3);
   expect(await getGraphDownloadCallCount(page)).toBe(0);
+  expect(await getDbRuntimeCloseCallCount(page)).toBeGreaterThan(0);
 });
 
 test('shows a startup sync error when transient metadata failures exhaust retries without a cached DB', async ({
@@ -1781,11 +1796,9 @@ test('shows a startup sync error when transient metadata failures exhaust retrie
 
   await page.goto(appPath('#/accounts'));
 
-  await expect(
-    page.getByText(
-      'Unable to refresh the selected OneDrive database metadata after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again.',
-    ),
-  ).toBeVisible();
+  await expect(page.getByTestId('accounts-route-status')).toContainText(
+    'Unable to refresh the selected OneDrive database metadata after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again.',
+  );
   expect(await getGraphMetadataCallCount(page)).toBe(3);
   expect(await getGraphDownloadCallCount(page)).toBe(0);
 });
@@ -1805,7 +1818,7 @@ test('fails fast on non-retryable startup metadata errors and surfaces the clear
 
   await page.goto(appPath('#/accounts'));
 
-  await expect(page.getByText('Mock access denied.')).toBeVisible();
+  await expect(page.getByTestId('accounts-route-status')).toContainText('Mock access denied.');
   expect(await getGraphMetadataCallCount(page)).toBe(1);
   expect(await getGraphDownloadCallCount(page)).toBe(0);
 });
@@ -1831,9 +1844,9 @@ test('surfaces a sign-in-again recovery action when startup metadata refresh fai
 
   await page.goto(appPath('#/accounts'));
 
-  await expect(
-    page.getByText('Your session has expired. Please sign in again to sync with OneDrive.'),
-  ).toBeVisible();
+  await expect(page.getByTestId('accounts-route-status')).toContainText(
+    'Your session has expired. Please sign in again to sync with OneDrive.',
+  );
   expect(await getGraphMetadataCallCount(page)).toBe(1);
   expect(await getGraphDownloadCallCount(page)).toBe(0);
 
@@ -1900,7 +1913,7 @@ test('retries transient startup download failures before downloading the latest 
   expect(await getGraphDownloadCallCount(page)).toBe(3);
 });
 
-test('keeps the cached DB as stale when transient startup download failures exhaust retries', async ({
+test('rejects cached transfer data when transient startup download failures exhaust retries', async ({
   page,
 }) => {
   await installMockAuthClient(page, {
@@ -1922,18 +1935,41 @@ test('keeps the cached DB as stale when transient startup download failures exha
       dbBytes: createSqliteBytes([1, 1, 1, 1]),
     },
   });
+  await installMockDbRuntime(page, {
+    accountRows: [
+      { accountId: 3, name: 'Checking', amountCents: 1_000, accountTypeId: 3 },
+      { accountId: 4, name: 'Savings', amountCents: 2_000, accountTypeId: 3 },
+    ],
+    transferRows: [
+      {
+        transferId: 99,
+        bookingDateEpochDay: Math.floor(Date.now() / 86_400_000),
+        name: 'Stale cached transfer',
+        amountCents: 500,
+        fromAccountId: 3,
+        toAccountId: 4,
+        categoryIds: [],
+        buyplace: null,
+      },
+    ],
+  });
   await installPersistedBinding(page);
   await installMockStartupNetworkState(page, true);
 
-  await page.goto(appPath('#/accounts'));
+  await page.goto(appPath('#/transfers'));
 
-  await expect(
-    page.getByText(
-      'Unable to download the latest OneDrive database snapshot after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again. Using the last cached DB for now.',
-    ),
-  ).toBeVisible();
+  await expect(page.getByTestId('transfers-route-status')).toHaveAttribute('role', 'alert');
+  await expect(page.getByTestId('transfers-route-status')).toContainText(
+    'Unable to download the latest OneDrive database snapshot after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again.',
+  );
+  await expect(page.getByTestId('transfers-route-cards')).toHaveCount(0);
+  await expect(page.getByText('Stale cached transfer')).toHaveCount(0);
   expect(await getGraphMetadataCallCount(page)).toBe(1);
   expect(await getGraphDownloadCallCount(page)).toBe(3);
+
+  await page.getByRole('link', { name: 'Settings' }).click();
+  await expect(page.getByTestId('route-settings')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Change DB file' })).toBeVisible();
 });
 
 test('shows a startup sync error when transient download failures exhaust retries without a cached DB', async ({
@@ -1956,16 +1992,14 @@ test('shows a startup sync error when transient download failures exhaust retrie
 
   await page.goto(appPath('#/accounts'));
 
-  await expect(
-    page.getByText(
-      'Unable to download the latest OneDrive database snapshot after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again.',
-    ),
-  ).toBeVisible();
+  await expect(page.getByTestId('accounts-route-status')).toContainText(
+    'Unable to download the latest OneDrive database snapshot after 3 attempts because OneDrive or the network remained unavailable. Check your connection and try again.',
+  );
   expect(await getGraphMetadataCallCount(page)).toBe(1);
   expect(await getGraphDownloadCallCount(page)).toBe(3);
 });
 
-test('keeps the cached DB available and offers sign-in again when download fails because the session expired', async ({
+test('rejects the cached DB and offers sign-in again when download auth expires', async ({
   page,
 }) => {
   await installMockAuthClient(page, {
@@ -1994,11 +2028,11 @@ test('keeps the cached DB available and offers sign-in again when download fails
 
   await page.goto(appPath('#/accounts'));
 
-  await expect(
-    page.getByText(
-      'Your session has expired. Please sign in again to sync with OneDrive. Using the last cached DB for now.',
-    ),
-  ).toBeVisible();
+  await expect(page.getByTestId('accounts-route-status')).toContainText(
+    'Your session has expired. Please sign in again to sync with OneDrive.',
+  );
+  await expect(page.getByTestId('accounts-route-status')).toHaveAttribute('role', 'alert');
+  await expect(page.getByTestId('accounts-route-cards')).toHaveCount(0);
   expect(await getGraphMetadataCallCount(page)).toBe(1);
   expect(await getGraphDownloadCallCount(page)).toBe(1);
 
@@ -2006,7 +2040,7 @@ test('keeps the cached DB available and offers sign-in again when download fails
   await expect(page.getByTestId('route-settings')).toBeVisible();
 });
 
-test('uses the cached DB on startup when offline', async ({ page }) => {
+test('rejects cached DB data when startup is offline', async ({ page }) => {
   await installMockAuthClient(page, {
     startAuthenticated: true,
   });
@@ -2024,8 +2058,12 @@ test('uses the cached DB on startup when offline', async ({ page }) => {
 
   await page.goto(appPath('#/accounts'));
 
-  await expect(page.getByText('Offline mode using the last cached DB.')).toBeVisible();
-  expect(await getCacheReadSnapshotCallCount(page)).toBe(1);
+  await expect(page.getByTestId('accounts-route-status')).toContainText(
+    'Connection is required to load the database.',
+  );
+  await expect(page.getByTestId('accounts-route-status')).toHaveAttribute('role', 'alert');
+  await expect(page.getByTestId('accounts-route-cards')).toHaveCount(0);
+  expect(await getCacheReadSnapshotCallCount(page)).toBe(0);
   expect(await getGraphMetadataCallCount(page)).toBe(0);
   expect(await getGraphDownloadCallCount(page)).toBe(0);
 });
@@ -2041,10 +2079,11 @@ test('shows a startup sync error when offline without a cached DB', async ({ pag
 
   await page.goto(appPath('#/accounts'));
 
-  await expect(
-    page.getByText('No cached OneDrive database is available while offline.'),
-  ).toBeVisible();
-  expect(await getCacheReadSnapshotCallCount(page)).toBe(1);
+  await expect(page.getByTestId('accounts-route-status')).toContainText(
+    'Connection is required to load the database.',
+  );
+  await expect(page.getByTestId('accounts-route-status')).toBeVisible();
+  expect(await getCacheReadSnapshotCallCount(page)).toBe(0);
   expect(await getGraphMetadataCallCount(page)).toBe(0);
   expect(await getGraphDownloadCallCount(page)).toBe(0);
 });


### PR DESCRIPTION
# Pull Request

## Linked Issue (Required)

- Closes #211
- Milestone / backlog item: M7-08

## Context

- Problem: Startup could open stale cached database bytes after offline, authentication, metadata, or download failures, while transient sync feedback disappeared before slow operations completed.
- Goal: Fail closed unless OneDrive is reachable and the cached eTag is verified, keep sync feedback visible for the full operation, and preserve Settings as the recovery route.

## Changes

- Removed offline and failed-sync cached database fallback branches while retaining online eTag-verified cache reuse.
- Added persistent startup-toast ownership/teardown and indeterminate metadata-check progress.
- Propagated terminal sync errors to Accounts and Transfers so stale rows and misleading empty states are not shown.
- Updated unit, lifecycle, route, and Playwright regression coverage.
- Bumped the app version to `0.7.08` and aligned the M7-08 backlog/architecture documentation.

## Test Plan

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (418 app tests + 63 script tests)
- [x] `npm run build`
- [x] `npm run test:e2e` (114 tests across Chromium and Pixel 5)
- Notes: The complete local gate was rerun after reviewer feedback and is green.

## Screenshots

- [ ] UI change: screenshots attached
- [ ] No UI change
- Notes: Transient sync/error states are verified in the automated browser suite; no static screenshots are attached.

## Risk Notes

- User impact: Offline or failed startup sync now intentionally blocks database viewing and directs users to reconnect or recover through Settings.
- Rollback plan: Revert this single M7-08 commit to restore the previous startup decision branches and UI behavior.

## QS Checklist

- [x] Linked issue ID is included in this PR.
- [x] Lint, typecheck, tests, and build were run and pass.
- [ ] Screenshots are included for UI changes.
- [x] Risk and rollback notes are documented.
- [x] No secrets, tokens, or credentials were added to the repository.
- [x] No breaking path/base URL changes were introduced (preserves `/conspectus/webapp/` deployment behavior).

## Merge And Cleanup (PR Path)

- [ ] Required GitHub checks are green.
- [x] PR will be merged into `main` with Rebase and merge.
- [x] PR will be merged into `main` once checks/review requirements are satisfied.
- [x] Head branch will be deleted after merge.
- [x] The M7-08 backlog marker is included in this issue branch; GitHub issue #211 will be closed only after merge.
