### PR TITLE
feat: [M7-02] implement force refresh action

### DIFF
--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -551,7 +551,7 @@ An issue is only considered done when:
 - Depends on: `M3-08, M4-05`
 - GitHub: [#75](https://github.com/Jon2050/Conspectus-Mobile/issues/75)
 
-### :green_circle: M7-02 Implement force refresh action
+### :white_check_mark: M7-02 Implement force refresh action
 
 - Label: `feature`
 - Milestone: `M7 - Settings + Recovery`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.7.08",
+  "version": "0.7.02",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.7.08",
+      "version": "0.7.02",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.7.08",
+  "version": "0.7.02",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -77,6 +77,7 @@
   let currentSyncId = 0;
   let footerVisibilityTrackingIsActive = false;
   let lastRenderedRoute: AppRouteKey | null = null;
+  let forceRefreshIsRunning = false;
   let stopFooterVisibilityTracking = (): void => {};
   const navIconBaseUrl = import.meta.env.BASE_URL;
   const unsubscribe = routeStore.subscribe((route) => {
@@ -131,6 +132,7 @@
   const performSync = async (
     binding: DriveItemBinding | null,
     isInitialSync = false,
+    mode: 'reuse_if_current' | 'force_download' = 'reuse_if_current',
   ): Promise<void> => {
     const syncId = ++currentSyncId;
     dataRoutesAwaitInitialSync = isInitialSync;
@@ -165,6 +167,7 @@
             updateStartupSyncProgress(syncStateStore, loadedBytes, totalBytes);
           }
         },
+        mode,
       );
 
       if (!appShellIsMounted || syncId !== currentSyncId) {
@@ -198,6 +201,19 @@
         syncStateStore,
         'Startup sync failed unexpectedly. Check the browser console and retry.',
       );
+    }
+  };
+
+  const requestForceRefresh = async (): Promise<void> => {
+    if (forceRefreshIsRunning || get(syncStateStore).state === 'syncing') {
+      return;
+    }
+
+    forceRefreshIsRunning = true;
+    try {
+      await performSync(get(appSelectedDriveItemBindingStore), false, 'force_download');
+    } finally {
+      forceRefreshIsRunning = false;
     }
   };
 
@@ -512,7 +528,7 @@
           canOpenPanel={addTransferDatabaseIsReady}
         />
       {:else}
-        <SettingsRoute {syncStateStore} />
+        <SettingsRoute {syncStateStore} onForceRefresh={requestForceRefresh} />
       {/if}
     </div>
   </main>

--- a/src/features/app-shell/routes/SettingsRoute.svelte
+++ b/src/features/app-shell/routes/SettingsRoute.svelte
@@ -37,6 +37,7 @@
   export let cacheStore: SettingsCacheStore = resolveSettingsCacheStore();
   export let graphClient: GraphClient = resolveSettingsGraphClient();
   export let syncStateStore: SyncStateStore = appSyncStateStore;
