### PR TITLE
feat: [M7-04] Add stale token recovery

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -742,6 +742,12 @@ M7-03 implementation clarification:
 - Concise English and German wording explains why desktop and mobile must not use the database concurrently and directs users to the personal OneDrive 30-day file version history recovery path.
 - The recovery card includes the restore steps and links to Microsoft's official instructions; no custom backup or version-history API is added to the app.
 
+M7-04 implementation clarification:
+
+- Existing Graph `unauthorized` normalization and the `online_auth_expired` sync branch drive one global stale-session recovery action without duplicating token-expiry detection in the UI.
+- Re-authentication uses MSAL `acquireTokenRedirect` with the existing OneDrive scope and active account, preserving the selected account/file ownership instead of opening the general account picker.
+- The current hash-route URL is passed as MSAL's `redirectStartPage`, so successful recovery returns to the screen that requested it. The recovery action exposes pending and failure feedback and blocks duplicate redirect attempts.
+
 M7-08 implementation clarification:
 
 - Startup database access now fails closed when offline or when authentication, OneDrive metadata, or snapshot download fails; cached bytes are reused only after a successful online eTag match.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -567,7 +567,7 @@ An issue is only considered done when:
 - Depends on: `M7-01`
 - GitHub: [#77](https://github.com/Jon2050/Conspectus-Mobile/issues/77)
 
-### :green_circle: M7-04 Implement stale token recovery flow
+### :white_check_mark: M7-04 Implement stale token recovery flow
 
 - Label: `feature`
 - Milestone: `M7 - Settings + Recovery`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.7.03",
+  "version": "0.7.04",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.7.03",
+      "version": "0.7.04",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.7.03",
+  "version": "0.7.04",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -15,7 +15,7 @@ Expected public interfaces (`src/auth/index.ts`):
 
 - `AuthAccount`: signed-in account identity surfaced to UI/state layers.
 - `AuthSession`: deterministic auth state snapshot (`isAuthenticated` + account).
-- `AuthClient`: bootstrap/login/logout/token API used by higher-level modules.
+- `AuthClient`: bootstrap/login/logout/token and active-account re-authentication API used by higher-level modules.
 - `createAuthClient`: factory that hides MSAL details behind the `AuthClient` interface.
 - `AuthErrorCode` and `AuthError`: normalized, provider-agnostic auth failure model.
 
@@ -23,5 +23,6 @@ M3 implementation target:
 
 - Keep MSAL-specific details behind `AuthClient`.
 - Use silent-first token acquisition (`acquireTokenSilent`) and return `interaction_required` when user re-auth is needed.
+- Recover expired Graph sessions with `acquireTokenRedirect`, pinned to the active account and the requesting app route.
 - Restore active account in deterministic order: redirect result account, current active account, then cached account fallback.
 - Return stable session and error shapes so feature code does not depend on MSAL internals.

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -18,6 +18,7 @@ const createMinimalMsalInstance = (): MsalInstance => {
     }),
     getAllAccounts: vi.fn(() => []),
     loginRedirect: vi.fn(async () => {}),
