### PR TITLE
feat: [M7-05] Recover missing OneDrive file binding

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -748,6 +748,12 @@ M7-04 implementation clarification:
 - Re-authentication uses MSAL `acquireTokenRedirect` with the existing OneDrive scope and active account, preserving the selected account/file ownership instead of opening the general account picker.
 - The current hash-route URL is passed as MSAL's `redirectStartPage`, so successful recovery returns to the screen that requested it. The recovery action exposes pending and failure feedback and blocks duplicate redirect attempts.
 
+M7-05 implementation clarification:
+
+- An item-ID metadata `404` triggers one direct Graph lookup at the saved drive, parent path, and filename; the app does not search for renamed or moved files.
+- Self-healing accepts only a file with the exact unchanged drive, normalized parent path, and filename plus a different non-empty item ID. The replacement ID is persisted only after the recovered snapshot passes the established metadata, download, cache, and SQLite-open verification flow.
+- If the exact saved path is definitively missing, database access remains fail-closed, the previous binding and cached bytes are preserved without being opened, and a global recovery action directs the user to the existing Settings rebind flow.
+
 M7-08 implementation clarification:
 
 - Startup database access now fails closed when offline or when authentication, OneDrive metadata, or snapshot download fails; cached bytes are reused only after a successful online eTag match.

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -575,7 +575,7 @@ An issue is only considered done when:
 - Depends on: `M3-03, M3-04`
 - GitHub: [#78](https://github.com/Jon2050/Conspectus-Mobile/issues/78)
 
-### :green_circle: M7-05 Implement missing/moved OneDrive file recovery
+### :white_check_mark: M7-05 Implement missing/moved OneDrive file recovery
 
 - Label: `feature`
 - Milestone: `M7 - Settings + Recovery`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.7.04",
+  "version": "0.7.05",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.7.04",
+      "version": "0.7.05",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.7.04",
+  "version": "0.7.05",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -46,6 +46,7 @@
   import { resolveAppStartupIsOnline } from './startupNetworkStateResolver';
   import { syncSelectedDriveItemBindingStoreAtStartup } from './startupBindingSync';
   import { resolveAppSnapshotValidator } from './snapshotValidatorResolver';
+  import { createMissingFileRecoveryService } from './missingFileRecoveryService';
   import {
     createInitialFormFields,
     type AddTransferFormFields,
@@ -86,6 +87,7 @@
   let forceRefreshIsRunning = false;
   let authRecoveryIsPending = false;
   let authRecoveryError: string | null = null;
+  let bindingRepairPersistenceIsRunning = false;
   let stopFooterVisibilityTracking = (): void => {};
   const navIconBaseUrl = import.meta.env.BASE_URL;
   const unsubscribe = routeStore.subscribe((route) => {
@@ -109,6 +111,8 @@
   $: startupSyncIsActive = $syncStateStore.state === 'syncing' && $syncStateStore.branch === null;
   $: staleTokenRecoveryIsRequired =
     $syncStateStore.state === 'error' && $syncStateStore.branch === 'online_auth_expired';
+  $: missingFileRecoveryIsRequired =
+    $syncStateStore.state === 'error' && $syncStateStore.branch === 'online_file_missing';
   $: if (!staleTokenRecoveryIsRequired && authRecoveryError !== null) {
     authRecoveryError = null;
   }
@@ -120,6 +124,12 @@
   const openPendingTransfer = (): void => {
     if (typeof window !== 'undefined') {
       window.location.hash = '#/add';
+    }
+  };
+
+  const openMissingFileRecovery = (): void => {
+    if (typeof window !== 'undefined') {
+      window.location.hash = '#/settings';
     }
   };
 
@@ -200,6 +210,9 @@
         createCachedDatabaseSnapshotService(graphClient, cacheStore, {
           snapshotValidator: resolveAppSnapshotValidator(),
         }),
+        {
+          missingFileRecovery: createMissingFileRecoveryService(graphClient),
+        },
       );
       const decision = await startupFreshnessService.resolve(
         binding,
@@ -228,6 +241,15 @@
         console.warn('Opening cached OneDrive database snapshot failed.', error);
         applyStartupDbRuntimeError(syncStateStore, error);
         return;
+      }
+
+      if (decision.kind === 'ready' && decision.recoveredBinding !== undefined) {
+        bindingRepairPersistenceIsRunning = true;
+        try {
+          appSelectedDriveItemBindingStore.setBinding(decision.recoveredBinding);
+        } finally {
+          bindingRepairPersistenceIsRunning = false;
+        }
       }
 
       applyStartupFreshnessDecision(syncStateStore, decision);
@@ -263,6 +285,10 @@
     selectedBinding = binding;
     if (!selectedBindingHasEmitted) {
       selectedBindingHasEmitted = true;
+      return;
+    }
+
+    if (bindingRepairPersistenceIsRunning) {
       return;
     }
 
@@ -508,6 +534,23 @@
     </section>
   {/if}
 
+  {#if missingFileRecoveryIsRequired}
+    <section class="file-recovery" role="alert" data-testid="missing-file-recovery">
+      <div>
+        <h2>{$_('appShell.missingFileTitle')}</h2>
+        <p>{$_('appShell.missingFileDescription')}</p>
+      </div>
+      <button
+        type="button"
+        class="app-button app-button--primary"
+        data-testid="missing-file-recovery-button"
+        on:click={openMissingFileRecovery}
+      >
+        {$_('appShell.selectAnotherFile')}
+      </button>
+    </section>
+  {/if}
+
   {#if pendingTransferNeedsAttention}
     <section
       class="pending-transfer-sync"
@@ -633,7 +676,8 @@
 
   <style>
     .auth-recovery,
-    .pending-transfer-sync {
+    .pending-transfer-sync,
+    .file-recovery {
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -648,10 +692,17 @@
       border-bottom: 1px solid color-mix(in srgb, var(--negative) 24%, var(--border));
     }
 
+    .file-recovery {
+      background: color-mix(in srgb, var(--accent) 12%, var(--surface-strong));
+      border-bottom: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+    }
+
     .auth-recovery h2,
     .auth-recovery p,
     .pending-transfer-sync h2,
-    .pending-transfer-sync p {
+    .pending-transfer-sync p,
+    .file-recovery h2,
+    .file-recovery p {
       margin: 0;
     }
 
@@ -663,7 +714,8 @@
       color: color-mix(in srgb, var(--negative) 72%, var(--text-primary));
     }
 
-    .pending-transfer-sync h2 {
+    .pending-transfer-sync h2,
+    .file-recovery h2 {
       font-size: 1rem;
     }
 
@@ -681,12 +733,14 @@
 
     @media (max-width: 36rem) {
       .auth-recovery,
-      .pending-transfer-sync {
+      .pending-transfer-sync,
+      .file-recovery {
         align-items: stretch;
         flex-direction: column;
       }
 
-      .auth-recovery :global(.app-button) {
+      .auth-recovery :global(.app-button),
+      .file-recovery :global(.app-button) {
         width: 100%;
       }
 

--- a/src/features/app-shell/AppShell.test.ts
+++ b/src/features/app-shell/AppShell.test.ts
@@ -157,4 +157,25 @@ describe('AppShell component', () => {
     expect(body).not.toContain('data-testid="stale-token-recovery"');
     expect(body).not.toContain('data-testid="stale-token-recovery-button"');
   });
+
+  it('offers the rebind path only for a definitively missing saved file', () => {
+    const syncStateStore = createSyncStateStore({
+      state: 'error',
+      branch: 'online_file_missing',
+      message: 'The selected file is missing.',
+    });
+    const { body } = render(AppShell, {
+      props: {
+        routeStore: readable<AppRouteKey>('accounts'),
+        showLoadingPlaceholder: false,
+        syncStateStore,
+      },
+    });
+
+    expect(body).toContain('data-testid="missing-file-recovery"');
+    expect(body).toContain('data-testid="missing-file-recovery-button"');
+    expect(body).toContain('OneDrive-Datenbank nicht gefunden');
+    expect(body).toContain('Andere Datenbank auswählen');
+    expect(body).not.toContain('data-testid="stale-token-recovery"');
+  });
 });

--- a/src/features/app-shell/graphClientResolver.test.ts
+++ b/src/features/app-shell/graphClientResolver.test.ts
@@ -30,6 +30,7 @@ const createStubAuthClient = (): AuthClient => ({
 
 const createStubGraphClient = (): GraphClient => ({
   listChildren: vi.fn(async () => []),
+  resolveFileByPath: vi.fn(async (binding) => ({ ...binding, itemId: 'replacement-item-id' })),
   getFileMetadata: vi.fn(async () => ({
     eTag: '"etag-1"',
     sizeBytes: 1,

--- a/src/features/app-shell/missingFileRecoveryService.test.ts
+++ b/src/features/app-shell/missingFileRecoveryService.test.ts
@@ -1,0 +1,86 @@
+// Verifies missing-file recovery accepts only an exact same-path replacement item ID.
+import { describe, expect, it, vi } from 'vitest';
+import type { DriveItemBinding, GraphClient } from '@graph';
+
+import {
+  createMissingFileRecoveryService,
+  MissingFileRecoveryError,
+} from './missingFileRecoveryService';
+
+const BINDING: DriveItemBinding = {
+  driveId: 'drive-123',
+  itemId: 'old-item-id',
+  name: 'conspectus.db',
+  parentPath: '/Finance',
+};
+
+const createService = (outcome: DriveItemBinding | unknown) => {
+  const resolveFileByPath = vi.fn(async () => {
+    if (
+      outcome instanceof Error ||
+      (typeof outcome === 'object' && outcome !== null && 'code' in outcome)
+    ) {
+      throw outcome;
+    }
+    return outcome as DriveItemBinding;
+  });
+  return {
+    resolveFileByPath,
+    service: createMissingFileRecoveryService({ resolveFileByPath } satisfies Pick<
+      GraphClient,
+      'resolveFileByPath'
+    >),
+  };
+};
+
+describe('missing file recovery service', () => {
+  it('returns an exact same-path replacement with a new item ID', async () => {
+    const replacement = { ...BINDING, itemId: 'new-item-id' };
+    const { service, resolveFileByPath } = createService(replacement);
+
+    await expect(service.recover(BINDING)).resolves.toEqual(replacement);
+    expect(resolveFileByPath).toHaveBeenCalledWith(BINDING);
+  });
+
+  it.each([
+    { ...BINDING, driveId: 'other-drive', itemId: 'new-item-id' },
+    { ...BINDING, parentPath: '/Archive', itemId: 'new-item-id' },
+    { ...BINDING, name: 'renamed.db', itemId: 'new-item-id' },
+    { ...BINDING },
+    { ...BINDING, itemId: '   ' },
+  ])('requires an exact unchanged identity boundary for $itemId', async (candidate) => {
+    const { service } = createService(candidate);
+
+    await expect(service.recover(BINDING)).rejects.toBeInstanceOf(MissingFileRecoveryError);
+  });
+
+  it('maps a definitive path 404 to rebind-required recovery', async () => {
+    const { service } = createService({
+      code: 'not_found',
+      message: 'Missing at path.',
+      status: 404,
+    });
+
+    await expect(service.recover(BINDING)).rejects.toMatchObject({
+      code: 'rebind_required',
+    });
+  });
+
+  it('maps a folder occupying the saved file path to rebind-required recovery', async () => {
+    const { service } = createService({
+      code: 'not_found',
+      message: 'A folder occupies the saved file path.',
+    });
+
+    await expect(service.recover(BINDING)).rejects.toMatchObject({
+      code: 'rebind_required',
+    });
+  });
+
+  it('preserves transient and authentication errors for their existing recovery flows', async () => {
+    const networkError = { code: 'network_error', message: 'Temporary outage.', status: 503 };
+    const { service } = createService(networkError);
+
+    await expect(service.recover(BINDING)).rejects.toBe(networkError);
+  });
+});

--- a/src/features/app-shell/missingFileRecoveryService.ts
+++ b/src/features/app-shell/missingFileRecoveryService.ts
@@ -1,0 +1,72 @@
+// Resolves a replacement OneDrive item ID only when the saved drive, path, and file name are unchanged.
+import type { DriveItemBinding, GraphClient, GraphError } from '@graph';
+
+export type MissingFileRecoveryErrorCode = 'rebind_required';
+
+export class MissingFileRecoveryError extends Error {
+  readonly code: MissingFileRecoveryErrorCode;
+  override readonly cause: unknown;
+
+  constructor(message: string, cause: unknown) {
+    super(message);
+    this.name = 'MissingFileRecoveryError';
+    this.code = 'rebind_required';
+    this.cause = cause;
+  }
+}
+
+export interface MissingFileRecoveryService {
+  recover(binding: DriveItemBinding): Promise<DriveItemBinding>;
+}
+
+const isGraphError = (error: unknown): error is GraphError =>
+  typeof error === 'object' &&
+  error !== null &&
+  typeof (error as Partial<GraphError>).code === 'string' &&
+  typeof (error as Partial<GraphError>).message === 'string';
+
+const isExactReplacement = (
+  currentBinding: DriveItemBinding,
+  candidateBinding: DriveItemBinding,
+): boolean =>
+  candidateBinding.driveId === currentBinding.driveId &&
+  candidateBinding.parentPath === currentBinding.parentPath &&
+  candidateBinding.name === currentBinding.name &&
+  candidateBinding.itemId.trim().length > 0 &&
+  candidateBinding.itemId !== currentBinding.itemId;
+
+export const isMissingFileRecoveryError = (error: unknown): error is MissingFileRecoveryError =>
+  error instanceof MissingFileRecoveryError ||
+  (typeof error === 'object' &&
+    error !== null &&
+    (error as { code?: unknown }).code === 'rebind_required');
+
+export const createMissingFileRecoveryService = (
+  graphClient: Pick<GraphClient, 'resolveFileByPath'>,
+): MissingFileRecoveryService => ({
+  async recover(binding): Promise<DriveItemBinding> {
+    let candidateBinding: DriveItemBinding;
+
+    try {
+      candidateBinding = await graphClient.resolveFileByPath(binding);
+    } catch (error) {
+      if (isGraphError(error) && error.code === 'not_found') {
+        throw new MissingFileRecoveryError(
+          'The selected OneDrive file no longer exists at its saved path.',
+          error,
+        );
+      }
+
+      throw error;
+    }
+
+    if (!isExactReplacement(binding, candidateBinding)) {
+      throw new MissingFileRecoveryError(
+        'The OneDrive path lookup did not return the exact saved database file with a replacement item ID.',
+        candidateBinding,
+      );
+    }
+
+    return candidateBinding;
+  },
+});

--- a/src/features/app-shell/routes/settingsFileBindingController.test.ts
+++ b/src/features/app-shell/routes/settingsFileBindingController.test.ts
@@ -76,6 +76,7 @@ const createGraphClientHarness = (): {
   return {
     graphClient: {
       listChildren,
+      resolveFileByPath: vi.fn(async (binding) => binding),
       getFileMetadata: vi.fn(async () => ({
         eTag: '"etag-1"',
         sizeBytes: 2048,

--- a/src/features/app-shell/startupFreshnessService.test.ts
+++ b/src/features/app-shell/startupFreshnessService.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createStartupFreshnessService } from './startupFreshnessService';
+import { MissingFileRecoveryError } from './missingFileRecoveryService';
 
 import type { CacheStore, CachedDatabaseSnapshot } from '@cache';
 import type { DriveItemBinding, GraphClient, GraphError, GraphFileMetadata } from '@graph';
@@ -11,6 +12,11 @@ const DRIVE_ITEM_BINDING: DriveItemBinding = {
   itemId: 'item-456',
   name: 'conspectus.db',
   parentPath: '/Finance',
+};
+
+const RECOVERED_DRIVE_ITEM_BINDING: DriveItemBinding = {
+  ...DRIVE_ITEM_BINDING,
+  itemId: 'item-789',
 };
 
 const createSnapshot = (
@@ -133,6 +139,99 @@ describe('startup freshness service', () => {
     expect(cacheStore.readSnapshot).not.toHaveBeenCalled();
     expect(graphClient.getFileMetadata).not.toHaveBeenCalled();
     expect(snapshotService.downloadAndCacheSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('continues verified sync with an exact-path replacement after the saved item ID returns 404', async () => {
+    const metadata = createMetadata({ eTag: '"etag-recovered"' });
+    const graphClient = createGraphClient(
+      createGraphError('not_found', 'Old item ID not found.', 404),
+      metadata,
+    );
+    const cacheStore = createCacheStore(null);
+    const downloadedSnapshot = createSnapshot({
+      binding: RECOVERED_DRIVE_ITEM_BINDING,
+      metadata: {
+        eTag: metadata.eTag,
+        lastSyncAtIso: '2026-03-11T10:30:00.000Z',
+      },
+    });
+    const snapshotService = createSnapshotService(downloadedSnapshot);
+    const recover = vi.fn(async () => RECOVERED_DRIVE_ITEM_BINDING);
+    const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService, {
+      missingFileRecovery: { recover },
+    });
+
+    await expect(service.resolve(DRIVE_ITEM_BINDING, true)).resolves.toEqual({
+      kind: 'ready',
+      branch: 'online_changed',
+      syncState: 'synced',
+      snapshot: downloadedSnapshot,
+      failure: null,
+      recoveredBinding: RECOVERED_DRIVE_ITEM_BINDING,
+    });
+
+    expect(recover).toHaveBeenCalledWith(DRIVE_ITEM_BINDING);
+    expect(graphClient.getFileMetadata).toHaveBeenNthCalledWith(1, DRIVE_ITEM_BINDING);
+    expect(graphClient.getFileMetadata).toHaveBeenNthCalledWith(2, RECOVERED_DRIVE_ITEM_BINDING);
+    expect(cacheStore.readSnapshot).toHaveBeenCalledWith(RECOVERED_DRIVE_ITEM_BINDING);
+    expect(snapshotService.downloadAndCacheSnapshot).toHaveBeenCalledWith(
+      RECOVERED_DRIVE_ITEM_BINDING,
+      metadata,
+      undefined,
+    );
+  });
+
+  it('returns a distinct rebind-required decision when the exact saved path is missing', async () => {
+    const graphClient = createGraphClient(
+      createGraphError('not_found', 'Old item ID not found.', 404),
+    );
+    const cacheStore = createCacheStore(createSnapshot());
+    const snapshotService = createSnapshotService(createSnapshot());
+    const recover = vi.fn(async () => {
+      throw new MissingFileRecoveryError('No file exists at the saved path.', {
+        code: 'not_found',
+      });
+    });
+    const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService, {
+      missingFileRecovery: { recover },
+    });
+
+    await expect(service.resolve(DRIVE_ITEM_BINDING, true)).resolves.toMatchObject({
+      kind: 'error',
+      branch: 'online_file_missing',
+      syncState: 'error',
+      snapshot: null,
+      failure: {
+        code: 'file_not_found',
+      },
+    });
+
+    expect(cacheStore.readSnapshot).not.toHaveBeenCalled();
+    expect(snapshotService.downloadAndCacheSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('keeps transient path lookup failures in the normal retryable metadata error flow', async () => {
+    const graphClient = createGraphClient(
+      createGraphError('not_found', 'Old item ID not found.', 404),
+    );
+    const cacheStore = createCacheStore(null);
+    const snapshotService = createSnapshotService(createSnapshot());
+    const recover = vi.fn(async () => {
+      throw createGraphError('network_error', 'Path lookup temporarily failed.', 503);
+    });
+    const service = createStartupFreshnessService(graphClient, cacheStore, snapshotService, {
+      missingFileRecovery: { recover },
+      retry: { maxAttempts: 1 },
+    });
+
+    await expect(service.resolve(DRIVE_ITEM_BINDING, true)).resolves.toMatchObject({
+      kind: 'error',
+      branch: 'online_metadata_failed',
+      failure: {
+        code: 'metadata_fetch_failed',
+        cause: { code: 'network_error' },
+      },
+    });
   });
 
   it('reuses the cached snapshot when the OneDrive eTag is unchanged', async () => {

--- a/src/features/app-shell/startupFreshnessService.ts
+++ b/src/features/app-shell/startupFreshnessService.ts
@@ -1,9 +1,13 @@
 // Decides whether startup should use the cached DB snapshot, download a fresh one, or fail deterministically.
 import type { CacheStore, CachedDatabaseSnapshot } from '@cache';
-import type { DriveItemBinding, GraphClient, GraphError } from '@graph';
+import type { DriveItemBinding, GraphClient, GraphError, GraphFileMetadata } from '@graph';
 import type { SyncState } from '@shared';
 
 import type { CachedDatabaseSnapshotService } from './cachedDatabaseSnapshotService';
+import {
+  isMissingFileRecoveryError,
+  type MissingFileRecoveryService,
+} from './missingFileRecoveryService';
 
 export type StartupFreshnessBranch =
   | 'no_binding'
@@ -12,13 +16,15 @@ export type StartupFreshnessBranch =
   | 'offline_unsupported'
   | 'online_metadata_failed'
   | 'online_download_failed'
-  | 'online_auth_expired';
+  | 'online_auth_expired'
+  | 'online_file_missing';
 
 export type StartupFreshnessFailureCode =
   | 'offline_unsupported'
   | 'metadata_fetch_failed'
   | 'snapshot_download_failed'
-  | 'auth_expired';
+  | 'auth_expired'
+  | 'file_not_found';
 
 export type StartupFreshnessMode = 'reuse_if_current' | 'force_download';
 
@@ -32,6 +38,7 @@ interface StartupFreshnessBaseDecision {
   readonly branch: StartupFreshnessBranch;
   readonly syncState: SyncState;
   readonly failure: StartupFreshnessFailure | null;
+  readonly recoveredBinding?: DriveItemBinding;
 }
 
 export interface StartupFreshnessSkippedDecision extends StartupFreshnessBaseDecision {
@@ -54,7 +61,8 @@ export interface StartupFreshnessErrorDecision extends StartupFreshnessBaseDecis
     | 'offline_unsupported'
     | 'online_metadata_failed'
     | 'online_download_failed'
-    | 'online_auth_expired';
+    | 'online_auth_expired'
+    | 'online_file_missing';
   readonly syncState: 'error';
   readonly snapshot: null;
   readonly failure: StartupFreshnessFailure;
@@ -84,6 +92,7 @@ export interface StartupFreshnessRetryOptions {
 
 export interface CreateStartupFreshnessServiceOptions {
   readonly retry?: StartupFreshnessRetryOptions;
+  readonly missingFileRecovery?: Pick<MissingFileRecoveryService, 'recover'>;
 }
 
 interface NormalizedStartupFreshnessRetryOptions {
@@ -259,15 +268,63 @@ export const createStartupFreshnessService = (
       };
     }
 
-    const cachedSnapshot = await cacheStore.readSnapshot(binding);
-
     try {
       const retryOptions = normalizeRetryOptions(options.retry);
-      const metadata = await executeWithRetry(
-        'refresh the selected OneDrive database metadata',
-        async () => graphClient.getFileMetadata(binding),
-        retryOptions,
-      );
+      const missingFileRecovery = options.missingFileRecovery;
+      let effectiveBinding = binding;
+      let recoveredBinding: DriveItemBinding | undefined;
+      let metadata: GraphFileMetadata;
+
+      try {
+        metadata = await executeWithRetry(
+          'refresh the selected OneDrive database metadata',
+          async () => graphClient.getFileMetadata(effectiveBinding),
+          retryOptions,
+        );
+      } catch (error) {
+        if (
+          missingFileRecovery === undefined ||
+          !isGraphError(error) ||
+          error.code !== 'not_found'
+        ) {
+          throw error;
+        }
+
+        try {
+          effectiveBinding = await executeWithRetry(
+            'resolve the selected OneDrive database at its saved path',
+            async () => missingFileRecovery.recover(binding),
+            retryOptions,
+          );
+          recoveredBinding = effectiveBinding;
+          metadata = await executeWithRetry(
+            'refresh the recovered OneDrive database metadata',
+            async () => graphClient.getFileMetadata(effectiveBinding),
+            retryOptions,
+          );
+        } catch (recoveryError) {
+          if (
+            isMissingFileRecoveryError(recoveryError) ||
+            (isGraphError(recoveryError) && recoveryError.code === 'not_found')
+          ) {
+            return {
+              kind: 'error',
+              branch: 'online_file_missing',
+              syncState: 'error',
+              snapshot: null,
+              failure: createFailure(
+                'file_not_found',
+                recoveryError,
+                'The selected OneDrive database no longer exists at its saved path.',
+              ),
+            };
+          }
+
+          throw recoveryError;
+        }
+      }
+
+      const cachedSnapshot = await cacheStore.readSnapshot(effectiveBinding);
 
       if (
         mode === 'reuse_if_current' &&
@@ -280,13 +337,15 @@ export const createStartupFreshnessService = (
           syncState: 'synced',
           snapshot: cachedSnapshot,
           failure: null,
+          ...(recoveredBinding === undefined ? {} : { recoveredBinding }),
         };
       }
 
       try {
         const downloadedSnapshot = await executeWithRetry(
           'download the latest OneDrive database snapshot',
-          async () => snapshotService.downloadAndCacheSnapshot(binding, metadata, onProgress),
+          async () =>
+            snapshotService.downloadAndCacheSnapshot(effectiveBinding, metadata, onProgress),
           retryOptions,
         );
 
@@ -296,6 +355,7 @@ export const createStartupFreshnessService = (
           syncState: 'synced',
           snapshot: downloadedSnapshot,
           failure: null,
+          ...(recoveredBinding === undefined ? {} : { recoveredBinding }),
         };
       } catch (error) {
         const isAuthError = isGraphError(error) && error.code === 'unauthorized';

--- a/src/features/app-shell/startupSyncStateController.test.ts
+++ b/src/features/app-shell/startupSyncStateController.test.ts
@@ -181,6 +181,35 @@ describe('startupSyncStateController', () => {
     expect(toastStore.show).not.toHaveBeenCalled();
   });
 
+  it('preserves a distinct localized missing-file branch without a toast', () => {
+    const store = createSyncStateStore();
+    const toastStore = createToastStore();
+    const decision: StartupFreshnessDecision = {
+      kind: 'error',
+      branch: 'online_file_missing',
+      syncState: 'error',
+      snapshot: null,
+      failure: {
+        code: 'file_not_found',
+        message: 'Internal missing file detail.',
+        cause: { code: 'rebind_required' },
+      },
+    };
+
+    beginStartupSync(store);
+    toastStore.show.mockClear();
+    applyStartupFreshnessDecision(store, decision, toastStore);
+
+    expect(get(store)).toEqual({
+      state: 'error',
+      message:
+        'Die ausgewählte OneDrive-Datenbank ist am gespeicherten Pfad nicht mehr verfügbar. Wähle in den Einstellungen eine andere Datenbank aus.',
+      branch: 'online_file_missing',
+      progress: null,
+    });
+    expect(toastStore.show).not.toHaveBeenCalled();
+  });
+
   it('resets to idle when the startup decision is skipped', () => {
     const store = createSyncStateStore({
       state: 'error',

--- a/src/features/app-shell/startupSyncStateController.ts
+++ b/src/features/app-shell/startupSyncStateController.ts
@@ -30,6 +30,8 @@ const buildStartupSyncMessage = (decision: StartupFreshnessDecision): string | n
       return get(_)('sync.startup.onlineUnchanged');
     case 'online_changed':
       return get(_)('sync.startup.onlineChanged');
+    case 'online_file_missing':
+      return get(_)('sync.startup.fileMissing');
     case 'online_auth_expired':
     case 'offline_unsupported':
     case 'online_metadata_failed':
@@ -54,6 +56,7 @@ const showDecisionToast = (
     case 'online_changed':
       toastStore.show(message, 'success', 3200);
       return;
+    case 'online_file_missing':
     case 'online_auth_expired':
     case 'offline_unsupported':
     case 'online_metadata_failed':

--- a/src/graph/graphClient.test.ts
+++ b/src/graph/graphClient.test.ts
@@ -157,6 +157,94 @@ describe('createGraphClient', () => {
     );
   });
 
+  it('resolves a replacement file by its exact saved path with segment encoding', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        id: 'new-item-id',
+        name: 'budget #100%.db',
+        parentReference: {
+          driveId: 'drive-123',
+          path: '/drive/root:/Finanzen 2026/Überblick',
+        },
+        file: {},
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(
+      client.resolveFileByPath({
+        driveId: 'drive-123',
+        itemId: 'old-item-id',
+        name: 'budget #100%.db',
+        parentPath: '/Finanzen 2026/Überblick',
+      }),
+    ).resolves.toEqual({
+      driveId: 'drive-123',
+      itemId: 'new-item-id',
+      name: 'budget #100%.db',
+      parentPath: '/Finanzen 2026/Überblick',
+    });
+
+    const [requestUrl] = getFetchCall(fetchFn);
+    expect(requestUrl).toBe(
+      'https://graph.microsoft.com/v1.0/drives/drive-123/root:/Finanzen%202026/%C3%9Cberblick/budget%20%23100%25.db?$select=id%2Cname%2CparentReference%2Cfile%2Cfolder',
+    );
+  });
+
+  it('resolves a root-level replacement without adding an empty path segment', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        id: 'new-item-id',
+        name: 'conspectus.db',
+        parentReference: {
+          driveId: 'drive-123',
+          path: '/drive/root:',
+        },
+        file: {},
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await client.resolveFileByPath({ ...DRIVE_ITEM_BINDING, parentPath: '/' });
+
+    expect(getFetchCall(fetchFn)[0]).toBe(
+      'https://graph.microsoft.com/v1.0/drives/drive-123/root:/conspectus.db?$select=id%2Cname%2CparentReference%2Cfile%2Cfolder',
+    );
+  });
+
+  it('treats a folder at the saved file path as a definitively missing file', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () =>
+      createJsonResponse({
+        id: 'folder-id',
+        name: 'conspectus.db',
+        parentReference: {
+          driveId: 'drive-123',
+          path: '/drive/root:/Apps/Conspectus',
+        },
+        folder: {},
+      }),
+    );
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.resolveFileByPath(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
+      code: 'not_found',
+    });
+  });
+
+  it('normalizes a missing exact path as not_found', async () => {
+    const authClient = createAuthClient();
+    const fetchFn = vi.fn(async () => createJsonResponse({}, 404));
+    const client = createGraphClient({ authClient, fetchFn });
+
+    await expect(client.resolveFileByPath(DRIVE_ITEM_BINDING)).rejects.toMatchObject({
+      code: 'not_found',
+      status: 404,
+    });
+  });
+
   it('follows paginated children responses until all browse items are loaded', async () => {
     const authClient = createAuthClient();
     const fetchFn = vi

--- a/src/graph/graphClient.ts
+++ b/src/graph/graphClient.ts
@@ -13,6 +13,7 @@ import type {
 
 const GRAPH_API_BASE_URL = 'https://graph.microsoft.com/v1.0';
 const CHILDREN_FIELDS = 'id,name,parentReference,file,folder';
+const FILE_BINDING_FIELDS = 'id,name,parentReference,file,folder';
 const METADATA_FIELDS = 'eTag,size,lastModifiedDateTime';
 const DOWNLOAD_URL_FIELDS = 'id,@microsoft.graph.downloadUrl';
 
@@ -123,6 +124,17 @@ const buildFolderChildrenUrl = (folder?: DriveFolderReference): string => {
   const driveId = encodeURIComponent(folder.driveId);
   const itemId = encodeURIComponent(folder.itemId);
   return `${GRAPH_API_BASE_URL}/drives/${driveId}/items/${itemId}/children`;
+};
+
+const encodeDrivePath = (parentPath: string, name: string): string =>
+  [...parentPath.split('/').filter((segment) => segment.length > 0), name]
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+
+const buildDriveItemPathUrl = (binding: DriveItemBinding): string => {
+  const driveId = encodeURIComponent(binding.driveId);
+  const itemPath = encodeDrivePath(binding.parentPath, binding.name);
+  return `${GRAPH_API_BASE_URL}/drives/${driveId}/root:/${itemPath}`;
 };
 
 const normalizeParentPath = (value: string): string => {
@@ -457,6 +469,35 @@ export const createGraphClient = (options: CreateGraphClientOptions): GraphClien
 
         return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
       });
+    },
+
+    async resolveFileByPath(binding): Promise<DriveItemBinding> {
+      const pathUrl = `${buildDriveItemPathUrl(binding)}?$select=${encodeURIComponent(FILE_BINDING_FIELDS)}`;
+      const response = await executeRequest(pathUrl);
+      const invalidResponseMessage =
+        'Microsoft Graph path lookup response did not include the required file fields.';
+      const payload = await readJsonPayload(response, invalidResponseMessage);
+      const item = normalizeDriveItem(payload, invalidResponseMessage);
+
+      if (item?.kind === 'folder') {
+        throw new GraphClientError(
+          'not_found',
+          getDefaultErrorMessage('not_found'),
+          undefined,
+          payload,
+        );
+      }
+
+      if (item === null) {
+        throw new GraphClientError('unknown', invalidResponseMessage, response.status, payload);
+      }
+
+      return {
+        driveId: item.driveId,
+        itemId: item.itemId,
+        name: item.name,
+        parentPath: item.parentPath,
+      };
     },
 
     async getFileMetadata(binding): Promise<GraphFileMetadata> {

--- a/src/graph/index.test.ts
+++ b/src/graph/index.test.ts
@@ -32,6 +32,7 @@ describe('graph barrel contract', () => {
     expect(client).toEqual(
       expect.objectContaining({
         listChildren: expect.any(Function),
+        resolveFileByPath: expect.any(Function),
         getFileMetadata: expect.any(Function),
         getFileDownloadUrl: expect.any(Function),
         downloadFile: expect.any(Function),

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -51,6 +51,7 @@ export interface GraphError {
 
 export interface GraphClient {
   listChildren(folder?: DriveFolderReference): Promise<readonly GraphDriveItem[]>;
+  resolveFileByPath(binding: DriveItemBinding): Promise<DriveItemBinding>;
   getFileMetadata(binding: DriveItemBinding): Promise<GraphFileMetadata>;
   getFileDownloadUrl(binding: DriveItemBinding): Promise<string>;
   downloadFile(

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -11,6 +11,9 @@
     "sessionExpiredTitle": "Microsoft-Sitzung abgelaufen",
     "reauthenticating": "Microsoft-Anmeldung wird geöffnet...",
     "reauthenticationFailed": "Die Microsoft-Anmeldung konnte nicht geöffnet werden. Versuche es erneut.",
+    "missingFileTitle": "OneDrive-Datenbank nicht gefunden",
+    "missingFileDescription": "Die Datenbank ist am gespeicherten Pfad nicht mehr verfügbar. Öffne die Einstellungen und wähle Datenbank ändern, um sie erneut auszuwählen.",
+    "selectAnotherFile": "Andere Datenbank auswählen",
     "downloadedKb": "{kb} KB heruntergeladen...",
     "downloadProgress": "{loaded} KB / {total} KB",
     "uploadedKb": "{kb} KB hochgeladen...",
@@ -211,6 +214,7 @@
       "checking": "Suche nach DB-Updates auf OneDrive...",
       "onlineUnchanged": "Zwischengespeicherte DB ist aktuell",
       "onlineChanged": "Neueste DB von OneDrive heruntergeladen.",
+      "fileMissing": "Die ausgewählte OneDrive-Datenbank ist am gespeicherten Pfad nicht mehr verfügbar. Wähle in den Einstellungen eine andere Datenbank aus.",
       "completed": "DB-Synchronisation abgeschlossen.",
       "failed": "Start-Synchronisation fehlgeschlagen.",
       "failedUnexpected": "Start-Synchronisation unerwartet fehlgeschlagen. Bitte prüfe die Browser-Konsole und versuche es erneut."

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -11,6 +11,9 @@
     "sessionExpiredTitle": "Microsoft session expired",
     "reauthenticating": "Opening Microsoft sign-in...",
     "reauthenticationFailed": "Microsoft sign-in could not be opened. Try again.",
+    "missingFileTitle": "OneDrive database not found",
+    "missingFileDescription": "The database is no longer available at its saved path. Open Settings and choose Change DB file to select it again.",
+    "selectAnotherFile": "Select another DB file",
     "downloadedKb": "{kb} KB downloaded...",
     "downloadProgress": "{loaded} KB / {total} KB",
     "uploadedKb": "{kb} KB uploaded...",
@@ -211,6 +214,7 @@
       "checking": "Checking OneDrive for DB updates...",
       "onlineUnchanged": "Cached DB is current with OneDrive.",
       "onlineChanged": "Downloaded the latest DB from OneDrive.",
+      "fileMissing": "The selected OneDrive database is no longer available at its saved path. Select another DB file in Settings.",
       "completed": "DB sync completed.",
       "failed": "Startup sync failed.",
       "failedUnexpected": "Startup sync failed unexpectedly. Check the browser console and retry."

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -229,6 +229,13 @@ type MockGraphClientOptions = {
   readonly metadataLastModifiedDateTime?: string;
   readonly downloadBytes?: readonly number[];
   readonly metadataErrorSequence?: readonly MockGraphError[];
+  readonly resolvedPathBinding?: {
+    readonly driveId: string;
+    readonly itemId: string;
+    readonly name: string;
+    readonly parentPath: string;
+  };
+  readonly resolvePathError?: MockGraphError;
   readonly downloadErrorSequence?: readonly MockGraphError[];
   readonly uploadErrorSequence?: readonly MockGraphError[];
   readonly uploadDelayMs?: number;
@@ -392,6 +399,7 @@ const installMockGraphClient = async (
 ): Promise<void> => {
   await page.addInitScript((mockOptions: MockGraphClientOptions) => {
     let listChildrenCallCount = 0;
+    let resolveFileByPathCallCount = 0;
     let getFileMetadataCallCount = 0;
     let downloadFileCallCount = 0;
     let uploadFileCallCount = 0;
@@ -481,6 +489,28 @@ const installMockGraphClient = async (
         }
 
         return rootItems;
+      },
+      async resolveFileByPath(binding: {
+        driveId: string;
+        itemId: string;
+        name: string;
+        parentPath: string;
+      }) {
+        resolveFileByPathCallCount += 1;
+        (
+          window as Window & { __CONSPECTUS_GRAPH_RESOLVE_PATH_CALL_COUNT__?: number }
+        ).__CONSPECTUS_GRAPH_RESOLVE_PATH_CALL_COUNT__ = resolveFileByPathCallCount;
+
+        if (mockOptions.resolvePathError !== undefined) {
+          throw mockOptions.resolvePathError;
+        }
+
+        return (
+          mockOptions.resolvedPathBinding ?? {
+            ...binding,
+            itemId: 'recovered-file-id',
+          }
+        );
       },
       async getFileMetadata() {
         getFileMetadataCallCount += 1;
@@ -602,6 +632,9 @@ const installMockGraphClient = async (
     (
       window as Window & { __CONSPECTUS_GRAPH_LIST_CHILDREN_CALL_COUNT__?: number }
     ).__CONSPECTUS_GRAPH_LIST_CHILDREN_CALL_COUNT__ = listChildrenCallCount;
+    (
+      window as Window & { __CONSPECTUS_GRAPH_RESOLVE_PATH_CALL_COUNT__?: number }
+    ).__CONSPECTUS_GRAPH_RESOLVE_PATH_CALL_COUNT__ = resolveFileByPathCallCount;
     (
       window as Window & { __CONSPECTUS_GRAPH_GET_FILE_METADATA_CALL_COUNT__?: number }
     ).__CONSPECTUS_GRAPH_GET_FILE_METADATA_CALL_COUNT__ = getFileMetadataCallCount;
@@ -1089,6 +1122,18 @@ const getGraphMetadataCallCount = async (page: import('@playwright/test').Page):
         __CONSPECTUS_GRAPH_GET_FILE_METADATA_CALL_COUNT__?: unknown;
       }
     ).__CONSPECTUS_GRAPH_GET_FILE_METADATA_CALL_COUNT__;
+    return typeof value === 'number' ? value : 0;
+  });
+
+const getGraphResolvePathCallCount = async (
+  page: import('@playwright/test').Page,
+): Promise<number> =>
+  page.evaluate(() => {
+    const value = (
+      window as Window & {
+        __CONSPECTUS_GRAPH_RESOLVE_PATH_CALL_COUNT__?: unknown;
+      }
+    ).__CONSPECTUS_GRAPH_RESOLVE_PATH_CALL_COUNT__;
     return typeof value === 'number' ? value : 0;
   });
 
@@ -1835,6 +1880,136 @@ test('shows download progress feedback during slow startup sync', async ({ page 
   // Wait for it to finish
   await expect(page.getByText('Downloaded the latest DB from OneDrive.')).toBeVisible();
   await expect(page.getByTestId('progress-indicator')).toHaveCount(0);
+});
+
+test('silently repairs a changed OneDrive item ID at the exact saved path', async ({ page }) => {
+  const oldBinding = {
+    driveId: 'drive-123',
+    itemId: 'old-safe-save-id',
+    name: 'conspectus.db',
+    parentPath: '/',
+  };
+  const recoveredBinding = { ...oldBinding, itemId: 'new-safe-save-id' };
+  await installMockAuthClient(page, { startAuthenticated: true });
+  await installMockGraphClient(page, {
+    metadataErrorSequence: [
+      createMockGraphError('not_found', 'Old safe-save item ID is gone.', 404),
+    ],
+    resolvedPathBinding: recoveredBinding,
+    metadataETag: '"etag-recovered"',
+  });
+  await installMockCacheStore(page, {
+    startupSnapshot: {
+      binding: oldBinding,
+      metadata: { eTag: '"etag-old"' },
+      dbBytes: createSqliteBytes([9, 9, 9]),
+    },
+  });
+  await installMockDbRuntime(page, {
+    accountRows: [
+      { accountId: 7, name: 'Recovered account', amountCents: 12_300, accountTypeId: 3 },
+    ],
+  });
+  await installPersistedBinding(page, oldBinding);
+  await installMockStartupNetworkState(page, true);
+
+  await page.goto(appPath('#/accounts'));
+
+  await expect(page.getByText('Downloaded the latest DB from OneDrive.')).toBeVisible();
+  await expect(page.getByText('Recovered account')).toBeVisible();
+  await expect(page.getByTestId('missing-file-recovery')).toHaveCount(0);
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const rawValue = window.localStorage.getItem('conspectus.selectedDriveItemBinding');
+        if (rawValue === null) {
+          return null;
+        }
+        return JSON.parse(rawValue).bindingsByAccountId['mock-home-account'];
+      }),
+    )
+    .toEqual(recoveredBinding);
+
+  await page.waitForTimeout(250);
+  expect(await getGraphResolvePathCallCount(page)).toBe(1);
+  expect(await getGraphMetadataCallCount(page)).toBe(2);
+  expect(await getGraphDownloadCallCount(page)).toBe(1);
+});
+
+test('keeps the app usable and offers rebind when the exact saved path is missing', async ({
+  page,
+}) => {
+  const oldBinding = {
+    driveId: 'drive-123',
+    itemId: 'deleted-item-id',
+    name: 'conspectus.db',
+    parentPath: '/',
+  };
+  await installMockAuthClient(page, { startAuthenticated: true });
+  await installMockGraphClient(page, {
+    metadataErrorSequence: [createMockGraphError('not_found', 'Deleted item ID.', 404)],
+    resolvePathError: createMockGraphError('not_found', 'No file at the saved path.', 404),
+  });
+  await installMockCacheStore(page, {
+    startupSnapshot: {
+      binding: oldBinding,
+      metadata: { eTag: '"etag-stale"' },
+      dbBytes: createSqliteBytes([8, 8, 8]),
+    },
+  });
+  await installMockDbRuntime(page, {
+    accountRows: [
+      { accountId: 8, name: 'Account after rebind', amountCents: 45_600, accountTypeId: 3 },
+    ],
+  });
+  await installPersistedBinding(page, oldBinding);
+  await installMockStartupNetworkState(page, true);
+
+  await page.goto(appPath('#/accounts'));
+
+  await expect(page.getByTestId('missing-file-recovery')).toBeVisible();
+  await expect(page.getByTestId('accounts-route-cards')).toHaveCount(0);
+  await expect(page.getByText('Account after rebind')).toHaveCount(0);
+  expect(await getGraphResolvePathCallCount(page)).toBe(1);
+  expect(await getGraphDownloadCallCount(page)).toBe(0);
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const rawValue = window.localStorage.getItem('conspectus.selectedDriveItemBinding');
+        return rawValue === null
+          ? null
+          : JSON.parse(rawValue).bindingsByAccountId['mock-home-account'].itemId;
+      }),
+    )
+    .toBe(oldBinding.itemId);
+
+  await page.getByTestId('missing-file-recovery-button').click();
+  await expect(page.getByTestId('route-settings')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Change DB file' })).toBeVisible();
+  await page.getByRole('button', { name: 'Change DB file' }).click();
+  await page.getByTestId('open-folder-folder-finance').click();
+  await page.getByTestId('select-file-file-finance-db').click();
+
+  await expect(page.getByTestId('missing-file-recovery')).toHaveCount(0);
+  await expect(page.getByText('Downloaded the latest DB from OneDrive.').last()).toBeVisible();
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const rawValue = window.localStorage.getItem('conspectus.selectedDriveItemBinding');
+        return rawValue === null
+          ? null
+          : JSON.parse(rawValue).bindingsByAccountId['mock-home-account'];
+      }),
+    )
+    .toMatchObject({
+      driveId: 'drive-123',
+      itemId: 'file-finance-db',
+      name: 'budget.db',
+      parentPath: '/Finance',
+    });
+
+  await page.getByRole('link', { name: 'Accounts' }).click();
+  await expect(page.getByText('Account after rebind')).toBeVisible();
 });
 
 test('retries transient startup metadata failures before settling on the cached DB state', async ({


### PR DESCRIPTION
# Pull Request

## Linked Issue (Required)

- Closes #79
- Milestone/issue: M7-05

## Context

- Problem: OneDrive desktop safe-saves can replace the database item ID while leaving the drive, path, and filename unchanged, causing the mobile binding to fail with a 404.
- Goal: Repair only that exact unchanged-path case automatically and provide a safe explicit rebind path when the file is definitively absent.

## Changes

- Added an exact saved-path Graph lookup with segment-safe URL encoding and file/folder response validation.
- Added fail-closed missing-file recovery orchestration that accepts only an unchanged drive/path/name with a different item ID.
- Persisted verified replacement bindings without launching an overlapping duplicate sync.
- Added localized, responsive missing-file recovery feedback that routes to the existing Settings rebind flow.
- Added unit, component, and Chromium/Pixel 5 E2E coverage for silent repair, definitive missing-file behavior, folder-at-path behavior, preserved stale state, and successful rebind.
- Bumped the app version to `0.7.05`, documented the implementation boundary, and marked M7-05 complete in the backlog.

## Acceptance Criteria

- [x] Silently self-heals when only the OneDrive item ID changed.
- [x] Missing files fail closed without opening stale cached rows or breaking Settings/navigation.
- [x] Users can select a replacement database through the existing rebind flow.
- [x] Renamed or moved files are never searched for or rebound automatically.

## Test Plan

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 446 app tests and 65 script tests passed.
- [x] `npm run build`
- [x] `npm run test:e2e` — 124 tests passed across Chromium and Pixel 5.
- Notes: The build retains the existing Vite chunk-size warning; no new build failure or budget gate was introduced.

## Screenshots

- [ ] UI change: screenshots attached
- [ ] No UI change
- Automated responsive browser coverage verifies the recovery notice and rebind path on Chromium and Pixel 5; no manual screenshot artifact was added.

## Risk Notes

- User impact: Users recover transparently from desktop safe-save item-ID replacement and receive an explicit Settings action when the exact saved path no longer contains a database file.
- Rollback plan: Revert commit `8f178ab`; the previous behavior will continue to fail closed on item-ID 404 responses.

## QS Checklist

- [x] Linked issue ID is included in this PR.
- [x] Lint, typecheck, tests, build, formatting, and E2E were run and pass.
- [ ] Screenshots are included for UI changes.
- [x] Risk and rollback notes are documented.
- [x] No secrets, tokens, or credentials were added to the repository.
- [x] No breaking path/base URL changes were introduced (preserves `/conspectus/webapp/` deployment behavior).

## Merge And Cleanup (PR Path)

- [ ] Required GitHub checks are green.
- [x] PR will be merged into `main` with Rebase and merge.
- [x] PR will be merged into `main` once checks/review requirements are satisfied.
- [x] Head branch will be deleted after merge.
- [x] Linked issue/backlog marker will only be considered done after merge.
