### PR TITLE
feat: [M8-02] Implement PWA service worker update flow

### DIFF
--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -796,6 +796,12 @@ M8-01 implementation clarification:
 - The optional Apache header CSP matches the document policy and adds `frame-ancestors 'none'`, plus `X-Content-Type-Options: nosniff` and `Referrer-Policy: strict-origin-when-cross-origin`. No PHP runtime is required by the production artifact.
 - The website consumer validates and preserves the artifact-owned files, then requests the public staging path before promotion to prove that the static app shell and its document policy are live. Local Playwright serving exercises the stricter optional header contract; post-deploy smoke checks use the policy that the free hosting package can enforce.
 
+M8-02 implementation clarification:
+
+- The generated service worker uses vite-plugin-pwa prompt mode so a waiting deployment never reloads an in-progress transfer form without user confirmation.
+- Active clients check for a new service worker once per hour, bypassing HTTP caches and skipping checks while offline or while another worker is installing.
+- A persistent, non-dismissible app-shell banner lets the user activate the waiting worker. Activation is single-flight, reloads after the new worker takes control, and remains retryable if activation fails.
+
 Substeps:
 
 1. Security hardening:

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -615,7 +615,7 @@ An issue is only considered done when:
 - Depends on: `M2-04`
 - GitHub: [#82](https://github.com/Jon2050/Conspectus-Mobile/issues/82)
 
-### :green_circle: M8-02 Implement PWA Service Worker Update Flow
+### :white_check_mark: M8-02 Implement PWA Service Worker Update Flow
 
 - Label: `feature`
 - Milestone: `M8 - Hardening + QA + Release`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.8.01",
+  "version": "0.8.02",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.8.01",
+      "version": "0.8.02",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.8.01",
+  "version": "0.8.02",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/scripts/viteConfig.test.ts
+++ b/scripts/viteConfig.test.ts
@@ -4,7 +4,18 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-import { loadBuildEnvironment, resolveBasePath, resolveViteBasePath } from '../vite.config';
+import {
+  PWA_REGISTER_TYPE,
+  loadBuildEnvironment,
+  resolveBasePath,
+  resolveViteBasePath,
+} from '../vite.config';
+
+describe('PWA update strategy', () => {
+  it('requires user confirmation before activating a waiting service worker', () => {
+    expect(PWA_REGISTER_TYPE).toBe('prompt');
+  });
+});
 
 describe('resolveBasePath', () => {
   it('uses a VITE_DEPLOY_BASE_PATH value supplied by a local .env file', () => {

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -19,6 +19,11 @@
   import AddRoute from './routes/AddRoute.svelte';
   import SettingsRoute from './routes/SettingsRoute.svelte';
   import ToastContainer from './components/ToastContainer.svelte';
+  import ServiceWorkerUpdateBanner from './components/ServiceWorkerUpdateBanner.svelte';
+  import {
+    appServiceWorkerUpdateController,
+    type ServiceWorkerUpdateController,
+  } from './serviceWorkerUpdateController';
   import { initializeAppAuthClient, resolveAppAuthClient } from './authClientResolver';
   import { resolveAppCacheStore } from './cacheStoreResolver';
   import { createCachedDatabaseSnapshotService } from './cachedDatabaseSnapshotService';
@@ -60,6 +65,8 @@
   export let routeStore: Readable<AppRouteKey> = createHashRouteStore();
   export let syncStateStore: SyncStateStore = appSyncStateStore;
   export let networkStateStore: NetworkStateStore = appNetworkStateStore;
+  export let serviceWorkerUpdateController: ServiceWorkerUpdateController =
+    appServiceWorkerUpdateController;
   export let addTransferSaveController: AddTransferSaveController =
     createAddTransferSaveController();
   export let loadingDelayMs = 160;
@@ -509,6 +516,8 @@
   <header class="app-header">
     <h1>{$_('appShell.title')}</h1>
   </header>
+
+  <ServiceWorkerUpdateBanner updateController={serviceWorkerUpdateController} />
 
   {#if staleTokenRecoveryIsRequired}
     <section class="auth-recovery" role="alert" data-testid="stale-token-recovery">

--- a/src/features/app-shell/AppShell.test.ts
+++ b/src/features/app-shell/AppShell.test.ts
@@ -5,6 +5,7 @@ import { render } from 'svelte/server';
 import { createSyncStateStore, formatBuildInfoLabel, getFallbackBuildInfo } from '@shared';
 
 import AppShell from './AppShell.svelte';
+import { createServiceWorkerUpdateController } from './serviceWorkerUpdateController';
 import { APP_ROUTES, type AppRouteKey } from './hashRouting';
 import type {
   AddTransferSaveController,
@@ -40,6 +41,22 @@ const createMockSaveController = (state: AddTransferSaveState): AddTransferSaveC
 });
 
 describe('AppShell component', () => {
+  it('shows an available app update globally before route content', () => {
+    const serviceWorkerUpdateController = createServiceWorkerUpdateController();
+    serviceWorkerUpdateController.notifyUpdateAvailable();
+
+    const { body } = render(AppShell, {
+      props: {
+        routeStore: readable<AppRouteKey>('accounts'),
+        serviceWorkerUpdateController,
+        showLoadingPlaceholder: false,
+      },
+    });
+
+    expect(body).toContain('data-testid="service-worker-update-banner"');
+    expect(body).toContain('data-testid="route-accounts"');
+  });
+
   it('renders loading placeholder before route placeholder content', () => {
     const { body } = render(AppShell);
 

--- a/src/features/app-shell/components/ServiceWorkerUpdateBanner.svelte
+++ b/src/features/app-shell/components/ServiceWorkerUpdateBanner.svelte
@@ -1,0 +1,84 @@
+<!-- Keeps a service-worker update visible and actionable until the new app shell takes control. -->
+<script lang="ts">
+  import { _ } from 'svelte-i18n';
+  import {
+    appServiceWorkerUpdateController,
+    type ServiceWorkerUpdateController,
+  } from '../serviceWorkerUpdateController';
+
+  export let updateController: ServiceWorkerUpdateController = appServiceWorkerUpdateController;
+</script>
+
+{#if $updateController.phase !== 'idle'}
+  <section
+    class="update-banner"
+    role="status"
+    aria-live="polite"
+    aria-busy={$updateController.phase === 'applying'}
+    data-testid="service-worker-update-banner"
+  >
+    <div>
+      <h2>{$_('appUpdate.title')}</h2>
+      <p>{$_('appUpdate.description')}</p>
+      {#if $updateController.phase === 'error'}
+        <p class="update-banner__error" role="alert" data-testid="service-worker-update-error">
+          {$_('appUpdate.error')}
+        </p>
+      {/if}
+    </div>
+    <button
+      type="button"
+      class="app-button app-button--primary"
+      disabled={$updateController.phase === 'applying'}
+      data-testid="service-worker-update-button"
+      on:click={() => void updateController.acceptUpdate()}
+    >
+      {$updateController.phase === 'applying'
+        ? $_('appUpdate.applying')
+        : $updateController.phase === 'error'
+          ? $_('appUpdate.retry')
+          : $_('appUpdate.action')}
+    </button>
+  </section>
+{/if}
+
+<style>
+  .update-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.875rem 1rem;
+    background: color-mix(in srgb, var(--accent) 12%, var(--surface-strong));
+    border-bottom: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  }
+
+  .update-banner h2,
+  .update-banner p {
+    margin: 0;
+  }
+
+  .update-banner h2 {
+    font-size: 1rem;
+  }
+
+  .update-banner p {
+    margin-top: 0.25rem;
+    color: var(--text-secondary);
+  }
+
+  .update-banner__error {
+    color: color-mix(in srgb, var(--negative) 72%, var(--text-primary));
+  }
+
+  @media (max-width: 36rem) {
+    .update-banner {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .update-banner :global(.app-button) {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/features/app-shell/components/ServiceWorkerUpdateBanner.test.ts
+++ b/src/features/app-shell/components/ServiceWorkerUpdateBanner.test.ts
@@ -1,0 +1,55 @@
+// Verifies the persistent update banner's hidden, actionable, busy, and retry states.
+import { render } from 'svelte/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createServiceWorkerUpdateController } from '../serviceWorkerUpdateController';
+import ServiceWorkerUpdateBanner from './ServiceWorkerUpdateBanner.svelte';
+
+describe('ServiceWorkerUpdateBanner component', () => {
+  it('stays hidden until a service worker update is available', () => {
+    const { body } = render(ServiceWorkerUpdateBanner, {
+      props: { updateController: createServiceWorkerUpdateController() },
+    });
+
+    expect(body).not.toContain('data-testid="service-worker-update-banner"');
+  });
+
+  it('renders a persistent accessible update action', () => {
+    const updateController = createServiceWorkerUpdateController();
+    updateController.notifyUpdateAvailable();
+
+    const { body } = render(ServiceWorkerUpdateBanner, { props: { updateController } });
+
+    expect(body).toContain('data-testid="service-worker-update-banner"');
+    expect(body).toContain('role="status"');
+    expect(body).toContain('aria-live="polite"');
+    expect(body).toContain('data-testid="service-worker-update-button"');
+    expect(body).toContain('type="button"');
+    expect(body).not.toContain('disabled');
+  });
+
+  it('disables duplicate activation while the waiting worker takes control', () => {
+    const updateController = createServiceWorkerUpdateController();
+    updateController.setUpdater(() => new Promise<void>(() => {}));
+    updateController.notifyUpdateAvailable();
+    void updateController.acceptUpdate();
+
+    const { body } = render(ServiceWorkerUpdateBanner, { props: { updateController } });
+
+    expect(body).toContain('aria-busy="true"');
+    expect(body).toContain('disabled');
+  });
+
+  it('keeps a failed update visible with an alert and retry action', async () => {
+    const updateController = createServiceWorkerUpdateController();
+    updateController.setUpdater(vi.fn().mockRejectedValue(new Error('failed')));
+    updateController.notifyUpdateAvailable();
+    await updateController.acceptUpdate();
+
+    const { body } = render(ServiceWorkerUpdateBanner, { props: { updateController } });
+
+    expect(body).toContain('data-testid="service-worker-update-error"');
+    expect(body).toContain('role="alert"');
+    expect(body).not.toContain('disabled');
+  });
+});

--- a/src/features/app-shell/components/index.ts
+++ b/src/features/app-shell/components/index.ts
@@ -4,3 +4,4 @@ export { default as ErrorBoundaryPlaceholder } from './ErrorBoundaryPlaceholder.
 export { default as LoadingPlaceholder } from './LoadingPlaceholder.svelte';
 export { default as SkeletonCard } from './SkeletonCard.svelte';
 export { default as ToastContainer } from './ToastContainer.svelte';
+export { default as ServiceWorkerUpdateBanner } from './ServiceWorkerUpdateBanner.svelte';

--- a/src/features/app-shell/serviceWorkerUpdateController.test.ts
+++ b/src/features/app-shell/serviceWorkerUpdateController.test.ts
@@ -1,0 +1,67 @@
+// Verifies update notifications remain actionable and service-worker activation is single-flight.
+import { get } from 'svelte/store';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createServiceWorkerUpdateController } from './serviceWorkerUpdateController';
+
+describe('serviceWorkerUpdateController', () => {
+  it('starts idle and exposes a new update persistently', () => {
+    const controller = createServiceWorkerUpdateController();
+
+    expect(get(controller)).toEqual({ phase: 'idle' });
+
+    controller.notifyUpdateAvailable();
+
+    expect(get(controller)).toEqual({ phase: 'available' });
+  });
+
+  it('activates the waiting worker once while an update is applying', async () => {
+    let finishUpdate: (() => void) | undefined;
+    const updater = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishUpdate = resolve;
+        }),
+    );
+    const controller = createServiceWorkerUpdateController();
+    controller.setUpdater(updater);
+    controller.notifyUpdateAvailable();
+
+    const firstAttempt = controller.acceptUpdate();
+    const duplicateAttempt = controller.acceptUpdate();
+
+    expect(get(controller)).toEqual({ phase: 'applying' });
+    expect(updater).toHaveBeenCalledTimes(1);
+    expect(updater).toHaveBeenCalledWith(true);
+
+    finishUpdate?.();
+    await Promise.all([firstAttempt, duplicateAttempt]);
+    expect(get(controller)).toEqual({ phase: 'applying' });
+  });
+
+  it('keeps a failed activation visible and retryable', async () => {
+    const updater = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('activation failed'))
+      .mockResolvedValueOnce();
+    const controller = createServiceWorkerUpdateController();
+    controller.setUpdater(updater);
+    controller.notifyUpdateAvailable();
+
+    await controller.acceptUpdate();
+    expect(get(controller)).toEqual({ phase: 'error' });
+
+    await controller.acceptUpdate();
+    expect(updater).toHaveBeenCalledTimes(2);
+    expect(get(controller)).toEqual({ phase: 'applying' });
+  });
+
+  it('keeps the prompt retryable when activation is requested before setup completes', async () => {
+    const controller = createServiceWorkerUpdateController();
+    controller.notifyUpdateAvailable();
+
+    await controller.acceptUpdate();
+
+    expect(get(controller)).toEqual({ phase: 'error' });
+  });
+});

--- a/src/features/app-shell/serviceWorkerUpdateController.ts
+++ b/src/features/app-shell/serviceWorkerUpdateController.ts
@@ -1,0 +1,64 @@
+// Holds the persistent service-worker update prompt state and activates a waiting worker once.
+import { writable } from 'svelte/store';
+
+export type ServiceWorkerUpdater = (reloadPage?: boolean) => Promise<void>;
+export type ServiceWorkerUpdatePhase = 'idle' | 'available' | 'applying' | 'error';
+
+export interface ServiceWorkerUpdateState {
+  phase: ServiceWorkerUpdatePhase;
+}
+
+export interface ServiceWorkerUpdateController {
+  subscribe: ReturnType<typeof writable<ServiceWorkerUpdateState>>['subscribe'];
+  setUpdater(updater: ServiceWorkerUpdater): void;
+  notifyUpdateAvailable(): void;
+  acceptUpdate(): Promise<void>;
+}
+
+const INITIAL_STATE: ServiceWorkerUpdateState = { phase: 'idle' };
+
+export const createServiceWorkerUpdateController = (): ServiceWorkerUpdateController => {
+  const { subscribe, set, update } = writable<ServiceWorkerUpdateState>(INITIAL_STATE);
+  let updater: ServiceWorkerUpdater | null = null;
+
+  const setUpdater = (nextUpdater: ServiceWorkerUpdater): void => {
+    updater = nextUpdater;
+  };
+
+  const notifyUpdateAvailable = (): void => {
+    set({ phase: 'available' });
+  };
+
+  const acceptUpdate = async (): Promise<void> => {
+    let shouldApply = false;
+    update((state) => {
+      shouldApply = state.phase === 'available' || state.phase === 'error';
+      return shouldApply ? { phase: 'applying' } : state;
+    });
+
+    if (!shouldApply) {
+      return;
+    }
+
+    if (updater === null) {
+      set({ phase: 'error' });
+      return;
+    }
+
+    try {
+      await updater(true);
+    } catch (error) {
+      console.error('Activating the service worker update failed.', error);
+      set({ phase: 'error' });
+    }
+  };
+
+  return {
+    subscribe,
+    setUpdater,
+    notifyUpdateAvailable,
+    acceptUpdate,
+  };
+};
+
+export const appServiceWorkerUpdateController = createServiceWorkerUpdateController();

--- a/src/features/app-shell/serviceWorkerUpdateRegistration.test.ts
+++ b/src/features/app-shell/serviceWorkerUpdateRegistration.test.ts
@@ -1,0 +1,118 @@
+// Verifies service-worker callback wiring and guarded periodic update checks for active clients.
+import type { RegisterSWOptions } from 'vite-plugin-pwa/types';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createServiceWorkerUpdateController } from './serviceWorkerUpdateController';
+import {
+  checkForServiceWorkerUpdate,
+  registerServiceWorkerUpdates,
+  SERVICE_WORKER_UPDATE_INTERVAL_MS,
+} from './serviceWorkerUpdateRegistration';
+
+const createRegistration = (installing: ServiceWorker | null = null) =>
+  ({
+    installing,
+    update: vi.fn().mockResolvedValue(undefined),
+  }) as unknown as ServiceWorkerRegistration;
+
+describe('serviceWorkerUpdateRegistration', () => {
+  it('wires prompt and activation callbacks and schedules hourly active-client checks', async () => {
+    let capturedOptions: RegisterSWOptions | undefined;
+    const updater = vi.fn().mockResolvedValue(undefined);
+    const registerServiceWorker = vi.fn((options?: RegisterSWOptions) => {
+      capturedOptions = options;
+      return updater;
+    });
+    const controller = createServiceWorkerUpdateController();
+    const notifyUpdateAvailable = vi.spyOn(controller, 'notifyUpdateAvailable');
+    const scheduleInterval = vi.fn(() => 1 as unknown as ReturnType<typeof setInterval>);
+
+    registerServiceWorkerUpdates(registerServiceWorker, controller, {
+      fetchServiceWorker: vi.fn(),
+      isOnline: () => true,
+      scheduleInterval,
+    });
+
+    expect(capturedOptions?.immediate).toBe(true);
+    capturedOptions?.onNeedRefresh?.();
+    expect(notifyUpdateAvailable).toHaveBeenCalledOnce();
+
+    capturedOptions?.onRegisteredSW?.('/sw.js', createRegistration());
+    expect(scheduleInterval).toHaveBeenCalledWith(
+      expect.any(Function),
+      SERVICE_WORKER_UPDATE_INTERVAL_MS,
+    );
+
+    controller.notifyUpdateAvailable();
+    await controller.acceptUpdate();
+    expect(updater).toHaveBeenCalledWith(true);
+  });
+
+  it('does not schedule checks when registration is unavailable', () => {
+    let capturedOptions: RegisterSWOptions | undefined;
+    const scheduleInterval = vi.fn();
+
+    registerServiceWorkerUpdates(
+      (options) => {
+        capturedOptions = options;
+        return vi.fn();
+      },
+      createServiceWorkerUpdateController(),
+      { scheduleInterval },
+    );
+
+    capturedOptions?.onRegisteredSW?.('/sw.js', undefined);
+    expect(scheduleInterval).not.toHaveBeenCalled();
+  });
+});
+
+describe('checkForServiceWorkerUpdate', () => {
+  it('bypasses HTTP caches before asking the browser to update the worker', async () => {
+    const registration = createRegistration();
+    const fetchServiceWorker = vi.fn().mockResolvedValue({ status: 200 });
+
+    await checkForServiceWorkerUpdate('/sw.js', registration, fetchServiceWorker, () => true);
+
+    expect(fetchServiceWorker).toHaveBeenCalledWith('/sw.js', {
+      cache: 'no-store',
+      headers: {
+        cache: 'no-store',
+        'cache-control': 'no-cache',
+      },
+    });
+    expect(registration.update).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { name: 'the client is offline', installing: null, online: false },
+    { name: 'another worker is installing', installing: {} as ServiceWorker, online: true },
+  ])('skips the check when $name', async ({ installing, online }) => {
+    const registration = createRegistration(installing);
+    const fetchServiceWorker = vi.fn();
+
+    await checkForServiceWorkerUpdate('/sw.js', registration, fetchServiceWorker, () => online);
+
+    expect(fetchServiceWorker).not.toHaveBeenCalled();
+    expect(registration.update).not.toHaveBeenCalled();
+  });
+
+  it('ignores unavailable worker responses and transient check failures', async () => {
+    const unavailableRegistration = createRegistration();
+    await checkForServiceWorkerUpdate(
+      '/sw.js',
+      unavailableRegistration,
+      vi.fn().mockResolvedValue({ status: 503 }),
+      () => true,
+    );
+    expect(unavailableRegistration.update).not.toHaveBeenCalled();
+
+    const failedRegistration = createRegistration();
+    await checkForServiceWorkerUpdate(
+      '/sw.js',
+      failedRegistration,
+      vi.fn().mockRejectedValue(new Error('offline')),
+      () => true,
+    );
+    expect(failedRegistration.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/app-shell/serviceWorkerUpdateRegistration.ts
+++ b/src/features/app-shell/serviceWorkerUpdateRegistration.ts
@@ -1,0 +1,84 @@
+// Connects vite-plugin-pwa registration callbacks to update UI state and periodic active-client checks.
+import type { RegisterSWOptions } from 'vite-plugin-pwa/types';
+
+import {
+  appServiceWorkerUpdateController,
+  type ServiceWorkerUpdateController,
+  type ServiceWorkerUpdater,
+} from './serviceWorkerUpdateController';
+
+export const SERVICE_WORKER_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
+
+type RegisterServiceWorker = (options?: RegisterSWOptions) => ServiceWorkerUpdater;
+type IntervalScheduler = (callback: () => void, delayMs: number) => ReturnType<typeof setInterval>;
+
+export interface ServiceWorkerUpdateRegistrationDependencies {
+  fetchServiceWorker?: typeof fetch;
+  isOnline?: () => boolean;
+  scheduleInterval?: IntervalScheduler;
+  updateIntervalMs?: number;
+}
+
+export const checkForServiceWorkerUpdate = async (
+  serviceWorkerUrl: string,
+  registration: ServiceWorkerRegistration,
+  fetchServiceWorker: typeof fetch,
+  isOnline: () => boolean,
+): Promise<void> => {
+  if (registration.installing !== null || !isOnline()) {
+    return;
+  }
+
+  try {
+    const response = await fetchServiceWorker(serviceWorkerUrl, {
+      cache: 'no-store',
+      headers: {
+        cache: 'no-store',
+        'cache-control': 'no-cache',
+      },
+    });
+
+    if (response.status === 200) {
+      await registration.update();
+    }
+  } catch (error) {
+    console.warn('Checking for a service worker update failed.', error);
+  }
+};
+
+export const registerServiceWorkerUpdates = (
+  registerServiceWorker: RegisterServiceWorker,
+  controller: ServiceWorkerUpdateController = appServiceWorkerUpdateController,
+  dependencies: ServiceWorkerUpdateRegistrationDependencies = {},
+): void => {
+  const fetchServiceWorker = dependencies.fetchServiceWorker ?? globalThis.fetch.bind(globalThis);
+  const isOnline = dependencies.isOnline ?? (() => navigator.onLine);
+  const scheduleInterval = dependencies.scheduleInterval ?? globalThis.setInterval.bind(globalThis);
+  const updateIntervalMs = dependencies.updateIntervalMs ?? SERVICE_WORKER_UPDATE_INTERVAL_MS;
+
+  const updater = registerServiceWorker({
+    immediate: true,
+    onNeedRefresh: () => {
+      controller.notifyUpdateAvailable();
+    },
+    onRegisteredSW: (serviceWorkerUrl, registration) => {
+      if (registration === undefined) {
+        return;
+      }
+
+      scheduleInterval(() => {
+        void checkForServiceWorkerUpdate(
+          serviceWorkerUrl,
+          registration,
+          fetchServiceWorker,
+          isOnline,
+        );
+      }, updateIntervalMs);
+    },
+    onRegisterError: (error) => {
+      console.error('Service worker registration failed.', error);
+    },
+  });
+
+  controller.setUpdater(updater);
+};

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -20,6 +20,14 @@
     "uploadProgress": "{loaded} KB / {total} KB hochgeladen",
     "title": "Conspectus Mobile"
   },
+  "appUpdate": {
+    "title": "Update verfügbar",
+    "description": "Eine neue Version ist bereit. Schließe einen ungespeicherten Transfer ab und aktualisiere dann die App.",
+    "action": "Jetzt aktualisieren",
+    "applying": "Wird aktualisiert...",
+    "retry": "Update erneut versuchen",
+    "error": "Das Update konnte nicht aktiviert werden. Die aktuelle Version läuft weiter; versuche es erneut."
+  },
   "accounts": {
     "title": "Konten",
     "loading": "Konten werden geladen...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -20,6 +20,14 @@
     "uploadProgress": "{loaded} KB / {total} KB uploaded",
     "title": "Conspectus Mobile"
   },
+  "appUpdate": {
+    "title": "Update available",
+    "description": "A new version is ready. Finish any unsaved transfer, then update to load it.",
+    "action": "Update now",
+    "applying": "Updating...",
+    "retry": "Retry update",
+    "error": "The update could not be activated. Your current version is still running; try again."
+  },
   "accounts": {
     "title": "Accounts",
     "loading": "Loading accounts from the local database...",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { mount } from 'svelte';
 import { registerSW } from 'virtual:pwa-register';
 import { RuntimeEnvError, loadRuntimeEnv } from '@shared';
+import { registerServiceWorkerUpdates } from './features/app-shell/serviceWorkerUpdateRegistration';
 import { syncRootDocumentLanguage } from './i18n';
 import './app.css';
 import App from './App.svelte';
@@ -40,7 +41,7 @@ let app: ReturnType<typeof mount> | undefined;
 try {
   syncRootDocumentLanguage();
   loadRuntimeEnv();
-  registerSW({ immediate: true });
+  registerServiceWorkerUpdates(registerSW);
 
   app = mount(App, {
     target: appRoot,

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -3196,6 +3196,62 @@ test('exposes manifest and registers service worker', async ({ context, page }) 
   }
 });
 
+test('prompts for an available service worker update and reloads into it', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium', 'One real-worker update smoke is sufficient.');
+
+  const serviceWorkerPath = path.join(process.cwd(), 'dist', 'sw.js');
+  const originalServiceWorker = fs.readFileSync(serviceWorkerPath, 'utf8');
+
+  try {
+    await page.goto(appPath());
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async (appBasePath) => {
+            const registration = await navigator.serviceWorker.getRegistration(appBasePath);
+            return Boolean(registration?.active);
+          }, APP_BASE_PATH),
+        { timeout: 15_000 },
+      )
+      .toBeTruthy();
+
+    await page.reload();
+    await expect
+      .poll(() => page.evaluate(() => Boolean(navigator.serviceWorker.controller)))
+      .toBeTruthy();
+
+    fs.writeFileSync(
+      serviceWorkerPath,
+      `${originalServiceWorker}\n// playwright-update-${Date.now()}\n`,
+    );
+
+    await page.evaluate(async (appBasePath) => {
+      const registration = await navigator.serviceWorker.getRegistration(appBasePath);
+      if (!registration) {
+        throw new Error('Expected an active service worker registration.');
+      }
+      await registration.update();
+    }, APP_BASE_PATH);
+
+    await expect(page.getByTestId('service-worker-update-banner')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByTestId('service-worker-update-button')).toHaveText('Update now');
+
+    await Promise.all([
+      page.waitForEvent('framenavigated'),
+      page.getByTestId('service-worker-update-button').click(),
+    ]);
+
+    await expect(page.getByTestId('app-shell')).toBeVisible();
+    await expect(page.getByTestId('service-worker-update-banner')).toHaveCount(0);
+  } finally {
+    fs.writeFileSync(serviceWorkerPath, originalServiceWorker);
+  }
+});
+
 const seedAndBindTestDb = async (
   page: import('@playwright/test').Page,
   graphOptions: MockGraphClientOptions = {},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ import { normalizeBasePath, toPreviewSlug } from './scripts/deploy-utils.mjs';
 
 const DEFAULT_PRODUCTION_BASE_PATH = '/';
 const LIGHT_APP_THEME_COLOR = '#f3f4f6';
+export const PWA_REGISTER_TYPE = 'prompt' as const;
 const PACKAGE_JSON_URL = new URL('./package.json', import.meta.url);
 const packageJson = JSON.parse(readFileSync(PACKAGE_JSON_URL, 'utf-8')) as {
   version: string;
@@ -75,7 +76,7 @@ export default defineConfig(({ command, mode }) => {
     plugins: [
       svelte(),
       VitePWA({
-        registerType: 'autoUpdate',
+        registerType: PWA_REGISTER_TYPE,
         scope: basePath,
         workbox: {
           navigateFallback: 'index.html',


### PR DESCRIPTION
# Pull Request

## Linked Issue (Required)

- Closes #83

## Context

- Problem: Active installed clients had no user-visible service-worker update path and could remain on a stale cached shell.
- Goal: [M8-02] notify active clients about a waiting deployment and let users activate it safely without losing an in-progress transfer draft to an automatic reload.

## Changes

- Switch vite-plugin-pwa from automatic activation to explicit prompt mode.
- Check hourly for deployments while the client stays open, with offline/installing/server guards.
- Add a persistent responsive update banner with localized activate, busy, error, and retry states.
- Add controller, registration, component, configuration, and real generated-worker browser regression coverage.
- Bump the app version to 0.8.02 and include the completed M8-02 backlog marker.

## Test Plan

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run test:e2e`
- Notes: 461 app tests, 76 script tests, and 123 Playwright tests passed; one duplicate real-worker update smoke was intentionally skipped on the second browser project.

## Screenshots

- [ ] UI change: screenshots attached
- [ ] No UI change
- Note: The responsive banner is exercised through component assertions and the real generated service-worker Playwright flow; no static screenshot is attached.

## Risk Notes

- User impact: Updates are announced persistently and activate only after explicit confirmation, protecting unsaved form input.
- Rollback plan: Revert this PR to restore the prior automatic service-worker activation behavior.

## QS Checklist

- [x] Linked issue ID is included in this PR.
- [x] Lint, typecheck, tests, and build were run and pass.
- [ ] Screenshots are included for UI changes.
- [x] Risk and rollback notes are documented.
- [x] No secrets, tokens, or credentials were added to the repository.
- [x] No unintended path/base URL changes were introduced (production remains rooted at `https://conspectus.jon2050.de/`).

## Merge And Cleanup (PR Path)

- [ ] Required GitHub checks are green.
- [x] PR will be merged into `main` with `Rebase and merge`.
- [x] PR will be merged into `main` once checks/review requirements are satisfied.
- [x] Head branch will be deleted after merge.
- [x] The backlog marker is included in this branch; issue closure occurs only after merge and green checks.