+    acquireTokenRedirect: vi.fn(async () => {}),
     logoutRedirect: vi.fn(async () => {}),
     acquireTokenSilent: vi.fn(async () => ({
       authority: 'https://login.microsoftonline.com/consumers',
@@ -54,6 +55,7 @@ describe('auth barrel contract', () => {
         initialize: expect.any(Function),
         getSession: expect.any(Function),
         signIn: expect.any(Function),
+        reauthenticate: expect.any(Function),
         signOut: expect.any(Function),
         getAccessToken: expect.any(Function),
       }),

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -20,6 +20,7 @@ export interface AuthClient {
   initialize(): Promise<void>;
   getSession(): AuthSession;
   signIn(): Promise<void>;
+  reauthenticate(redirectStartPage: string): Promise<void>;
   signOut(): Promise<void>;
   getAccessToken(scopes: readonly string[]): Promise<string>;
 }

--- a/src/auth/msalAuthClient.test.ts
+++ b/src/auth/msalAuthClient.test.ts
@@ -24,6 +24,7 @@ interface MockMsalOptions {
   readonly cachedAccounts?: AccountInfo[];
   readonly silentResult?: AuthenticationResult;
   readonly silentError?: unknown;
+  readonly redirectError?: unknown;
   readonly logoutError?: unknown;
 }
 
@@ -66,6 +67,11 @@ const createMockMsalInstance = (options: MockMsalOptions = {}) => {
   });
   const getAllAccounts = vi.fn(() => [...cachedAccounts]);
   const loginRedirect = vi.fn(async () => {});
+  const acquireTokenRedirect = vi.fn(async () => {
+    if (options.redirectError !== undefined) {
+      throw options.redirectError;
+    }
+  });
   const logoutRedirect = vi.fn(async () => {
     if (options.logoutError !== undefined) {
       throw options.logoutError;
@@ -92,6 +98,7 @@ const createMockMsalInstance = (options: MockMsalOptions = {}) => {
     setActiveAccount,
     getAllAccounts,
     loginRedirect,
+    acquireTokenRedirect,
     logoutRedirect,
     acquireTokenSilent,
   };
@@ -101,6 +108,7 @@ const createMockMsalInstance = (options: MockMsalOptions = {}) => {
     handleRedirectPromise,
     setActiveAccount,
     loginRedirect,
+    acquireTokenRedirect,
     logoutRedirect,
     acquireTokenSilent,
     getActiveAccountValue: (): AccountInfo | null => activeAccount,
@@ -310,6 +318,59 @@ describe('createAuthClient', () => {
     expect(mockMsal.loginRedirect).toHaveBeenCalledWith({
       scopes: [...AUTH_REQUEST_SCOPES],
       prompt: 'select_account',
+    });
+  });
+
+  it('re-authenticates the active account and returns to the requesting app screen', async () => {
+    const activeAccount = createAccount('active@example.com', 'active-home');
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: activeAccount,
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+    await client.reauthenticate('https://jon2050.de/conspectus/webapp/#/transfers');
+
+    expect(mockMsal.acquireTokenRedirect).toHaveBeenCalledWith({
+      account: activeAccount,
+      scopes: ['Files.ReadWrite'],
+      redirectStartPage: 'https://jon2050.de/conspectus/webapp/#/transfers',
+    });
+    expect(mockMsal.loginRedirect).not.toHaveBeenCalled();
+  });
+
+  it('requires the existing active account for safe re-authentication', async () => {
+    const mockMsal = createMockMsalInstance();
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+
+    await expect(
+      client.reauthenticate('https://conspectus.local/#/accounts'),
+    ).rejects.toMatchObject({
+      code: 'no_active_account',
+    });
+    expect(mockMsal.acquireTokenRedirect).not.toHaveBeenCalled();
+  });
+
+  it('normalizes failures that prevent the re-authentication redirect', async () => {
+    const activeAccount = createAccount('active@example.com', 'active-home');
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: activeAccount,
+      redirectError: {
+        errorCode: BrowserAuthErrorCodes.noNetworkConnectivity,
+        errorMessage: 'Network unavailable',
+      },
+    });
+    const client = createAuthClient({ msalInstance: mockMsal.instance });
+
+    await client.initialize();
+
+    await expect(
+      client.reauthenticate('https://conspectus.local/#/accounts'),
+    ).rejects.toMatchObject({
+      code: 'network_error',
+      message: 'Authentication network request failed. Check your connection and try again.',
     });
   });
 

--- a/src/auth/msalAuthClient.ts
+++ b/src/auth/msalAuthClient.ts
@@ -15,7 +15,7 @@ import {
 import { loadRuntimeEnv } from '@shared';
 
 import type { AuthAccount, AuthClient, AuthErrorCode, AuthSession } from './index';
-import { AUTH_REQUEST_SCOPES } from './scopes';
+import { AUTH_REQUEST_SCOPES, GRAPH_ONEDRIVE_FILE_SCOPES } from './scopes';
 
 const MSAL_CONSUMERS_AUTHORITY = 'https://login.microsoftonline.com/consumers';
 
@@ -26,6 +26,7 @@ type MsalInstance = {
   setActiveAccount(account: AccountInfo | null): void;
   getAllAccounts(): AccountInfo[];
   loginRedirect(request?: RedirectRequest): Promise<void>;
+  acquireTokenRedirect(request: RedirectRequest): Promise<void>;
   logoutRedirect(logoutRequest?: EndSessionRequest): Promise<void>;
   acquireTokenSilent(request: SilentRequest): Promise<AuthenticationResult>;
 };
@@ -294,6 +295,24 @@ export const createAuthClient = (options: CreateAuthClientOptions = {}): AuthCli
         await resolveMsalInstance().loginRedirect(signInRequest);
       } catch (error) {
         throw normalizeAuthError(error, 'Sign-in failed.');
+      }
+    },
+
+    async reauthenticate(redirectStartPage: string): Promise<void> {
+      assertInitialized();
+
+      const resolvedMsalInstance = resolveMsalInstance();
+      const activeAccount = ensureActiveAccount(resolvedMsalInstance);
+      const reauthenticationRequest: RedirectRequest = {
+        account: activeAccount,
+        scopes: [...GRAPH_ONEDRIVE_FILE_SCOPES],
+        redirectStartPage,
+      };
+
+      try {
+        await resolvedMsalInstance.acquireTokenRedirect(reauthenticationRequest);
+      } catch (error) {
+        throw normalizeAuthError(error, 'Re-authentication failed.');
       }
     },
 

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -24,7 +24,13 @@
   import { createCachedDatabaseSnapshotService } from './cachedDatabaseSnapshotService';
   import { resolveAppGraphClient } from './graphClientResolver';
   import { resolveAppDbRuntime } from './dbRuntimeResolver';
-  import { APP_ROUTES, createHashRouteStore, DEFAULT_ROUTE, type AppRouteKey } from './hashRouting';
+  import {
+    APP_ROUTES,
+    createHashRouteStore,
+    DEFAULT_ROUTE,
+    toRouteHash,
+    type AppRouteKey,
+  } from './hashRouting';
   import {
     createStartupFreshnessService,
     type StartupFreshnessDecision,
@@ -78,6 +84,8 @@
   let footerVisibilityTrackingIsActive = false;
   let lastRenderedRoute: AppRouteKey | null = null;
   let forceRefreshIsRunning = false;
+  let authRecoveryIsPending = false;
+  let authRecoveryError: string | null = null;
   let stopFooterVisibilityTracking = (): void => {};
   const navIconBaseUrl = import.meta.env.BASE_URL;
   const unsubscribe = routeStore.subscribe((route) => {
@@ -99,6 +107,11 @@
     addTransferSaveState.phase === 'conflict' || addTransferSaveState.phase === 'conflict_syncing';
   $: pendingTransferIsOffline = !$networkStateStore;
   $: startupSyncIsActive = $syncStateStore.state === 'syncing' && $syncStateStore.branch === null;
+  $: staleTokenRecoveryIsRequired =
+    $syncStateStore.state === 'error' && $syncStateStore.branch === 'online_auth_expired';
+  $: if (!staleTokenRecoveryIsRequired && authRecoveryError !== null) {
+    authRecoveryError = null;
+  }
   $: startupSyncBlocksDataRoute =
     dataRoutesAwaitInitialSync &&
     startupSyncIsActive &&
@@ -107,6 +120,35 @@
   const openPendingTransfer = (): void => {
     if (typeof window !== 'undefined') {
       window.location.hash = '#/add';
+    }
+  };
+
+  const toRecoveryErrorMessage = (error: unknown): string => {
+    if (typeof error === 'object' && error !== null) {
+      const message = (error as { message?: unknown }).message;
+      if (typeof message === 'string' && message.trim().length > 0) {
+        return message;
+      }
+    }
+
+    return $_('appShell.reauthenticationFailed');
+  };
+
+  const requestStaleTokenRecovery = async (): Promise<void> => {
+    if (authRecoveryIsPending) {
+      return;
+    }
+
+    authRecoveryIsPending = true;
+    authRecoveryError = null;
+
+    try {
+      const redirectStartPage = new URL(toRouteHash(currentRoute), window.location.href).toString();
+      await resolveAppAuthClient().reauthenticate(redirectStartPage);
+    } catch (error) {
+      authRecoveryError = toRecoveryErrorMessage(error);
+    } finally {
+      authRecoveryIsPending = false;
     }
   };
 
@@ -442,6 +484,30 @@
     <h1>{$_('appShell.title')}</h1>
   </header>
 
+  {#if staleTokenRecoveryIsRequired}
+    <section class="auth-recovery" role="alert" data-testid="stale-token-recovery">
+      <div>
+        <h2>{$_('appShell.sessionExpiredTitle')}</h2>
+        <p>{$syncStateStore.message}</p>
+        {#if authRecoveryError !== null}
+          <p class="auth-recovery__error" data-testid="stale-token-recovery-error">
+            {authRecoveryError}
+          </p>
+        {/if}
+      </div>
+      <button
+        type="button"
+        class="app-button app-button--primary"
+        data-testid="stale-token-recovery-button"
+        aria-busy={authRecoveryIsPending}
+        disabled={authRecoveryIsPending}
+        on:click={() => void requestStaleTokenRecovery()}
+      >
+        {authRecoveryIsPending ? $_('appShell.reauthenticating') : $_('appShell.signInAgain')}
+      </button>
+    </section>
+  {/if}
+
   {#if pendingTransferNeedsAttention}
     <section
       class="pending-transfer-sync"
@@ -566,6 +632,7 @@
   </div>
 
   <style>
+    .auth-recovery,
     .pending-transfer-sync {
       display: flex;
       align-items: center;
@@ -576,9 +643,24 @@
       border-bottom: 1px solid var(--border);
     }
 
+    .auth-recovery {
+      background: color-mix(in srgb, var(--negative) 10%, var(--surface-strong));
+      border-bottom: 1px solid color-mix(in srgb, var(--negative) 24%, var(--border));
+    }
+
+    .auth-recovery h2,
+    .auth-recovery p,
     .pending-transfer-sync h2,
     .pending-transfer-sync p {
       margin: 0;
+    }
+
+    .auth-recovery h2 {
+      font-size: 1rem;
+    }
+
+    .auth-recovery__error {
+      color: color-mix(in srgb, var(--negative) 72%, var(--text-primary));
     }
 
     .pending-transfer-sync h2 {
@@ -598,9 +680,14 @@
     }
 
     @media (max-width: 36rem) {
+      .auth-recovery,
       .pending-transfer-sync {
         align-items: stretch;
         flex-direction: column;
+      }
+
+      .auth-recovery :global(.app-button) {
+        width: 100%;
       }
 
       .pending-transfer-sync__actions {

--- a/src/features/app-shell/AppShell.test.ts
+++ b/src/features/app-shell/AppShell.test.ts
@@ -119,4 +119,42 @@ describe('AppShell component', () => {
     expect(body).toContain('Checking OneDrive database freshness...');
     expect(body).not.toMatch(/<progress[^>]*\svalue=/u);
   });
+
+  it('renders the stale-token recovery action only for an expired auth session', () => {
+    const syncStateStore = createSyncStateStore({
+      state: 'error',
+      branch: 'online_auth_expired',
+      message: 'Your session has expired. Please sign in again to sync with OneDrive.',
+    });
+    const { body } = render(AppShell, {
+      props: {
+        routeStore: readable<AppRouteKey>('transfers'),
+        showLoadingPlaceholder: false,
+        syncStateStore,
+      },
+    });
+
+    expect(body).toContain('data-testid="stale-token-recovery"');
+    expect(body).toContain('data-testid="stale-token-recovery-button"');
+    expect(body).toContain('Microsoft-Sitzung abgelaufen');
+    expect(body).toContain('Erneut anmelden');
+  });
+
+  it('does not offer re-authentication for unrelated sync errors', () => {
+    const syncStateStore = createSyncStateStore({
+      state: 'error',
+      branch: 'online_metadata_failed',
+      message: 'OneDrive metadata is unavailable.',
+    });
+    const { body } = render(AppShell, {
+      props: {
+        routeStore: readable<AppRouteKey>('accounts'),
+        showLoadingPlaceholder: false,
+        syncStateStore,
+      },
+    });
+
+    expect(body).not.toContain('data-testid="stale-token-recovery"');
+    expect(body).not.toContain('data-testid="stale-token-recovery-button"');
+  });
 });

--- a/src/features/app-shell/authClientResolver.test.ts
+++ b/src/features/app-shell/authClientResolver.test.ts
@@ -19,6 +19,7 @@ const createStubAuthClient = (): AuthClient => {
     initialize: vi.fn(async () => {}),
     getSession: () => session,
     signIn: vi.fn(async () => {}),
+    reauthenticate: vi.fn(async () => {}),
     signOut: vi.fn(async () => {}),
     getAccessToken: vi.fn(async () => 'token'),
   };

--- a/src/features/app-shell/graphClientResolver.test.ts
+++ b/src/features/app-shell/graphClientResolver.test.ts
@@ -23,6 +23,7 @@ const createStubAuthClient = (): AuthClient => ({
     account: null,
   })),
   signIn: vi.fn(async () => {}),
+  reauthenticate: vi.fn(async () => {}),
   signOut: vi.fn(async () => {}),
   getAccessToken: vi.fn(async () => 'token'),
 });

--- a/src/features/app-shell/routes/settingsAuthController.test.ts
+++ b/src/features/app-shell/routes/settingsAuthController.test.ts
@@ -45,6 +45,7 @@ const createMockAuthClientHarness = (): MockAuthClientHarness => {
   const signIn = vi.fn(async () => {
     session = SIGNED_IN_SESSION;
   });
+  const reauthenticate = vi.fn(async () => {});
   const signOut = vi.fn(async () => {
     session = SIGNED_OUT_SESSION;
   });
@@ -53,6 +54,7 @@ const createMockAuthClientHarness = (): MockAuthClientHarness => {
   const client: AuthClient = {
     initialize,
     signIn,
+    reauthenticate,
     signOut,
     getAccessToken,
     getSession: () => session,

--- a/src/graph/graphClient.test.ts
+++ b/src/graph/graphClient.test.ts
@@ -21,6 +21,7 @@ const createAuthClient = (accessTokenResult: string | Error = 'graph-token') => 
     },
   })),
   signIn: vi.fn(async () => {}),
+  reauthenticate: vi.fn(async () => {}),
   signOut: vi.fn(async () => {}),
   getAccessToken: vi.fn(async () => {
     if (accessTokenResult instanceof Error) {

--- a/src/graph/index.test.ts
+++ b/src/graph/index.test.ts
@@ -17,6 +17,7 @@ const createMinimalAuthClient = (): AuthClient => ({
     },
   })),
   signIn: vi.fn(async () => {}),
+  reauthenticate: vi.fn(async () => {}),
   signOut: vi.fn(async () => {}),
   getAccessToken: vi.fn(async () => 'graph-access-token'),
 });

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -8,6 +8,9 @@
   },
   "appShell": {
     "signInAgain": "Erneut anmelden",
+    "sessionExpiredTitle": "Microsoft-Sitzung abgelaufen",
+    "reauthenticating": "Microsoft-Anmeldung wird geöffnet...",
+    "reauthenticationFailed": "Die Microsoft-Anmeldung konnte nicht geöffnet werden. Versuche es erneut.",
     "downloadedKb": "{kb} KB heruntergeladen...",
     "downloadProgress": "{loaded} KB / {total} KB",
     "uploadedKb": "{kb} KB hochgeladen...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -8,6 +8,9 @@
   },
   "appShell": {
     "signInAgain": "Sign in again",
+    "sessionExpiredTitle": "Microsoft session expired",
+    "reauthenticating": "Opening Microsoft sign-in...",
+    "reauthenticationFailed": "Microsoft sign-in could not be opened. Try again.",
     "downloadedKb": "{kb} KB downloaded...",
     "downloadProgress": "{loaded} KB / {total} KB",
     "uploadedKb": "{kb} KB uploaded...",

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -197,10 +197,12 @@ const inspectTransferMonthSwipeMove = async (
 type MockAuthClientOptions = {
   readonly initializeDelayMs?: number;
   readonly signInDelayMs?: number;
+  readonly reauthenticateDelayMs?: number;
   readonly signOutDelayMs?: number;
   readonly consumeRedirectHashOnInitialize?: boolean;
   readonly failInitialize?: boolean;
   readonly failSignIn?: boolean;
+  readonly failReauthenticate?: boolean;
   readonly failSignOut?: boolean;
   readonly failGetAccessToken?: boolean;
   readonly getAccessTokenErrorCode?: string;
@@ -300,6 +302,10 @@ const installMockAuthClient = async (
 
     let isInitialized = false;
     let isAuthenticated = mockOptions.startAuthenticated ?? false;
+    const trackedWindow = window as typeof window & {
+      __CONSPECTUS_REAUTHENTICATE_START_PAGES__?: string[];
+    };
+    trackedWindow.__CONSPECTUS_REAUTHENTICATE_START_PAGES__ = [];
 
     const toSession = () => ({
       isAuthenticated,
@@ -345,6 +351,16 @@ const installMockAuthClient = async (
           };
         }
         isAuthenticated = true;
+      },
+      async reauthenticate(redirectStartPage: string) {
+        trackedWindow.__CONSPECTUS_REAUTHENTICATE_START_PAGES__?.push(redirectStartPage);
+        await resolveDelay(mockOptions.reauthenticateDelayMs);
+        if (mockOptions.failReauthenticate) {
+          throw {
+            code: 'network_error',
+            message: 'Mock re-authentication failure.',
+          };
+        }
       },
       async signOut() {
         await resolveDelay(mockOptions.signOutDelayMs);
@@ -1940,11 +1956,64 @@ test('fails fast on non-retryable startup metadata errors and surfaces the clear
   expect(await getGraphDownloadCallCount(page)).toBe(0);
 });
 
-test('surfaces a sign-in-again recovery action when startup metadata refresh fails because the session expired', async ({
+test('starts one safe re-authentication and preserves the current screen after token expiry', async ({
   page,
 }) => {
   await installMockAuthClient(page, {
     startAuthenticated: true,
+    reauthenticateDelayMs: 250,
+  });
+  await installMockGraphClient(page, {
+    metadataErrorSequence: [
+      createMockGraphError(
+        'unauthorized',
+        'Your session has expired. Please sign in again to sync with OneDrive.',
+        401,
+      ),
+    ],
+  });
+  await installMockCacheStore(page);
+  await installPersistedBinding(page);
+  await installMockStartupNetworkState(page, true);
+
+  await page.goto(appPath('#/transfers'));
+
+  await expect(page.getByTestId('transfers-route-status')).toContainText(
+    'Your session has expired. Please sign in again to sync with OneDrive.',
+  );
+  expect(await getGraphMetadataCallCount(page)).toBe(1);
+  expect(await getGraphDownloadCallCount(page)).toBe(0);
+
+  const recoveryButton = page.getByTestId('stale-token-recovery-button');
+  const previousUrl = page.url();
+  await expect(recoveryButton).toBeVisible();
+  await recoveryButton.evaluate((button) => {
+    button.click();
+    button.click();
+  });
+  await expect(recoveryButton).toBeDisabled();
+  await expect(recoveryButton).toHaveAttribute('aria-busy', 'true');
+  await expect(recoveryButton).toBeEnabled();
+
+  const redirectStartPages = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          __CONSPECTUS_REAUTHENTICATE_START_PAGES__?: string[];
+        }
+      ).__CONSPECTUS_REAUTHENTICATE_START_PAGES__,
+  );
+  expect(redirectStartPages).toEqual([previousUrl]);
+  await expect(page).toHaveURL(previousUrl);
+  await expect(page.getByTestId('route-transfers')).toBeVisible();
+});
+
+test('keeps stale-token recovery retryable on the current screen when redirect startup fails', async ({
+  page,
+}) => {
+  await installMockAuthClient(page, {
+    startAuthenticated: true,
+    failReauthenticate: true,
   });
   await installMockGraphClient(page, {
     metadataErrorSequence: [
@@ -1960,15 +2029,17 @@ test('surfaces a sign-in-again recovery action when startup metadata refresh fai
   await installMockStartupNetworkState(page, true);
 
   await page.goto(appPath('#/accounts'));
+  const previousUrl = page.url();
+  const recoveryButton = page.getByTestId('stale-token-recovery-button');
+  await recoveryButton.click();
 
-  await expect(page.getByTestId('accounts-route-status')).toContainText(
-    'Your session has expired. Please sign in again to sync with OneDrive.',
+  await expect(page.getByTestId('stale-token-recovery-error')).toContainText(
+    'Mock re-authentication failure.',
   );
-  expect(await getGraphMetadataCallCount(page)).toBe(1);
-  expect(await getGraphDownloadCallCount(page)).toBe(0);
-
-  await page.getByRole('link', { name: 'Settings' }).click();
-  await expect(page.getByTestId('route-settings')).toBeVisible();
+  await expect(recoveryButton).toBeEnabled();
+  await expect(recoveryButton).toHaveAttribute('aria-busy', 'false');
+  await expect(page).toHaveURL(previousUrl);
+  await expect(page.getByTestId('route-accounts')).toBeVisible();
 });
 
 test('downloads a fresh DB on startup when the OneDrive eTag changed', async ({ page }) => {


### PR DESCRIPTION
# Pull Request

## Linked Issue (Required)

- Closes #78
- Milestone/issue: M7-04

## Context

- Problem: Expired or stale Microsoft access tokens were detected as `online_auth_expired`, but the app had no safe in-app action to renew the token and return to the interrupted screen.
- Goal: Recover the active OneDrive account with an interactive MSAL token redirect while preserving the current hash route and clear UX state.

## Changes

- Add an active-account `acquireTokenRedirect` recovery API using the existing OneDrive scope.
- Add a responsive stale-session recovery banner with pending/error feedback and duplicate-submit protection.
- Preserve the requesting screen through MSAL `redirectStartPage`.
- Add unit, component, and Chromium/Pixel 5 E2E regression coverage.
- Bump the app version to `0.7.04` and document the implementation contract.

## Test Plan

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (428 app tests + 65 script tests)
- [x] `npm run build`
- [x] `npm run test:e2e` (120 tests)
- Notes: The exact committed tree passed the full gate after the commit hook. Local reviewer gate: APPROVED.

## Screenshots

- [ ] UI change: screenshots attached
- [ ] No UI change
- Note: The recovery banner is covered at desktop Chromium and Pixel 5 viewports; no screenshot artifact is attached.

## Risk Notes

- User impact: Users can renew an expired OneDrive session without signing out, switching accounts, or losing their current app route.
- Rollback plan: Revert commit `98cfa4a`; existing unauthorized detection remains intact.
- Assumption: Issue #78's “user context” is the current app screen/hash route, matching its explicit “Return user to previous screen” implementation step.

## QS Checklist

- [x] Linked issue ID is included in this PR.
- [x] Lint, typecheck, tests, and build were run and pass.
- [ ] Screenshots are included for UI changes.
- [x] Risk and rollback notes are documented.
- [x] No secrets, tokens, or credentials were added to the repository.
- [x] No breaking path/base URL changes were introduced (preserves `/conspectus/webapp/` deployment behavior).

## Merge And Cleanup (PR Path)

- [x] Required GitHub checks are green.
- [x] PR will be merged into `main` with Rebase and merge.
- [x] PR will be merged into `main` once checks/review requirements are satisfied.
- [x] Head branch will be deleted after merge.
- [x] Linked issue/backlog marker will only become done on `main` through this merge.
