### PR TITLE
M8-01: support hosted security fallback

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -791,10 +791,10 @@ Goal: release with confidence on iOS and Android.
 
 M8-01 implementation clarification:
 
-- The PWA owns its production Apache response-header contract in `public/.htaccess`; Vite copies that file into every build artifact, and build verification rejects missing or incompatible header configuration.
+- The PWA owns its production response-header contract in `public/.htaccess` plus a PHP app-shell entrypoint for hosting packages without Apache `mod_headers`; Vite copies both files into every build artifact, and build verification rejects missing or incompatible configuration.
 - The document CSP permits only the Svelte/Vite and runtime capabilities the app currently needs, including the narrower `script-src 'wasm-unsafe-eval'` permission for sql.js and explicit Microsoft login, Graph, and short-lived OneDrive download endpoints.
-- The production header CSP matches the document policy and adds `frame-ancestors 'none'`; Apache also emits `X-Content-Type-Options: nosniff` and `Referrer-Policy: strict-origin-when-cross-origin` for the PWA directory.
-- The website consumer validates and preserves the artifact-owned `.htaccess` before upload. Local Playwright serving and post-deploy smoke checks use the same response-header contract, so sql.js, the manifest, and the service worker are exercised under production-equivalent CSP constraints.
+- The production header CSP matches the document policy and adds `frame-ancestors 'none'`; Apache emits the headers when `mod_headers` is available, while the preferred PHP app-shell entrypoint emits the same CSP, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` on the current shared-hosting package.
+- The website consumer validates and preserves the artifact-owned files, then requests the public staging path before promotion to prove that PHP executed and emitted the canonical headers. Local Playwright serving and post-deploy smoke checks use the same response-header contract, so sql.js, the manifest, and the service worker are exercised under production-equivalent CSP constraints.
 
 Substeps:
 

--- a/docs/CI-CD-Pipelines.md
+++ b/docs/CI-CD-Pipelines.md
@@ -101,7 +101,7 @@ flowchart TD
   - rebuilds the app for production because the production base URL (`/conspectus/webapp/`) differs from the preview URLs
   - the website repo target defaults to `Jon2050/Jon2050_Webpage` and can be overridden with `WEBSITE_REPO_FULL_NAME`
   - production smoke target defaults to `https://jon2050.de/conspectus/webapp/` and can be overridden with `PRODUCTION_APP_BASE_URL`
-  - the production artifact includes the PWA-owned `/.htaccess` for `/conspectus/webapp/`; the website consumer validates and preserves it unchanged before upload
+  - the production artifact includes the PWA-owned `/.htaccess` and PHP app-shell entrypoint for `/conspectus/webapp/`; the website consumer validates both before upload and proves the staged PHP response before promotion
   - production smoke fails unless the live app route returns the canonical `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` headers
   - the CSP keeps general JavaScript evaluation disabled while allowing the narrower WebAssembly permission required by sql.js plus the Microsoft login, Graph, and OneDrive download endpoints used by the app
 
@@ -132,6 +132,7 @@ flowchart TD
 - Consumer: the website repository deploy workflow
 - Required metadata file: `deploy-metadata.json`
 - Required Apache security configuration: `.htaccess`
+- Required PHP security entrypoint: `index.php`
 - Required metadata fields:
   - `channel`
   - `basePath`

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,6 @@
 # Applies the PWA-owned security policy only within the deployed /conspectus/webapp directory.
+DirectoryIndex index.php index.html
+
 <IfModule mod_headers.c>
   Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com https://*.1drv.com https://*.microsoftpersonalcontent.com; frame-src 'self' https://login.microsoftonline.com; worker-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
   Header always set X-Content-Type-Options "nosniff"

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+// Emits the app-shell headers when the hosting package does not provide Apache mod_headers.
+header("Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com https://*.1drv.com https://*.microsoftpersonalcontent.com; frame-src 'self' https://login.microsoftonline.com; worker-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'");
+header("X-Content-Type-Options: nosniff");
+header("Referrer-Policy: strict-origin-when-cross-origin");
+header("Content-Type: text/html; charset=utf-8");
+
+readfile(__DIR__ . '/index.html');