+  export let onForceRefresh: (() => Promise<void>) | null = null;
 
   let state: SettingsAuthState = {
     session: {
@@ -68,6 +69,9 @@
   let syncMetadataRequestId = 0;
   let loadedSyncMetadataBindingKey: string | null = null;
   let buildInfo: BuildInfo = getFallbackBuildInfo();
+  let forceRefreshIsPending = false;
+  let forceRefreshStatusIsVisible = false;
+  let syncSnapshot = get(syncStateStore);
 
   const buildStatusMessage = (nextState: SettingsAuthState): string => {
     if (nextState.operation !== 'idle') {
@@ -195,6 +199,20 @@
     void localDataController.confirmReset();
   };
 
+  const handleForceRefreshClick = async (): Promise<void> => {
+    if (onForceRefresh === null || forceRefreshIsPending || syncSnapshot.state === 'syncing') {
+      return;
+    }
+
+    forceRefreshIsPending = true;
+    forceRefreshStatusIsVisible = true;
+    try {
+      await onForceRefresh();
+    } finally {
+      forceRefreshIsPending = false;
+    }
+  };
+
   const handleLocalResetDialogCancel = (event: Event): void => {
     event.preventDefault();
     localDataController.cancelReset();
@@ -223,11 +241,13 @@
   const loadLastSyncMetadata = async (
     isAuthenticated: boolean,
     binding: SettingsFileBindingState['selectedBinding'],
+    resetForceRefreshStatus = true,
   ): Promise<void> => {
     if (!isAuthenticated || binding === null) {
       loadedSyncMetadataBindingKey = null;
       syncMetadataRequestId += 1;
       lastSyncAtIso = null;
+      forceRefreshStatusIsVisible = false;
       return;
     }
 
@@ -237,6 +257,9 @@
     }
 
     loadedSyncMetadataBindingKey = bindingKey;
+    if (resetForceRefreshStatus) {
+      forceRefreshStatusIsVisible = false;
+    }
     const requestId = ++syncMetadataRequestId;
     try {
       const snapshot = await cacheStore.readSnapshot(binding);
@@ -253,12 +276,13 @@
   $: void loadLastSyncMetadata(state.session.isAuthenticated, bindingState.selectedBinding);
 
   const unsubscribeSyncState = syncStateStore.subscribe((syncState) => {
+    syncSnapshot = syncState;
     if (syncState.state !== 'synced') {
       return;
     }
 
     loadedSyncMetadataBindingKey = null;
-    void loadLastSyncMetadata(state.session.isAuthenticated, bindingState.selectedBinding);
+    void loadLastSyncMetadata(state.session.isAuthenticated, bindingState.selectedBinding, false);
   });
 
   $: if (localDataResetDialogElement !== null) {
@@ -342,6 +366,23 @@
           ? $_('settings.db.actions.select')
           : $_('settings.db.actions.change')}
       </button>
+
+      {#if bindingState.selectedBinding !== null && onForceRefresh !== null}
+        <button
+          class="app-button app-button--secondary"
+          type="button"
+          data-testid="force-refresh-button"
+          aria-busy={forceRefreshIsPending}
+          on:click={() => void handleForceRefreshClick()}
+          disabled={authOperationIsPending ||
+            bindingState.operation !== 'idle' ||
+            localDataResetState.operation !== 'idle' ||
+            forceRefreshIsPending ||
+            syncSnapshot.state === 'syncing'}
+        >
+          {forceRefreshIsPending ? $_('settings.sync.refreshing') : $_('settings.sync.refresh')}
+        </button>
+      {/if}
 
       {#if bindingState.browserIsOpen}
         {#if bindingState.canGoBack}
@@ -444,6 +485,17 @@
           </dd>
         </div>
       </dl>
+
+      {#if forceRefreshStatusIsVisible && syncSnapshot.state !== 'idle' && syncSnapshot.message !== null}
+        <p
+          class="settings-screen__sync-status"
+          data-testid="force-refresh-status"
+          role={syncSnapshot.state === 'error' ? 'alert' : 'status'}
+          aria-live="polite"
+        >
+          {syncSnapshot.message}
+        </p>
+      {/if}
     {/if}
 
     {#if bindingState.browserIsOpen}
@@ -583,6 +635,14 @@
   .settings-screen__binding-status {
     margin: 0;
     color: var(--text-secondary);
+  }
+
+  .settings-screen__sync-status {
+    margin: 0;
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--accent) 10%, var(--surface-strong));
+    color: var(--text-primary);
   }
 
   .settings-screen__binding-error {

--- a/src/features/app-shell/routes/SettingsRoute.test.ts
+++ b/src/features/app-shell/routes/SettingsRoute.test.ts
@@ -10,6 +10,9 @@ describe('SettingsRoute styling', () => {
     expect(settingsRouteSource).toContain('data-testid="settings-build-information"');
     expect(settingsRouteSource).toContain('data-testid="settings-build-version"');
     expect(settingsRouteSource).toContain('data-testid="settings-build-time"');
+    expect(settingsRouteSource).toContain('data-testid="force-refresh-button"');
+    expect(settingsRouteSource).toContain('data-testid="force-refresh-status"');
+    expect(settingsRouteSource).toContain('onForceRefresh');
     expect(settingsRouteSource.indexOf('settings-build-information')).toBeGreaterThan(
       settingsRouteSource.indexOf('destructive-settings-actions'),
     );

--- a/src/features/app-shell/startupFreshnessService.test.ts
+++ b/src/features/app-shell/startupFreshnessService.test.ts
@@ -158,6 +158,70 @@ describe('startup freshness service', () => {
     expect(snapshotService.downloadAndCacheSnapshot).not.toHaveBeenCalled();
   });
 
+  it('forces a download when requested even if the OneDrive eTag is unchanged', async () => {
+    const cachedSnapshot = createSnapshot({
+      metadata: {
+        eTag: '"etag-unchanged"',
+        lastSyncAtIso: '2026-03-11T09:45:00.000Z',
+      },
+    });
+    const metadata = createMetadata({ eTag: '"etag-unchanged"' });
+    const downloadedSnapshot = createSnapshot({
+      metadata: {
+        eTag: '"etag-unchanged"',
+        lastSyncAtIso: '2026-03-11T10:45:00.000Z',
+      },
+      dbBytes: Uint8Array.from([9, 8, 7, 6]),
+    });
+    const graphClient = createGraphClient(metadata);
+    const cacheStore = createCacheStore(cachedSnapshot);
+    const snapshotService = createSnapshotService(downloadedSnapshot);
+    const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService);
+
+    await expect(
+      service.resolve(DRIVE_ITEM_BINDING, true, undefined, 'force_download'),
+    ).resolves.toEqual({
+      kind: 'ready',
+      branch: 'online_changed',
+      syncState: 'synced',
+      snapshot: downloadedSnapshot,
+      failure: null,
+    });
+
+    expect(graphClient.getFileMetadata).toHaveBeenCalledTimes(1);
+    expect(snapshotService.downloadAndCacheSnapshot).toHaveBeenCalledWith(
+      DRIVE_ITEM_BINDING,
+      metadata,
+      undefined,
+    );
+  });
+
+  it('reports a forced-download failure without returning the cached snapshot as success', async () => {
+    const cachedSnapshot = createSnapshot({
+      metadata: {
+        eTag: '"etag-unchanged"',
+        lastSyncAtIso: '2026-03-11T09:45:00.000Z',
+      },
+    });
+    const graphClient = createGraphClient(createMetadata({ eTag: '"etag-unchanged"' }));
+    const cacheStore = createCacheStore(cachedSnapshot);
+    const snapshotService = createSnapshotService(new Error('Forced refresh download failed.'));
+    const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService);
+
+    await expect(
+      service.resolve(DRIVE_ITEM_BINDING, true, undefined, 'force_download'),
+    ).resolves.toMatchObject({
+      kind: 'error',
+      branch: 'online_download_failed',
+      syncState: 'error',
+      snapshot: null,
+      failure: {
+        code: 'snapshot_download_failed',
+        message: 'Forced refresh download failed.',
+      },
+    });
+  });
+
   it('downloads and returns a fresh snapshot when the OneDrive eTag changed', async () => {
     const cachedSnapshot = createSnapshot({
       metadata: {

--- a/src/features/app-shell/startupFreshnessService.ts
+++ b/src/features/app-shell/startupFreshnessService.ts
@@ -20,6 +20,8 @@ export type StartupFreshnessFailureCode =
   | 'snapshot_download_failed'
   | 'auth_expired';
 
+export type StartupFreshnessMode = 'reuse_if_current' | 'force_download';
+
 export interface StartupFreshnessFailure {
   readonly code: StartupFreshnessFailureCode;
   readonly message: string;
@@ -64,10 +66,12 @@ export type StartupFreshnessDecision =
   | StartupFreshnessErrorDecision;
 
 export interface StartupFreshnessService {
+  /** Resolves online freshness; force_download bypasses unchanged-eTag cache reuse. */
   resolve(
     binding: DriveItemBinding | null,
     isOnline: boolean,
     onProgress?: (loadedBytes: number, totalBytes: number | null) => void,
+    mode?: StartupFreshnessMode,
   ): Promise<StartupFreshnessDecision>;
 }
 
@@ -229,6 +233,7 @@ export const createStartupFreshnessService = (
     binding: DriveItemBinding | null,
     isOnline: boolean,
     onProgress?: (loadedBytes: number, totalBytes: number | null) => void,
+    mode: StartupFreshnessMode = 'reuse_if_current',
   ): Promise<StartupFreshnessDecision> {
     if (binding === null) {
       return {
@@ -264,7 +269,11 @@ export const createStartupFreshnessService = (
         retryOptions,
       );
 
-      if (cachedSnapshot !== null && cachedSnapshot.metadata.eTag === metadata.eTag) {
+      if (
+        mode === 'reuse_if_current' &&
+        cachedSnapshot !== null &&
+        cachedSnapshot.metadata.eTag === metadata.eTag
+      ) {
         return {
           kind: 'ready',
           branch: 'online_unchanged',

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -166,7 +166,9 @@
     "sync": {
       "lastSync": "Letzte Synchronisierung",
       "never": "Noch nicht synchronisiert",
-      "unknown": "Unbekannt"
+      "unknown": "Unbekannt",
+      "refresh": "Von OneDrive aktualisieren",
+      "refreshing": "Aktualisierung von OneDrive läuft..."
     },
     "actions": {
       "standard": "Datenbankaktionen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -166,7 +166,9 @@
     "sync": {
       "lastSync": "Last sync",
       "never": "Not synced yet",
-      "unknown": "Unknown"
+      "unknown": "Unknown",
+      "refresh": "Refresh from OneDrive",
+      "refreshing": "Refreshing from OneDrive..."
     },
     "actions": {
       "standard": "Database actions",

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -1594,6 +1594,84 @@ test('reuses the cached DB on startup when the OneDrive eTag is unchanged', asyn
   expect(await getGraphDownloadCallCount(page)).toBe(0);
 });
 
+test('force refresh downloads an unchanged DB and reports progress plus the new sync timestamp', async ({
+  page,
+}) => {
+  await installMockAuthClient(page, {
+    startAuthenticated: true,
+  });
+  await installMockGraphClient(page, {
+    metadataETag: '"etag-1"',
+    downloadDelayMs: 1_200,
+  });
+  await installMockCacheStore(page, {
+    startupSnapshot: {
+      metadata: {
+        eTag: '"etag-1"',
+        lastSyncAtIso: '2026-03-11T09:45:00.000Z',
+      },
+      dbBytes: createSqliteBytes([7, 7, 7, 7]),
+    },
+  });
+  await installPersistedBinding(page);
+  await installMockStartupNetworkState(page, true);
+  await installMockDbRuntime(page, { forceAlwaysOpen: true });
+
+  await page.goto(appPath('#/settings'));
+
+  await expect(page.getByTestId('force-refresh-button')).toBeEnabled();
+  const initialLastSync = await page.getByTestId('settings-last-sync').textContent();
+  const metadataCallsBeforeRefresh = await getGraphMetadataCallCount(page);
+
+  await page.getByTestId('force-refresh-button').click();
+
+  await expect(page.getByTestId('force-refresh-button')).toBeDisabled();
+  await expect(page.getByTestId('startup-sync-progress')).toBeVisible();
+  await expect(page.getByTestId('force-refresh-status')).toContainText(
+    'Checking OneDrive for DB updates...',
+  );
+  await expect(page.getByTestId('force-refresh-status')).toContainText(
+    'Downloaded the latest DB from OneDrive.',
+  );
+  await expect(page.getByTestId('force-refresh-button')).toBeEnabled();
+
+  const refreshedLastSync = await page.getByTestId('settings-last-sync').textContent();
+  expect(refreshedLastSync).not.toBe(initialLastSync);
+  expect(await getGraphMetadataCallCount(page)).toBe(metadataCallsBeforeRefresh + 1);
+  expect(await getGraphDownloadCallCount(page)).toBe(1);
+});
+
+test('force refresh reports an offline failure and remains retryable', async ({ page }) => {
+  await installMockAuthClient(page, {
+    startAuthenticated: true,
+  });
+  await installMockGraphClient(page);
+  await installMockCacheStore(page, {
+    startupSnapshot: {
+      metadata: {
+        eTag: '"etag-1"',
+      },
+      dbBytes: createSqliteBytes([7, 7, 7, 7]),
+    },
+  });
+  await installPersistedBinding(page);
+  await installMockStartupNetworkState(page, false);
+
+  await page.goto(appPath('#/settings'));
+
+  const refreshButton = page.getByTestId('force-refresh-button');
+  await expect(refreshButton).toBeEnabled();
+  await refreshButton.click();
+
+  await expect(page.getByTestId('force-refresh-status')).toHaveAttribute('role', 'alert');
+  await expect(page.getByTestId('force-refresh-status')).toContainText(
+    'Connection is required to load the database.',
+  );
+  await expect(refreshButton).toBeEnabled();
+  expect(await getGraphMetadataCallCount(page)).toBe(0);
+  expect(await getGraphDownloadCallCount(page)).toBe(0);
+});
+
 test('preserves the selected transfer month while refreshing in the foreground', async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

Implements the M7-02 Settings force-refresh action by reusing the existing verified sync orchestration with an explicit forced-download mode.

Closes #76

## Acceptance criteria

- [x] Force refresh performs a fresh Graph metadata check and downloads/validates/caches the DB even when the eTag is unchanged.
- [x] Startup sync keeps the existing unchanged-eTag cache reuse behavior.
- [x] Settings shows localized progress, success/error status, disables duplicate submissions, and refreshes the displayed last-sync timestamp after a successful download.

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run test:e2e` (118 tests, Chromium and Pixel 5)

## Scope and assumption

The force action intentionally bypasses only unchanged-eTag reuse; metadata validation, snapshot integrity checks, cache replacement, and DB runtime reopening remain centralized in the existing sync flow. The package version follows the repository's issue-version convention and is set to `0.7.02`.
