### PR TITLE
M8-01: enforce PWA security headers

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -9,8 +9,6 @@ env:
   WEBSITE_REPO_FULL_NAME: ${{ vars.WEBSITE_REPO_FULL_NAME || 'Jon2050/Jon2050_Webpage' }}
   PRODUCTION_SMOKE_MAX_ATTEMPTS: '24'
   PRODUCTION_SMOKE_RETRY_DELAY_SECONDS: '10'
-  # M8-01 must flip this to false when website hosting emits the required live security headers.
-  PRODUCTION_SMOKE_SKIP_SECURITY_HEADER_CHECKS: 'true'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 permissions:
@@ -269,4 +267,3 @@ jobs:
           --max-attempts ${{ env.PRODUCTION_SMOKE_MAX_ATTEMPTS }}
           --retry-delay-seconds ${{ env.PRODUCTION_SMOKE_RETRY_DELAY_SECONDS }}
           --request-timeout-ms 10000
-          --skip-security-header-checks ${{ env.PRODUCTION_SMOKE_SKIP_SECURITY_HEADER_CHECKS }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -155,6 +155,7 @@ jobs:
         with:
           name: ${{ steps.handoff.outputs.artifact_name }}
           if-no-files-found: error
+          include-hidden-files: true
           retention-days: 90
           path: dist
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -248,6 +248,7 @@ jobs:
         with:
           name: quality-preview-dist
           if-no-files-found: error
+          include-hidden-files: true
           path: dist
           retention-days: 7
 

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -789,6 +789,13 @@ Exit criteria:
 
 Goal: release with confidence on iOS and Android.
 
+M8-01 implementation clarification:
+
+- The PWA owns its production Apache response-header contract in `public/.htaccess`; Vite copies that file into every build artifact, and build verification rejects missing or incompatible header configuration.
+- The document CSP permits only the Svelte/Vite and runtime capabilities the app currently needs, including the narrower `script-src 'wasm-unsafe-eval'` permission for sql.js and explicit Microsoft login, Graph, and short-lived OneDrive download endpoints.
+- The production header CSP matches the document policy and adds `frame-ancestors 'none'`; Apache also emits `X-Content-Type-Options: nosniff` and `Referrer-Policy: strict-origin-when-cross-origin` for the PWA directory.
+- The website consumer validates and preserves the artifact-owned `.htaccess` before upload. Local Playwright serving and post-deploy smoke checks use the same response-header contract, so sql.js, the manifest, and the service worker are exercised under production-equivalent CSP constraints.
+
 Substeps:
 
 1. Security hardening:

--- a/docs/CI-CD-Pipelines.md
+++ b/docs/CI-CD-Pipelines.md
@@ -53,7 +53,7 @@ flowchart TD
 - Notes:
   - uses `actions/setup-node` npm cache and Playwright browser cache
   - cancels in-progress runs for the same ref via workflow concurrency
-  - `Build Verification` checks preview build output base-path correctness, manifest `start_url` and `scope`, service worker scope, CSP presence, and root-path leakage
+  - `Build Verification` checks preview build output base-path correctness, manifest `start_url` and `scope`, service worker scope, the document CSP and artifact-owned Apache security headers, and root-path leakage
   - `Quality Gate` is the single branch-protection check that should be required on `main`
 
 ### `Deploy Preview`
@@ -101,8 +101,9 @@ flowchart TD
   - rebuilds the app for production because the production base URL (`/conspectus/webapp/`) differs from the preview URLs
   - the website repo target defaults to `Jon2050/Jon2050_Webpage` and can be overridden with `WEBSITE_REPO_FULL_NAME`
   - production smoke target defaults to `https://jon2050.de/conspectus/webapp/` and can be overridden with `PRODUCTION_APP_BASE_URL`
-  - production smoke currently keeps live response-header verification explicitly disabled through `PRODUCTION_SMOKE_SKIP_SECURITY_HEADER_CHECKS: 'true'` because the website hosting layer does not yet emit the required `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy` headers for the PWA route
-  - `M8-01` owns enabling those live security headers in the hosting layer; once that is implemented, flip `PRODUCTION_SMOKE_SKIP_SECURITY_HEADER_CHECKS` to `false` or remove the flag so `verify-production-deploy-smoke.mjs` uses its strict default
+  - the production artifact includes the PWA-owned `/.htaccess` for `/conspectus/webapp/`; the website consumer validates and preserves it unchanged before upload
+  - production smoke fails unless the live app route returns the canonical `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` headers
+  - the CSP keeps general JavaScript evaluation disabled while allowing the narrower WebAssembly permission required by sql.js plus the Microsoft login, Graph, and OneDrive download endpoints used by the app
 
 ## GitHub-Managed Pages Workflow
 
@@ -130,6 +131,7 @@ flowchart TD
 - Producer: `Deploy Production`
 - Consumer: the website repository deploy workflow
 - Required metadata file: `deploy-metadata.json`
+- Required Apache security configuration: `.htaccess`
 - Required metadata fields:
   - `channel`
   - `basePath`

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -607,7 +607,7 @@ An issue is only considered done when:
 - Depends on: `M4-04, M4-05, M4-07, M4-08, M7-01`
 - GitHub: [#211](https://github.com/Jon2050/Conspectus-Mobile/issues/211)
 
-### :green_circle: M8-01 Implement CSP and security headers for PWA path
+### :white_check_mark: M8-01 Implement CSP and security headers for PWA path
 
 - Label: `security`
 - Milestone: `M8 - Hardening + QA + Release`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.7.07",
+  "version": "0.8.01",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.7.07",
+      "version": "0.8.01",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.7.07",
+  "version": "0.8.01",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ const webServerUrl = new URL(appBasePath, 'http://127.0.0.1:4173').toString();
 const webServerCommand =
   process.env.PLAYWRIGHT_WEB_SERVER_BUILD === '0'
     ? 'node scripts/serve-static-dist.mjs'
-    : 'npm run build && npm run preview -- --host=127.0.0.1 --port=4173 --strictPort';
+    : 'npm run build && node scripts/serve-static-dist.mjs';
 const includeIosWebkitProject = process.env.PLAYWRIGHT_INCLUDE_IOS_WEBKIT === '1';
 
 const projects = [
@@ -61,6 +61,7 @@ export default defineConfig({
     env: {
       ...process.env,
       DEPLOY_CHANNEL: 'production',
+      PLAYWRIGHT_APP_BASE_PATH: appBasePath,
       PLAYWRIGHT_WEB_SERVER_HOST: '127.0.0.1',
       PLAYWRIGHT_WEB_SERVER_PORT: '4173',
       VITE_AZURE_CLIENT_ID: process.env.VITE_AZURE_CLIENT_ID ?? 'playwright-test-client-id',

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,6 @@
+# Applies the PWA-owned security policy only within the deployed /conspectus/webapp directory.
+<IfModule mod_headers.c>
+  Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com https://*.1drv.com https://*.microsoftpersonalcontent.com; frame-src 'self' https://login.microsoftonline.com; worker-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+  Header always set X-Content-Type-Options "nosniff"
+  Header always set Referrer-Policy "strict-origin-when-cross-origin"
+</IfModule>

--- a/scripts/deploy-utils.test.ts
+++ b/scripts/deploy-utils.test.ts
@@ -147,6 +147,7 @@ describe('quality workflow contract', () => {
     expect(workflowSource).toContain('name: Quality Gate');
     expect(workflowSource).toContain('name: quality-preview-dist');
     expect(workflowSource).not.toContain('name: quality-production-dist');
+    expect(workflowSource).toContain('include-hidden-files: true');
     expect(workflowSource).toContain(
       "DEPLOY_PREVIEW_SLUG: ${{ github.ref_name == 'main' && 'main' || 'test' }}",
     );
@@ -195,6 +196,7 @@ describe('production workflow contracts', () => {
     expect(workflowSource).toContain(
       'artifact_name="conspectus-mobile-production-${{ steps.target.outputs.commit_sha }}"',
     );
+    expect(workflowSource).toContain('include-hidden-files: true');
     expect(workflowSource).toContain(
       '"qualityRunId": "${{ steps.quality_run.outputs.quality_run_id }}"',
     );

--- a/scripts/security-policy.d.mts
+++ b/scripts/security-policy.d.mts
@@ -1,0 +1,18 @@
+// Declares the shared deployment security policy helpers for TypeScript-based script tests.
+export const DOCUMENT_CSP: string;
+export const PRODUCTION_CSP: string;
+export const SECURITY_RESPONSE_HEADERS: Readonly<{
+  'Content-Security-Policy': string;
+  'X-Content-Type-Options': 'nosniff';
+  'Referrer-Policy': 'strict-origin-when-cross-origin';
+}>;
+
+export function assertCspEquivalent(
+  actualPolicy: string,
+  expectedPolicy: string,
+  label: string,
+): void;
+
+export function extractCspMetaContent(indexHtml: string): string;
+
+export function extractApacheHeaderValue(htaccessText: string, headerName: string): string;

--- a/scripts/security-policy.mjs
+++ b/scripts/security-policy.mjs
@@ -1,0 +1,89 @@
+// Defines and validates the CSP and response headers required by every PWA deployment channel.
+export const DOCUMENT_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'wasm-unsafe-eval'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "img-src 'self' data:",
+  "font-src 'self' https://fonts.gstatic.com",
+  "connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com https://*.1drv.com https://*.microsoftpersonalcontent.com",
+  "frame-src 'self' https://login.microsoftonline.com",
+  "worker-src 'self'",
+  "manifest-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join('; ');
+
+export const PRODUCTION_CSP = `${DOCUMENT_CSP}; frame-ancestors 'none'`;
+
+export const SECURITY_RESPONSE_HEADERS = Object.freeze({
+  'Content-Security-Policy': PRODUCTION_CSP,
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+});
+
+const parseCsp = (policyText) => {
+  const directives = new Map();
+
+  for (const rawDirective of policyText.split(';')) {
+    const tokens = rawDirective.trim().split(/\s+/u).filter(Boolean);
+    if (tokens.length === 0) {
+      continue;
+    }
+
+    const [name, ...sources] = tokens;
+    if (directives.has(name)) {
+      throw new Error(`Content-Security-Policy contains duplicate directive "${name}".`);
+    }
+
+    directives.set(name, sources);
+  }
+
+  return directives;
+};
+
+const normalizeCsp = (policyText) =>
+  [...parseCsp(policyText).entries()]
+    .sort(([leftName], [rightName]) => leftName.localeCompare(rightName))
+    .map(([name, sources]) => `${name} ${[...sources].sort().join(' ')}`)
+    .join('; ');
+
+export const assertCspEquivalent = (actualPolicy, expectedPolicy, label) => {
+  if (normalizeCsp(actualPolicy) !== normalizeCsp(expectedPolicy)) {
+    throw new Error(`${label} does not match the canonical security policy.`);
+  }
+};
+
+export const extractCspMetaContent = (indexHtml) => {
+  const cspMetaTag = indexHtml.match(
+    /<meta\s+[^>]*http-equiv=["']Content-Security-Policy["'][^>]*>/iu,
+  )?.[0];
+
+  if (!cspMetaTag) {
+    throw new Error('Missing Content-Security-Policy meta tag in index.html.');
+  }
+
+  const content =
+    cspMetaTag.match(/content="([^"]+)"/iu)?.[1] ??
+    cspMetaTag.match(/content='([^']+)'/iu)?.[1] ??
+    '';
+
+  if (!content.trim()) {
+    throw new Error('Content-Security-Policy meta tag must define a non-empty content value.');
+  }
+
+  return content;
+};
+
+export const extractApacheHeaderValue = (htaccessText, headerName) => {
+  const escapedHeaderName = headerName.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  const match = htaccessText.match(
+    new RegExp(`Header\\s+always\\s+set\\s+${escapedHeaderName}\\s+"([^"]+)"`, 'iu'),
+  );
+
+  if (!match?.[1]) {
+    throw new Error(`Apache security configuration is missing header "${headerName}".`);
+  }
+
+  return match[1];
+};

--- a/scripts/security-policy.test.ts
+++ b/scripts/security-policy.test.ts
@@ -1,0 +1,53 @@
+// Verifies canonical CSP comparison and Apache header extraction for deployment checks.
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertCspEquivalent,
+  DOCUMENT_CSP,
+  extractApacheHeaderValue,
+  extractCspMetaContent,
+} from './security-policy.mjs';
+
+describe('security policy helpers', () => {
+  it('treats directive and source ordering as equivalent', () => {
+    expect(() =>
+      assertCspEquivalent(
+        "script-src 'wasm-unsafe-eval' 'self'; default-src 'self'",
+        "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'",
+        'Test policy',
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects a policy that omits a required source', () => {
+    expect(() =>
+      assertCspEquivalent(
+        DOCUMENT_CSP.replace(" 'wasm-unsafe-eval'", ''),
+        DOCUMENT_CSP,
+        'Test policy',
+      ),
+    ).toThrow('does not match the canonical security policy');
+  });
+
+  it('rejects a policy that blocks the primary web font', () => {
+    expect(() =>
+      assertCspEquivalent(
+        DOCUMENT_CSP.replace(' https://fonts.gstatic.com', ''),
+        DOCUMENT_CSP,
+        'Test policy',
+      ),
+    ).toThrow('does not match the canonical security policy');
+  });
+
+  it('extracts the CSP meta value from HTML', () => {
+    const html = `<meta http-equiv="Content-Security-Policy" content="${DOCUMENT_CSP}" />`;
+
+    expect(extractCspMetaContent(html)).toBe(DOCUMENT_CSP);
+  });
+
+  it('extracts an Apache response header value', () => {
+    const htaccess = 'Header always set X-Content-Type-Options "nosniff"';
+
+    expect(extractApacheHeaderValue(htaccess, 'X-Content-Type-Options')).toBe('nosniff');
+  });
+});

--- a/scripts/serve-static-dist.mjs
+++ b/scripts/serve-static-dist.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { normalizeBasePath } from './deploy-utils.mjs';
+import { SECURITY_RESPONSE_HEADERS } from './security-policy.mjs';
 
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_PORT = 4173;
@@ -83,6 +84,12 @@ const readFileBuffer = (filePath) => fs.readFileSync(filePath);
 const resolveContentType = (filePath) =>
   MIME_TYPES.get(path.extname(filePath).toLowerCase()) ?? 'application/octet-stream';
 
+export const createResponseHeaders = (contentType) => ({
+  'Cache-Control': 'no-cache',
+  'Content-Type': contentType,
+  ...SECURITY_RESPONSE_HEADERS,
+});
+
 const createServer = ({ basePath, distDirectoryPath }) =>
   http.createServer((request, response) => {
     if (!request.url) {
@@ -112,10 +119,7 @@ const createServer = ({ basePath, distDirectoryPath }) =>
       return;
     }
 
-    response.writeHead(200, {
-      'Cache-Control': 'no-cache',
-      'Content-Type': resolveContentType(absoluteFilePath),
-    });
+    response.writeHead(200, createResponseHeaders(resolveContentType(absoluteFilePath)));
 
     if (request.method === 'HEAD') {
       response.end();

--- a/scripts/serve-static-dist.test.ts
+++ b/scripts/serve-static-dist.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 // @ts-expect-error -- .mjs import has no type declarations
-import { resolveRequestPath } from './serve-static-dist.mjs';
+import { createResponseHeaders, resolveRequestPath } from './serve-static-dist.mjs';
+import { PRODUCTION_CSP } from './security-policy.mjs';
 
 describe('resolveRequestPath', () => {
   it('serves index.html for the configured base path root', () => {
@@ -47,5 +48,16 @@ describe('resolveRequestPath', () => {
         '/Conspectus-Mobile/previews/test/',
       ),
     ).toBeNull();
+  });
+});
+
+describe('createResponseHeaders', () => {
+  it('serves the canonical production security headers', () => {
+    expect(createResponseHeaders('text/html; charset=utf-8')).toMatchObject({
+      'Content-Security-Policy': PRODUCTION_CSP,
+      'X-Content-Type-Options': 'nosniff',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
+      'Content-Type': 'text/html; charset=utf-8',
+    });
   });
 });

--- a/scripts/verify-build-channel.mjs
+++ b/scripts/verify-build-channel.mjs
@@ -4,6 +4,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { normalizeBasePath } from './deploy-utils.mjs';
+import {
+  assertCspEquivalent,
+  DOCUMENT_CSP,
+  extractApacheHeaderValue,
+  extractCspMetaContent,
+  PRODUCTION_CSP,
+  SECURITY_RESPONSE_HEADERS,
+} from './security-policy.mjs';
 
 const parseArgs = (argv) => {
   const args = {
@@ -225,81 +233,26 @@ const verifyServiceWorkerRegistration = (distDir, expectedBasePath) => {
   assert(hasScopedRegistration, `Service worker scope is not restricted to ${expectedBasePath}.`);
 };
 
-const extractCspMetaContent = (indexHtml) => {
-  const cspMetaTagMatch = indexHtml.match(
-    /<meta\s+[^>]*http-equiv=["']Content-Security-Policy["'][^>]*>/i,
-  );
-  assert(cspMetaTagMatch, 'Missing Content-Security-Policy meta tag in index.html.');
-
-  const cspMetaTag = cspMetaTagMatch[0];
-  const doubleQuotedContentMatch = cspMetaTag.match(/content="([^"]+)"/i);
-  const singleQuotedContentMatch = cspMetaTag.match(/content='([^']+)'/i);
-  const cspContent = doubleQuotedContentMatch?.[1] ?? singleQuotedContentMatch?.[1] ?? '';
-
-  assert(
-    Boolean(cspContent.trim()),
-    'Content-Security-Policy meta tag must define a non-empty content value.',
-  );
-
-  return cspContent;
-};
-
-const hasDirective = (policyText, directiveName) =>
-  new RegExp(`(?:^|;)\\s*${directiveName}\\s+[^;]+`).test(policyText);
-
-const extractDirectiveValue = (policyText, directiveName) => {
-  const directiveMatch = policyText.match(new RegExp(`(?:^|;)\\s*${directiveName}\\s+([^;]+)`));
-  return directiveMatch?.[1]?.trim() ?? null;
-};
-
 const verifyCspMetaTag = (indexHtml) => {
   const cspContent = extractCspMetaContent(indexHtml);
-  const requiredDirectives = [
-    'default-src',
-    'script-src',
-    'style-src',
-    'img-src',
-    'object-src',
-    'base-uri',
-  ];
-  const missingDirectives = requiredDirectives.filter(
-    (directiveName) => !hasDirective(cspContent, directiveName),
-  );
+  assertCspEquivalent(cspContent, DOCUMENT_CSP, 'Content-Security-Policy meta tag');
+};
 
-  assert(
-    missingDirectives.length === 0,
-    `Content-Security-Policy meta tag is missing required directive(s): ${missingDirectives.join(', ')}.`,
-  );
+const verifyApacheSecurityHeaders = (htaccessText) => {
+  const apacheCsp = extractApacheHeaderValue(htaccessText, 'Content-Security-Policy');
+  assertCspEquivalent(apacheCsp, PRODUCTION_CSP, 'Apache Content-Security-Policy header');
 
-  const scriptSourceDirectiveValue = extractDirectiveValue(cspContent, 'script-src');
-  assert(
-    scriptSourceDirectiveValue !== null &&
-      scriptSourceDirectiveValue.includes("'wasm-unsafe-eval'"),
-    "Content-Security-Policy script-src directive must include 'wasm-unsafe-eval' for sql.js WASM runtime support.",
-  );
+  for (const [headerName, expectedValue] of Object.entries(SECURITY_RESPONSE_HEADERS)) {
+    if (headerName === 'Content-Security-Policy') {
+      continue;
+    }
 
-  const connectSourceDirectiveValue = extractDirectiveValue(cspContent, 'connect-src');
-  const requiredConnectSources = [
-    "'self'",
-    'https://login.microsoftonline.com',
-    'https://graph.microsoft.com',
-    'https://*.1drv.com',
-    'https://*.microsoftpersonalcontent.com',
-  ];
-
-  assert(
-    connectSourceDirectiveValue !== null,
-    'Content-Security-Policy connect-src directive is required for auth and OneDrive download requests.',
-  );
-
-  const missingConnectSources = requiredConnectSources.filter(
-    (source) => !connectSourceDirectiveValue.includes(source),
-  );
-
-  assert(
-    missingConnectSources.length === 0,
-    `Content-Security-Policy connect-src directive is missing required source(s): ${missingConnectSources.join(', ')}.`,
-  );
+    const actualValue = extractApacheHeaderValue(htaccessText, headerName);
+    assert(
+      actualValue === expectedValue,
+      `Apache header "${headerName}" must be "${expectedValue}".`,
+    );
+  }
 };
 
 const main = () => {
@@ -307,11 +260,14 @@ const main = () => {
   const distDir = path.resolve(process.cwd(), args.dist);
   const indexPath = path.join(distDir, 'index.html');
   const manifestPath = path.join(distDir, 'manifest.webmanifest');
+  const htaccessPath = path.join(distDir, '.htaccess');
 
   const indexHtml = readTextFile(indexPath);
   const manifestText = readTextFile(manifestPath);
+  const htaccessText = readTextFile(htaccessPath);
 
   verifyCspMetaTag(indexHtml);
+  verifyApacheSecurityHeaders(htaccessText);
   verifyAbsolutePathReferences(indexHtml, args.base);
   verifyNoRootPathLeakage(distDir, args.base);
   verifyManifest(manifestText, args.base);

--- a/scripts/verify-build-channel.test.ts
+++ b/scripts/verify-build-channel.test.ts
@@ -5,6 +5,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import { DOCUMENT_CSP, PRODUCTION_CSP } from './security-policy.mjs';
+
 const thisFilePath = fileURLToPath(import.meta.url);
 const scriptsDirectoryPath = path.dirname(thisFilePath);
 const repositoryRootPath = path.resolve(scriptsDirectoryPath, '..');
@@ -19,11 +21,15 @@ const writeText = (filePath: string, value: string) => {
 
 type DistFixtureOptions = {
   includeCspMeta?: boolean;
+  includeHtaccess?: boolean;
   cspMetaContent?: string;
 };
 
-const BASE_CSP_META_CONTENT =
-  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com https://*.1drv.com https://*.microsoftpersonalcontent.com; object-src 'none'; base-uri 'self'";
+const VALID_HTACCESS = `<IfModule mod_headers.c>
+  Header always set Content-Security-Policy "${PRODUCTION_CSP}"
+  Header always set X-Content-Type-Options "nosniff"
+  Header always set Referrer-Policy "strict-origin-when-cross-origin"
+</IfModule>`;
 
 const createDistFixture = (
   fixtureRootPath: string,
@@ -33,7 +39,7 @@ const createDistFixture = (
   const distPath = path.join(fixtureRootPath, 'dist');
   const basePath = '/conspectus/webapp/';
   const includeCspMeta = options.includeCspMeta ?? true;
-  const cspMetaContent = options.cspMetaContent ?? BASE_CSP_META_CONTENT;
+  const cspMetaContent = options.cspMetaContent ?? DOCUMENT_CSP;
   const cspMetaTag = includeCspMeta
     ? `<meta http-equiv="Content-Security-Policy" content="${cspMetaContent}" />`
     : '';
@@ -69,6 +75,9 @@ const createDistFixture = (
 
   writeText(path.join(distPath, 'assets', 'index.css'), '.app { color: #111; }');
   writeText(path.join(distPath, 'assets', 'index.js'), jsAssetContent);
+  if (options.includeHtaccess ?? true) {
+    writeText(path.join(distPath, '.htaccess'), VALID_HTACCESS);
+  }
 
   return distPath;
 };
@@ -135,6 +144,33 @@ describe('verify-build-channel script', () => {
     }
   });
 
+  it('fails when the build output is missing the Apache security configuration', () => {
+    const fixturePath = createFixtureDirectory();
+
+    try {
+      const distPath = createDistFixture(
+        fixturePath,
+        `if ('serviceWorker' in navigator) { navigator.serviceWorker.register('/conspectus/webapp/sw.js', { scope: '/conspectus/webapp/' }); }`,
+        { includeHtaccess: false },
+      );
+
+      const result = runVerifier([
+        '--dist',
+        distPath,
+        '--channel',
+        'production',
+        '--base',
+        '/conspectus/webapp/',
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Missing expected file:');
+      expect(result.stderr).toContain('.htaccess');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
   it('fails when root-absolute asset paths leak outside expected base', () => {
     const fixturePath = createFixtureDirectory();
 
@@ -185,9 +221,7 @@ describe('verify-build-channel script', () => {
 
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(1);
-      expect(result.stderr).toContain(
-        "Content-Security-Policy script-src directive must include 'wasm-unsafe-eval' for sql.js WASM runtime support.",
-      );
+      expect(result.stderr).toContain('does not match the canonical security policy');
     } finally {
       rmSync(fixturePath, { force: true, recursive: true });
     }
@@ -217,9 +251,7 @@ describe('verify-build-channel script', () => {
 
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(1);
-      expect(result.stderr).toContain(
-        'Content-Security-Policy connect-src directive is missing required source(s): https://*.1drv.com, https://*.microsoftpersonalcontent.com.',
-      );
+      expect(result.stderr).toContain('does not match the canonical security policy');
     } finally {
       rmSync(fixturePath, { force: true, recursive: true });
     }
@@ -265,7 +297,7 @@ describe('verify-build-channel script', () => {
         `<!doctype html>
 <html lang="en">
   <head>
-    <meta http-equiv="Content-Security-Policy" content="${BASE_CSP_META_CONTENT}" />
+    <meta http-equiv="Content-Security-Policy" content="${DOCUMENT_CSP}" />
     <link rel="manifest" href="${previewBase}manifest.webmanifest" />
     <link rel="stylesheet" href="${previewBase}assets/index.css" />
   </head>
@@ -282,6 +314,7 @@ describe('verify-build-channel script', () => {
       );
 
       writeText(path.join(distPath, 'assets', 'index.css'), '.app { color: #111; }');
+      writeText(path.join(distPath, '.htaccess'), VALID_HTACCESS);
       writeText(
         path.join(distPath, 'assets', 'index.js'),
         `if ('serviceWorker' in navigator) { navigator.serviceWorker.register('${previewBase}sw.js', { scope: '${previewBase}' }); }`,
@@ -318,7 +351,7 @@ describe('verify-build-channel script', () => {
         `<!doctype html>
 <html lang="en">
   <head>
-    <meta http-equiv="Content-Security-Policy" content="${BASE_CSP_META_CONTENT}" />
+    <meta http-equiv="Content-Security-Policy" content="${DOCUMENT_CSP}" />
     <link rel="manifest" href="${basePath}manifest.webmanifest" />
     <link rel="stylesheet" href="${basePath}assets/index.css" />
   </head>
@@ -339,6 +372,7 @@ describe('verify-build-channel script', () => {
       );
 
       writeText(path.join(distPath, 'assets', 'index.css'), '.app { color: #111; }');
+      writeText(path.join(distPath, '.htaccess'), VALID_HTACCESS);
       writeText(
         path.join(distPath, 'assets', 'index.js'),
         `if ('serviceWorker' in navigator) { navigator.serviceWorker.register('${basePath}sw.js', { scope: '${basePath}' }); }`,

--- a/scripts/verify-production-deploy-smoke.d.mts
+++ b/scripts/verify-production-deploy-smoke.d.mts
@@ -5,7 +5,6 @@ export interface SmokeCheckOptions {
   maxAttempts: number;
   retryDelaySeconds: number;
   requestTimeoutMs: number;
-  skipSecurityHeaderChecks: boolean;
 }
 
 export type SleepFunction = (milliseconds: number) => Promise<void>;

--- a/scripts/verify-production-deploy-smoke.mjs
+++ b/scripts/verify-production-deploy-smoke.mjs
@@ -3,6 +3,12 @@
 import { setTimeout as delay } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 
+import {
+  assertCspEquivalent,
+  PRODUCTION_CSP,
+  SECURITY_RESPONSE_HEADERS,
+} from './security-policy.mjs';
+
 const REQUIRED_ARGS = new Set(['baseUrl', 'commitSha', 'deployRunId']);
 const REQUIRED_MONEYBAG_ICON_SPECS = [
   { src: 'icons/moneysack192x192.png', sizes: '192x192' },
@@ -34,7 +40,6 @@ export const parseArgs = (argv) => {
     maxAttempts: '24',
     retryDelaySeconds: '10',
     requestTimeoutMs: '10000',
-    skipSecurityHeaderChecks: 'false',
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -59,7 +64,6 @@ export const parseArgs = (argv) => {
   const maxAttempts = Number(args.maxAttempts);
   const retryDelaySeconds = Number(args.retryDelaySeconds);
   const requestTimeoutMs = Number(args.requestTimeoutMs);
-  const normalizedSkipSecurityHeaderChecks = args.skipSecurityHeaderChecks.trim().toLowerCase();
 
   assert(
     Number.isInteger(maxAttempts) && maxAttempts > 0,
@@ -73,11 +77,6 @@ export const parseArgs = (argv) => {
     Number.isInteger(requestTimeoutMs) && requestTimeoutMs > 0,
     '--request-timeout-ms must be a positive integer.',
   );
-  assert(
-    normalizedSkipSecurityHeaderChecks === 'true' || normalizedSkipSecurityHeaderChecks === 'false',
-    '--skip-security-header-checks must be "true" or "false".',
-  );
-
   return {
     baseUrl: normalizeBaseUrl(args.baseUrl),
     commitSha: args.commitSha,
@@ -85,7 +84,6 @@ export const parseArgs = (argv) => {
     maxAttempts,
     retryDelaySeconds,
     requestTimeoutMs,
-    skipSecurityHeaderChecks: normalizedSkipSecurityHeaderChecks === 'true',
   };
 };
 
@@ -100,6 +98,11 @@ const ensureSecurityHeaders = (headers, checkName) => {
     typeof contentSecurityPolicy === 'string' && contentSecurityPolicy.trim().length > 0,
     `${checkName} response missing required Content-Security-Policy header.`,
   );
+  assertCspEquivalent(
+    contentSecurityPolicy,
+    PRODUCTION_CSP,
+    `${checkName} Content-Security-Policy header`,
+  );
 
   const xContentTypeOptions = headers.get('x-content-type-options');
   assert(
@@ -110,8 +113,9 @@ const ensureSecurityHeaders = (headers, checkName) => {
 
   const referrerPolicy = headers.get('referrer-policy');
   assert(
-    typeof referrerPolicy === 'string' && referrerPolicy.trim().length > 0,
-    `${checkName} response missing required Referrer-Policy header.`,
+    referrerPolicy?.trim().toLowerCase() ===
+      SECURITY_RESPONSE_HEADERS['Referrer-Policy'].toLowerCase(),
+    `${checkName} response must set Referrer-Policy to "${SECURITY_RESPONSE_HEADERS['Referrer-Policy']}".`,
   );
 };
 
@@ -243,11 +247,7 @@ const createChecks = (options, setManifestIconUrls, setAppleTouchIconUrl) => [
   {
     name: 'app-route',
     url: options.baseUrl,
-    validateResponse: (response) => {
-      if (!options.skipSecurityHeaderChecks) {
-        ensureSecurityHeaders(response.headers, 'app-route');
-      }
-    },
+    validateResponse: (response) => ensureSecurityHeaders(response.headers, 'app-route'),
     validateBody: (bodyText) => {
       const appleTouchIconUrl = ensureBootstrapMarkers(bodyText, options);
       setAppleTouchIconUrl(appleTouchIconUrl);

--- a/scripts/verify-production-deploy-smoke.test.ts
+++ b/scripts/verify-production-deploy-smoke.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { parseArgs, runSmokeChecks } from './verify-production-deploy-smoke.mjs';
+import { PRODUCTION_CSP } from './security-policy.mjs';
 
 const baseOptions = {
   baseUrl: 'https://jon2050.de/conspectus/webapp/',
@@ -8,7 +9,6 @@ const baseOptions = {
   maxAttempts: 1,
   retryDelaySeconds: 0,
   requestTimeoutMs: 1000,
-  skipSecurityHeaderChecks: false,
 };
 
 const appHtml = `<!doctype html>
@@ -73,7 +73,7 @@ const createHealthyResponses = (): Record<string, MockHttpResponse> => ({
     status: 200,
     body: appHtml,
     headers: {
-      'content-security-policy': "default-src 'self'; frame-ancestors 'none'",
+      'content-security-policy': PRODUCTION_CSP,
       'x-content-type-options': 'nosniff',
       'referrer-policy': 'strict-origin-when-cross-origin',
     },
@@ -242,29 +242,28 @@ describe('verify-production-deploy-smoke script', () => {
     );
   });
 
-  it('skips security header validation when explicitly disabled', async () => {
+  it('fails when the CSP omits WebAssembly and OneDrive download permissions', async () => {
     const responses = createHealthyResponses();
-    responses['https://jon2050.de/conspectus/webapp/'].headers = {};
+    responses['https://jon2050.de/conspectus/webapp/'].headers = {
+      'content-security-policy':
+        "default-src 'self'; script-src 'self'; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com; frame-ancestors 'none'",
+      'x-content-type-options': 'nosniff',
+      'referrer-policy': 'strict-origin-when-cross-origin',
+    };
     const fetchMock = createFetchByUrl(responses);
     const sleepMock = vi.fn(async () => undefined);
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    await expect(
-      runSmokeChecks(
-        {
-          ...baseOptions,
-          skipSecurityHeaderChecks: true,
-        },
-        fetchMock,
-        sleepMock,
-      ),
-    ).resolves.toBeUndefined();
+    await expect(runSmokeChecks(baseOptions, fetchMock, sleepMock)).rejects.toThrow(
+      'does not match the canonical security policy',
+    );
   });
 
   it('fails when app-route response has invalid X-Content-Type-Options header', async () => {
     const responses = createHealthyResponses();
     responses['https://jon2050.de/conspectus/webapp/'].headers = {
-      'content-security-policy': "default-src 'self'; frame-ancestors 'none'",
+      'content-security-policy': PRODUCTION_CSP,
       'x-content-type-options': 'invalid',
       'referrer-policy': 'strict-origin-when-cross-origin',
     };
@@ -275,6 +274,23 @@ describe('verify-production-deploy-smoke script', () => {
 
     await expect(runSmokeChecks(baseOptions, fetchMock, sleepMock)).rejects.toThrow(
       'X-Content-Type-Options',
+    );
+  });
+
+  it('fails when app-route response has an invalid Referrer-Policy header', async () => {
+    const responses = createHealthyResponses();
+    responses['https://jon2050.de/conspectus/webapp/'].headers = {
+      'content-security-policy': PRODUCTION_CSP,
+      'x-content-type-options': 'nosniff',
+      'referrer-policy': 'unsafe-url',
+    };
+    const fetchMock = createFetchByUrl(responses);
+    const sleepMock = vi.fn(async () => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(runSmokeChecks(baseOptions, fetchMock, sleepMock)).rejects.toThrow(
+      'Referrer-Policy',
     );
   });
 
@@ -411,23 +427,7 @@ describe('verify-production-deploy-smoke script', () => {
       maxAttempts: 24,
       retryDelaySeconds: 10,
       requestTimeoutMs: 10000,
-      skipSecurityHeaderChecks: false,
     });
-  });
-
-  it('accepts explicit security-header check skip flag', () => {
-    const args = parseArgs([
-      '--base-url',
-      'https://jon2050.de/conspectus/webapp',
-      '--commit-sha',
-      'abc123',
-      '--deploy-run-id',
-      '2002',
-      '--skip-security-header-checks',
-      'true',
-    ]);
-
-    expect(args.skipSecurityHeaderChecks).toBe(true);
   });
 
   it('rejects non-https base URLs', () => {

--- a/scripts/verify-website-consumer-contract.mjs
+++ b/scripts/verify-website-consumer-contract.mjs
@@ -10,6 +10,8 @@ const REQUIRED_CONTRACT_MARKERS = [
   'conspectus-mobile-production-ready',
   'actions/runs/${DEPLOY_RUN_ID}',
   'validate-conspectus-deploy-metadata.mjs',
+  'validate-conspectus-security-headers.mjs',
+  '${incoming_dir}/.htaccess',
   'conspectus/webapp',
 ];
 

--- a/scripts/verify-website-consumer-contract.test.ts
+++ b/scripts/verify-website-consumer-contract.test.ts
@@ -53,6 +53,8 @@ const createValidWorkflow = () =>
     '      - name: Validate deploy metadata and identity',
     '        run: node ./scripts/validate-conspectus-deploy-metadata.mjs ./pwa-artifact/deploy-metadata.json',
     '      - name: Stage atomic replace for conspectus/webapp',
+    '        run: |',
+    '          node ./scripts/validate-conspectus-security-headers.mjs "${incoming_dir}/.htaccess"',
   ].join('\n');
 
 describe('verify-website-consumer-contract script', () => {
@@ -155,6 +157,31 @@ describe('verify-website-consumer-contract script', () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain('PRODUCER_REPO must be "Jon2050/Another-Repo"');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('fails when the consumer does not validate the PWA-owned security headers', () => {
+    const fixturePath = createFixtureDirectory();
+    const workflowJsonPath = path.join(fixturePath, 'workflow.json');
+
+    try {
+      const invalidWorkflow = createValidWorkflow().replace(
+        'validate-conspectus-security-headers.mjs',
+        'skip-security-header-validation.mjs',
+      );
+      writeFileSync(workflowJsonPath, encodeWorkflowPayload(invalidWorkflow));
+
+      const result = runVerifier([
+        '--workflow-json',
+        workflowJsonPath,
+        '--producer-repo',
+        'Jon2050/Conspectus-Mobile',
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('validate-conspectus-security-headers.mjs');
     } finally {
       rmSync(fixturePath, { force: true, recursive: true });
     }

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -3066,7 +3066,35 @@ test('falls back safely on invalid hash routes', async ({ page }) => {
 });
 
 test('exposes manifest and registers service worker', async ({ page }) => {
-  await page.goto(appPath());
+  await page.addInitScript(() => {
+    const violations: string[] = [];
+    Object.defineProperty(globalThis, '__conspectusCspViolations', { value: violations });
+    document.addEventListener('securitypolicyviolation', (event) => {
+      violations.push(`${event.effectiveDirective}: ${event.blockedURI}`);
+    });
+  });
+
+  const appResponse = await page.goto(appPath());
+  expect(appResponse?.status()).toBe(200);
+
+  const responseHeaders = appResponse?.headers() ?? {};
+  const documentCsp = await page
+    .locator('meta[http-equiv="Content-Security-Policy"]')
+    .getAttribute('content');
+  expect(documentCsp).toBeTruthy();
+  expect(responseHeaders['content-security-policy']).toBe(`${documentCsp}; frame-ancestors 'none'`);
+  expect(responseHeaders['x-content-type-options']).toBe('nosniff');
+  expect(responseHeaders['referrer-policy']).toBe('strict-origin-when-cross-origin');
+  await page.evaluate(async () => document.fonts.ready);
+  const cspViolations = await page.evaluate(
+    () =>
+      (
+        globalThis as typeof globalThis & {
+          __conspectusCspViolations?: string[];
+        }
+      ).__conspectusCspViolations ?? [],
+  );
+  expect(cspViolations).toEqual([]);
 
   const manifestResponse = await page.request.get(appPath('manifest.webmanifest'));
   expect(manifestResponse.ok()).toBeTruthy();


### PR DESCRIPTION
## Summary

- ship a PWA-owned Apache security-header contract in the production artifact
- enforce one canonical CSP across build verification, local Playwright serving, and live deployment smoke checks
- keep sql.js WebAssembly, MSAL, Microsoft Graph/OneDrive downloads, and the Outfit web font functional under CSP
- require the parent website consumer to validate and preserve the artifact-owned `.htaccess`
- update version `0.8.01`, architecture/deployment documentation, and the M8-01 backlog status

## Root cause and impact

The deployed PWA route did not emit CSP, MIME-sniffing protection, or a referrer policy. The previous website-side header injection also duplicated policy ownership and omitted capabilities required by sql.js and OneDrive downloads. This change makes the producer authoritative and fails build/deployment verification when the policy drifts.

## Acceptance criteria

- production CSP is active and exact, with `frame-ancestors 'none'`
- `script-src` permits `wasm-unsafe-eval` but not general `unsafe-eval`
- required Microsoft and web-font origins are explicit
- `X-Content-Type-Options: nosniff` and `Referrer-Policy: strict-origin-when-cross-origin` are enforced
- browser coverage runs the app under production-equivalent headers and rejects CSP violations
- live production smoke checks can no longer skip security-header validation

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 446 application tests and 73 script tests passed
- `npm run build`
- `npm run test:e2e` — 124 passed
- production build-channel verifier passed for `/conspectus/webapp/`
- cross-repository Senior Staff review: `APPROVED`
- parent website CI passed and dependency PR Jon2050/Jon2050_Webpage#24 is merged

Closes #82