--- a/scripts/security-policy.d.mts
+++ b/scripts/security-policy.d.mts
@@ -16,3 +16,4 @@ export function assertCspEquivalent(
 export function extractCspMetaContent(indexHtml: string): string;
 
 export function extractApacheHeaderValue(htaccessText: string, headerName: string): string;
+export function extractPhpHeaderValue(phpText: string, headerName: string): string;

--- a/scripts/security-policy.mjs
+++ b/scripts/security-policy.mjs
@@ -87,3 +87,16 @@ export const extractApacheHeaderValue = (htaccessText, headerName) => {
 
   return match[1];
 };
+
+export const extractPhpHeaderValue = (phpText, headerName) => {
+  const escapedHeaderName = headerName.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  const match = phpText.match(
+    new RegExp(`header\\(\\s*(["'])${escapedHeaderName}:\\s*(.*?)\\1\\s*\\)`, 'iu'),
+  );
+
+  if (!match?.[2]) {
+    throw new Error(`PHP security entrypoint is missing header "${headerName}".`);
+  }
+
+  return match[2];
+};

--- a/scripts/security-policy.test.ts
+++ b/scripts/security-policy.test.ts
@@ -6,6 +6,7 @@ import {
   DOCUMENT_CSP,
   extractApacheHeaderValue,
   extractCspMetaContent,
+  extractPhpHeaderValue,
 } from './security-policy.mjs';
 
 describe('security policy helpers', () => {
@@ -49,5 +50,11 @@ describe('security policy helpers', () => {
     const htaccess = 'Header always set X-Content-Type-Options "nosniff"';
 
     expect(extractApacheHeaderValue(htaccess, 'X-Content-Type-Options')).toBe('nosniff');
+  });
+
+  it('extracts a PHP response header value containing CSP source quotes', () => {
+    const php = `header("Content-Security-Policy: ${DOCUMENT_CSP}");`;
+
+    expect(extractPhpHeaderValue(php, 'Content-Security-Policy')).toBe(DOCUMENT_CSP);
   });
 });

--- a/scripts/serve-static-dist.mjs
+++ b/scripts/serve-static-dist.mjs
@@ -72,6 +72,10 @@ export const resolveRequestPath = (requestPathname, basePath) => {
   }
 
   const resolvedPath = pathSegments.join('/');
+  if (resolvedPath === 'index.php') {
+    return 'index.html';
+  }
+
   if (path.posix.extname(resolvedPath)) {
     return resolvedPath;
   }

--- a/scripts/serve-static-dist.test.ts
+++ b/scripts/serve-static-dist.test.ts
@@ -11,6 +11,12 @@ describe('resolveRequestPath', () => {
     ).toBe('index.html');
   });
 
+  it('simulates the hosted PHP app-shell response for service worker precaching', () => {
+    expect(resolveRequestPath('/conspectus/webapp/index.php', '/conspectus/webapp/')).toBe(
+      'index.html',
+    );
+  });
+
   it('serves index.html for the configured base path without trailing slash', () => {
     expect(
       resolveRequestPath('/Conspectus-Mobile/previews/test', '/Conspectus-Mobile/previews/test/'),

--- a/scripts/verify-build-channel.mjs
+++ b/scripts/verify-build-channel.mjs
@@ -9,6 +9,7 @@ import {
   DOCUMENT_CSP,
   extractApacheHeaderValue,
   extractCspMetaContent,
+  extractPhpHeaderValue,
   PRODUCTION_CSP,
   SECURITY_RESPONSE_HEADERS,
 } from './security-policy.mjs';
@@ -233,12 +234,43 @@ const verifyServiceWorkerRegistration = (distDir, expectedBasePath) => {
   assert(hasScopedRegistration, `Service worker scope is not restricted to ${expectedBasePath}.`);
 };
 
+const verifyServiceWorkerNavigationFallback = (distDir, channel) => {
+  const serviceWorkerText = readTextFile(path.join(distDir, 'sw.js'));
+  if (channel === 'preview') {
+    assert(
+      /createHandlerBoundToURL\(["']index\.html["']\)/u.test(serviceWorkerText),
+      'Preview service worker navigation fallback must use the static index.html app shell.',
+    );
+    assert(
+      !/url:["']index\.php["']/u.test(serviceWorkerText),
+      'Preview service worker must not precache the unexecuted PHP entrypoint.',
+    );
+    return;
+  }
+
+  assert(
+    /url:["']index\.php["'],revision:["']\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z["']/u.test(
+      serviceWorkerText,
+    ),
+    'Service worker must revision index.php with the unique build timestamp.',
+  );
+  assert(
+    /createHandlerBoundToURL\(["']index\.php["']\)/u.test(serviceWorkerText),
+    'Service worker navigation fallback must use the header-emitting index.php app shell.',
+  );
+};
+
 const verifyCspMetaTag = (indexHtml) => {
   const cspContent = extractCspMetaContent(indexHtml);
   assertCspEquivalent(cspContent, DOCUMENT_CSP, 'Content-Security-Policy meta tag');
 };
 
 const verifyApacheSecurityHeaders = (htaccessText) => {
+  assert(
+    /^\s*DirectoryIndex\s+index\.php\s+index\.html\s*$/imu.test(htaccessText),
+    'Apache security configuration must prefer index.php before index.html.',
+  );
+
   const apacheCsp = extractApacheHeaderValue(htaccessText, 'Content-Security-Policy');
   assertCspEquivalent(apacheCsp, PRODUCTION_CSP, 'Apache Content-Security-Policy header');
 
@@ -255,23 +287,48 @@ const verifyApacheSecurityHeaders = (htaccessText) => {
   }
 };
 
+const verifyPhpSecurityEntrypoint = (phpText) => {
+  const phpCsp = extractPhpHeaderValue(phpText, 'Content-Security-Policy');
+  assertCspEquivalent(phpCsp, PRODUCTION_CSP, 'PHP Content-Security-Policy header');
+
+  for (const [headerName, expectedValue] of Object.entries(SECURITY_RESPONSE_HEADERS)) {
+    if (headerName === 'Content-Security-Policy') {
+      continue;
+    }
+
+    assert(
+      extractPhpHeaderValue(phpText, headerName) === expectedValue,
+      `PHP header "${headerName}" must be "${expectedValue}".`,
+    );
+  }
+
+  assert(
+    /readfile\(__DIR__\s*\.\s*['"]\/index\.html['"]\)/u.test(phpText),
+    'PHP security entrypoint must serve the generated index.html app shell.',
+  );
+};
+
 const main = () => {
   const args = parseArgs(process.argv.slice(2));
   const distDir = path.resolve(process.cwd(), args.dist);
   const indexPath = path.join(distDir, 'index.html');
   const manifestPath = path.join(distDir, 'manifest.webmanifest');
   const htaccessPath = path.join(distDir, '.htaccess');
+  const phpEntrypointPath = path.join(distDir, 'index.php');
 
   const indexHtml = readTextFile(indexPath);
   const manifestText = readTextFile(manifestPath);
   const htaccessText = readTextFile(htaccessPath);
+  const phpEntrypointText = readTextFile(phpEntrypointPath);
 
   verifyCspMetaTag(indexHtml);
   verifyApacheSecurityHeaders(htaccessText);
+  verifyPhpSecurityEntrypoint(phpEntrypointText);
   verifyAbsolutePathReferences(indexHtml, args.base);
   verifyNoRootPathLeakage(distDir, args.base);
   verifyManifest(manifestText, args.base);
   verifyServiceWorkerRegistration(distDir, args.base);
+  verifyServiceWorkerNavigationFallback(distDir, args.channel);
 
   console.log(
     `[verify-build-channel] ${args.channel} build output is valid for base path ${args.base}`,

--- a/scripts/verify-build-channel.test.ts
+++ b/scripts/verify-build-channel.test.ts
@@ -22,14 +22,27 @@ const writeText = (filePath: string, value: string) => {
 type DistFixtureOptions = {
   includeCspMeta?: boolean;
   includeHtaccess?: boolean;
+  includePhpEntrypoint?: boolean;
   cspMetaContent?: string;
 };
 
-const VALID_HTACCESS = `<IfModule mod_headers.c>
+const VALID_HTACCESS = `DirectoryIndex index.php index.html
+
+<IfModule mod_headers.c>
   Header always set Content-Security-Policy "${PRODUCTION_CSP}"
   Header always set X-Content-Type-Options "nosniff"
   Header always set Referrer-Policy "strict-origin-when-cross-origin"
 </IfModule>`;
+
+const VALID_PHP_ENTRYPOINT = `<?php
+header("Content-Security-Policy: ${PRODUCTION_CSP}");
+header("X-Content-Type-Options: nosniff");
+header("Referrer-Policy: strict-origin-when-cross-origin");
+readfile(__DIR__ . '/index.html');`;
+
+const VALID_SERVICE_WORKER =
+  'url:"index.php",revision:"2026-07-15T00:00:00Z";createHandlerBoundToURL("index.php")';
+const VALID_PREVIEW_SERVICE_WORKER = 'createHandlerBoundToURL("index.html")';
 
 const createDistFixture = (
   fixtureRootPath: string,
@@ -75,8 +88,12 @@ const createDistFixture = (
 
   writeText(path.join(distPath, 'assets', 'index.css'), '.app { color: #111; }');
   writeText(path.join(distPath, 'assets', 'index.js'), jsAssetContent);
+  writeText(path.join(distPath, 'sw.js'), VALID_SERVICE_WORKER);
   if (options.includeHtaccess ?? true) {
     writeText(path.join(distPath, '.htaccess'), VALID_HTACCESS);
+  }
+  if (options.includePhpEntrypoint ?? true) {
+    writeText(path.join(distPath, 'index.php'), VALID_PHP_ENTRYPOINT);
   }
 
   return distPath;
@@ -166,6 +183,91 @@ describe('verify-build-channel script', () => {
       expect(result.status).toBe(1);
       expect(result.stderr).toContain('Missing expected file:');
       expect(result.stderr).toContain('.htaccess');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('fails when the build output is missing the PHP security entrypoint', () => {
+    const fixturePath = createFixtureDirectory();
+
+    try {
+      const distPath = createDistFixture(
+        fixturePath,
+        `if ('serviceWorker' in navigator) { navigator.serviceWorker.register('/conspectus/webapp/sw.js', { scope: '/conspectus/webapp/' }); }`,
+        { includePhpEntrypoint: false },
+      );
+
+      const result = runVerifier([
+        '--dist',
+        distPath,
+        '--channel',
+        'production',
+        '--base',
+        '/conspectus/webapp/',
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Missing expected file:');
+      expect(result.stderr).toContain('index.php');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('fails when the PHP app shell revision is not unique to the build', () => {
+    const fixturePath = createFixtureDirectory();
+
+    try {
+      const distPath = createDistFixture(
+        fixturePath,
+        `if ('serviceWorker' in navigator) { navigator.serviceWorker.register('/conspectus/webapp/sw.js', { scope: '/conspectus/webapp/' }); }`,
+      );
+      writeText(
+        path.join(distPath, 'sw.js'),
+        'url:"index.php",revision:"0.8.01";createHandlerBoundToURL("index.php")',
+      );
+
+      const result = runVerifier([
+        '--dist',
+        distPath,
+        '--channel',
+        'production',
+        '--base',
+        '/conspectus/webapp/',
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        'Service worker must revision index.php with the unique build timestamp.',
+      );
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('fails when a preview service worker uses the PHP production app shell', () => {
+    const fixturePath = createFixtureDirectory();
+
+    try {
+      const distPath = createDistFixture(
+        fixturePath,
+        `if ('serviceWorker' in navigator) { navigator.serviceWorker.register('/conspectus/webapp/sw.js', { scope: '/conspectus/webapp/' }); }`,
+      );
+
+      const result = runVerifier([
+        '--dist',
+        distPath,
+        '--channel',
+        'preview',
+        '--base',
+        '/conspectus/webapp/',
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        'Preview service worker navigation fallback must use the static index.html app shell.',
+      );
     } finally {
       rmSync(fixturePath, { force: true, recursive: true });
     }
@@ -314,7 +416,9 @@ describe('verify-build-channel script', () => {
       );
 
       writeText(path.join(distPath, 'assets', 'index.css'), '.app { color: #111; }');
+      writeText(path.join(distPath, 'sw.js'), VALID_PREVIEW_SERVICE_WORKER);
       writeText(path.join(distPath, '.htaccess'), VALID_HTACCESS);
+      writeText(path.join(distPath, 'index.php'), VALID_PHP_ENTRYPOINT);
       writeText(
         path.join(distPath, 'assets', 'index.js'),
         `if ('serviceWorker' in navigator) { navigator.serviceWorker.register('${previewBase}sw.js', { scope: '${previewBase}' }); }`,
@@ -372,7 +476,9 @@ describe('verify-build-channel script', () => {
       );
 
       writeText(path.join(distPath, 'assets', 'index.css'), '.app { color: #111; }');
+      writeText(path.join(distPath, 'sw.js'), VALID_SERVICE_WORKER);
       writeText(path.join(distPath, '.htaccess'), VALID_HTACCESS);
+      writeText(path.join(distPath, 'index.php'), VALID_PHP_ENTRYPOINT);
       writeText(
         path.join(distPath, 'assets', 'index.js'),
         `if ('serviceWorker' in navigator) { navigator.serviceWorker.register('${basePath}sw.js', { scope: '${basePath}' }); }`,

--- a/scripts/verify-website-consumer-contract.mjs
+++ b/scripts/verify-website-consumer-contract.mjs
@@ -11,7 +11,9 @@ const REQUIRED_CONTRACT_MARKERS = [
   'actions/runs/${DEPLOY_RUN_ID}',
   'validate-conspectus-deploy-metadata.mjs',
   'validate-conspectus-security-headers.mjs',
+  'verify-conspectus-staging-response.mjs',
   '${incoming_dir}/.htaccess',
+  '${incoming_dir}/index.php',
   'conspectus/webapp',
 ];
 

--- a/scripts/verify-website-consumer-contract.test.ts
+++ b/scripts/verify-website-consumer-contract.test.ts
@@ -55,6 +55,9 @@ const createValidWorkflow = () =>
     '      - name: Stage atomic replace for conspectus/webapp',
     '        run: |',
     '          node ./scripts/validate-conspectus-security-headers.mjs "${incoming_dir}/.htaccess"',
+    '          test -f "${incoming_dir}/index.php"',
+    '      - name: Verify staged PWA response headers',
+    '        run: node ./scripts/verify-conspectus-staging-response.mjs',
   ].join('\n');
 
 describe('verify-website-consumer-contract script', () => {
@@ -182,6 +185,31 @@ describe('verify-website-consumer-contract script', () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain('validate-conspectus-security-headers.mjs');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('fails when the consumer does not verify staged live response headers', () => {
+    const fixturePath = createFixtureDirectory();
+    const workflowJsonPath = path.join(fixturePath, 'workflow.json');
+
+    try {
+      const invalidWorkflow = createValidWorkflow().replace(
+        'verify-conspectus-staging-response.mjs',
+        'skip-staging-response-validation.mjs',
+      );
+      writeFileSync(workflowJsonPath, encodeWorkflowPayload(invalidWorkflow));
+
+      const result = runVerifier([
+        '--workflow-json',
+        workflowJsonPath,
+        '--producer-repo',
+        'Jon2050/Conspectus-Mobile',
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('verify-conspectus-staging-response.mjs');
     } finally {
       rmSync(fixturePath, { force: true, recursive: true });
     }

--- a/scripts/viteConfig.test.ts
+++ b/scripts/viteConfig.test.ts
@@ -4,7 +4,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-import { loadBuildEnvironment, resolveBasePath, resolveViteBasePath } from '../vite.config';
+import {
+  loadBuildEnvironment,
+  resolveBasePath,
+  resolvePwaNavigationFallback,
+  resolveViteBasePath,
+} from '../vite.config';
 
 describe('resolveBasePath', () => {
   it('uses a VITE_DEPLOY_BASE_PATH value supplied by a local .env file', () => {
@@ -59,5 +64,12 @@ describe('resolveBasePath', () => {
 
     expect(resolveViteBasePath(environment, 'build', 'production')).toBe('/conspectus/webapp/');
     expect(resolveViteBasePath(environment, 'serve', 'production')).toBe('/conspectus/webapp/');
+  });
+});
+
+describe('resolvePwaNavigationFallback', () => {
+  it('uses a static app shell for previews and the security entrypoint for production', () => {
+    expect(resolvePwaNavigationFallback({ DEPLOY_CHANNEL: 'preview' })).toBe('index.html');
+    expect(resolvePwaNavigationFallback({ DEPLOY_CHANNEL: 'production' })).toBe('index.php');
   });
 });

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -3065,7 +3065,7 @@ test('falls back safely on invalid hash routes', async ({ page }) => {
   await expect(page.getByRole('heading', { level: 2, name: 'Accounts' })).toBeVisible();
 });
 
-test('exposes manifest and registers service worker', async ({ page }) => {
+test('exposes manifest and registers service worker', async ({ context, page }) => {
   await page.addInitScript(() => {
     const violations: string[] = [];
     Object.defineProperty(globalThis, '__conspectusCspViolations', { value: violations });
@@ -3176,6 +3176,25 @@ test('exposes manifest and registers service worker', async ({ page }) => {
       { timeout: 15_000 },
     )
     .toBe(expectedServiceWorkerScope);
+
+  await page.reload();
+  await expect
+    .poll(() => page.evaluate(() => Boolean(navigator.serviceWorker.controller)))
+    .toBeTruthy();
+
+  await context.setOffline(true);
+  try {
+    const offlineNavigationResponse = await page.reload();
+    expect(offlineNavigationResponse?.status()).toBe(200);
+    expect(offlineNavigationResponse?.headers()).toMatchObject({
+      'content-security-policy': `${documentCsp}; frame-ancestors 'none'`,
+      'x-content-type-options': 'nosniff',
+      'referrer-policy': 'strict-origin-when-cross-origin',
+    });
+    await expect(page.getByTestId('app-shell')).toBeVisible();
+  } finally {
+    await context.setOffline(false);
+  }
 });
 
 test('does not register service worker for parent-site routes outside the app base path', async ({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,6 +58,11 @@ export const resolveViteBasePath = (
   mode: string,
 ): string => (command === 'serve' && mode === 'development' ? '/' : resolveBasePath(environment));
 
+export const resolvePwaNavigationFallback = (
+  environment: Record<string, string | undefined>,
+): 'index.html' | 'index.php' =>
+  environment.DEPLOY_CHANNEL?.trim().toLowerCase() === 'preview' ? 'index.html' : 'index.php';
+
 export const loadBuildEnvironment = (
   mode: string,
   envDirectory: string = process.cwd(),
@@ -66,6 +71,7 @@ export const loadBuildEnvironment = (
 export default defineConfig(({ command, mode }) => {
   const environment = loadBuildEnvironment(mode);
   const basePath = resolveViteBasePath(environment, command, mode);
+  const navigationFallback = resolvePwaNavigationFallback(environment);
 
   return {
     base: basePath,
@@ -78,6 +84,13 @@ export default defineConfig(({ command, mode }) => {
       VitePWA({
         registerType: 'autoUpdate',
         scope: basePath,
+        workbox: {
+          additionalManifestEntries:
+            navigationFallback === 'index.php'
+              ? [{ url: navigationFallback, revision: appBuildTimeUtc }]
+              : [],
+          navigateFallback: navigationFallback,
+        },
         includeAssets: [
           'icons/moneysack.ico',
           'icons/moneysack180x180.png',


### PR DESCRIPTION
## Summary

- serve the production app shell through `index.php` so the canonical CSP, `nosniff`, and referrer-policy headers reach browsers on the current host
- retain `.htaccess` as the preferred Apache path and validate both security mechanisms in build and deployment contracts
- keep GitHub Pages previews static with an `index.html` service-worker fallback
- verify offline navigation headers and per-build Workbox cache invalidation

## Dependency

- Jon2050/Jon2050_Webpage#25 (merged)

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (446 application + 80 script tests)
- production and preview builds with channel-specific artifact verification
- `npm run test:e2e` (124 tests)
- independent review: APPROVED

Closes #82
