### PR TITLE
docs: [M8-09] Add deterministic two-repo rollback

### DIFF
--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -152,28 +152,23 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Fetch public website consumer contract
-        env:
-          CONTRACT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
-          if [ -z "${CONTRACT_TOKEN}" ]; then
-            echo 'Missing required GitHub Actions token.' >&2
-            exit 1
-          fi
-
-          workflow_api_url="https://api.github.com/repos/${WEBSITE_REPO_FULL_NAME}/contents/.github/workflows/deploy.yml?ref=master"
-          workflow_status="$(curl -sS -L -o website-deploy-workflow.json -w '%{http_code}' \
-            -H "Authorization: Bearer ${CONTRACT_TOKEN}" \
-            -H 'Accept: application/vnd.github+json' \
+          workflow_raw_url="https://raw.githubusercontent.com/${WEBSITE_REPO_FULL_NAME}/master/.github/workflows/deploy.yml"
+          workflow_status="$(curl -sS -L -o website-deploy-workflow.yml -w '%{http_code}' \
             -H 'User-Agent: Conspectus-Mobile-Rollback' \
-            "${workflow_api_url}")"
+            "${workflow_raw_url}")"
 
           if [ "${workflow_status}" != '200' ]; then
             echo "Failed to read website deploy workflow from ${WEBSITE_REPO_FULL_NAME}." >&2
-            echo "Workflow API status: ${workflow_status}" >&2
+            echo "Workflow response status: ${workflow_status}" >&2
             exit 1
           fi
+
+          jq -n \
+            --arg content "$(base64 -w 0 website-deploy-workflow.yml)" \
+            '{encoding: "base64", content: $content}' > website-deploy-workflow.json
 
       - name: Verify website consumer handoff contract
         run: |

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -152,17 +152,26 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Fetch public website consumer contract
+        env:
+          CONTRACT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
+          if [ -z "${CONTRACT_TOKEN}" ]; then
+            echo 'Missing required GitHub Actions token.' >&2
+            exit 1
+          fi
+
           workflow_api_url="https://api.github.com/repos/${WEBSITE_REPO_FULL_NAME}/contents/.github/workflows/deploy.yml?ref=master"
           workflow_status="$(curl -sS -L -o website-deploy-workflow.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${CONTRACT_TOKEN}" \
             -H 'Accept: application/vnd.github+json' \
             -H 'User-Agent: Conspectus-Mobile-Rollback' \
             "${workflow_api_url}")"
 
           if [ "${workflow_status}" != '200' ]; then
             echo "Failed to read website deploy workflow from ${WEBSITE_REPO_FULL_NAME}." >&2
+            echo "Workflow API status: ${workflow_status}" >&2
             exit 1
           fi
 

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -155,27 +155,30 @@ jobs:
         run: |
           set -euo pipefail
 
-          workflow_raw_url="https://raw.githubusercontent.com/${WEBSITE_REPO_FULL_NAME}/master/.github/workflows/deploy.yml"
-          workflow_status="$(curl -sS -L -o website-deploy-workflow.yml -w '%{http_code}' \
+          contract_url="${PRODUCTION_APP_BASE_URL}conspectus-deploy-contract.json?rollback-probe=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          contract_status="$(curl -sS -L \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --retry 2 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            -o website-deploy-contract.json \
+            -w '%{http_code}' \
             -H 'User-Agent: Conspectus-Mobile-Rollback' \
-            "${workflow_raw_url}")"
+            "${contract_url}")"
 
-          if [ "${workflow_status}" != '200' ]; then
-            echo "Failed to read website deploy workflow from ${WEBSITE_REPO_FULL_NAME}." >&2
-            echo "Workflow response status: ${workflow_status}" >&2
+          if [ "${contract_status}" != '200' ]; then
+            echo "Failed to read live website consumer contract from ${contract_url}." >&2
+            echo "Contract response status: ${contract_status}" >&2
             exit 1
           fi
-
-          jq -n \
-            --arg content "$(base64 -w 0 website-deploy-workflow.yml)" \
-            '{encoding: "base64", content: $content}' > website-deploy-workflow.json
 
       - name: Verify website consumer handoff contract
         run: |
           set -euo pipefail
 
           node scripts/verify-website-consumer-contract.mjs \
-            --workflow-json website-deploy-workflow.json \
+            --contract-json website-deploy-contract.json \
             --producer-repo "${GITHUB_REPOSITORY}"
 
       - name: Record validated dry-run evidence

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -1,0 +1,246 @@
+# Validates or executes a deterministic rollback to an existing production artifact.
+name: Rollback Production
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/rollback-production.yml
+      - scripts/verify-rollback-target.mjs
+      - scripts/verify-website-consumer-contract.mjs
+      - scripts/verify-production-deploy-smoke.mjs
+      - docs/Production-Rollback.md
+  workflow_dispatch:
+    inputs:
+      deploy_run_id:
+        description: Successful Deploy Production run containing the known-good artifact
+        required: true
+        type: string
+      commit_sha:
+        description: Full main commit SHA recorded in the known-good deploy metadata
+        required: true
+        type: string
+      execute:
+        description: Dispatch the validated artifact to production
+        required: true
+        default: false
+        type: boolean
+
+env:
+  PRODUCTION_APP_BASE_URL: ${{ vars.PRODUCTION_APP_BASE_URL || 'https://conspectus.jon2050.de/' }}
+  WEBSITE_REPO_FULL_NAME: ${{ vars.WEBSITE_REPO_FULL_NAME || 'Jon2050/Jon2050_Webpage' }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  rollback-production:
+    name: ${{ github.event_name == 'pull_request' && 'Rollback Dry Run' || (inputs.execute && 'Execute Production Rollback' || 'Rollback Dry Run') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require main branch for manual runs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${GITHUB_REF_NAME}" != 'main' ]; then
+            echo 'Manual rollback validation and execution must be started from main.' >&2
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Resolve rollback target
+        id: target
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED_COMMIT_SHA: ${{ inputs.commit_sha }}
+          REQUESTED_DEPLOY_RUN_ID: ${{ inputs.deploy_run_id }}
+        run: |
+          set -euo pipefail
+
+          commit_sha="${REQUESTED_COMMIT_SHA}"
+          deploy_run_id="${REQUESTED_DEPLOY_RUN_ID}"
+
+          if [ "${GITHUB_EVENT_NAME}" = 'pull_request' ]; then
+            runs_status="$(curl -sS -o deploy-runs.json -w '%{http_code}' \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H 'Accept: application/vnd.github+json' \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-production.yml/runs?branch=main&event=workflow_dispatch&status=success&per_page=20")"
+
+            if [ "${runs_status}" != '200' ]; then
+              echo 'Failed to resolve a known-good production run for the pull-request dry run.' >&2
+              cat deploy-runs.json >&2 || true
+              exit 1
+            fi
+
+            deploy_run_id="$(jq -r '.workflow_runs[0].id // empty' deploy-runs.json)"
+            commit_sha="$(jq -r '.workflow_runs[0].head_sha // empty' deploy-runs.json)"
+          fi
+
+          if [ -z "${commit_sha}" ] || [ -z "${deploy_run_id}" ]; then
+            echo 'Rollback requires both commitSha and deployRunId.' >&2
+            exit 1
+          fi
+
+          if ! [[ "${commit_sha}" =~ ^[0-9a-f]{40}$ ]] || ! [[ "${deploy_run_id}" =~ ^[0-9]+$ ]]; then
+            echo 'Rollback target identity is malformed.' >&2
+            exit 1
+          fi
+
+          {
+            echo "commit_sha=${commit_sha}"
+            echo "deploy_run_id=${deploy_run_id}"
+            echo "artifact_name=conspectus-mobile-production-${commit_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Fetch rollback provenance
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_RUN_ID: ${{ steps.target.outputs.deploy_run_id }}
+        run: |
+          set -euo pipefail
+
+          run_status="$(curl -sS -L -o rollback-run.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${DEPLOY_RUN_ID}")"
+          artifacts_status="$(curl -sS -L -o rollback-artifacts.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${DEPLOY_RUN_ID}/artifacts?per_page=100")"
+
+          if [ "${run_status}" != '200' ] || [ "${artifacts_status}" != '200' ]; then
+            echo "Failed to read rollback provenance for deployRunId=${DEPLOY_RUN_ID}." >&2
+            exit 1
+          fi
+
+      - name: Download exact rollback artifact
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: ${{ steps.target.outputs.artifact_name }}
+          path: rollback-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.target.outputs.deploy_run_id }}
+
+      - name: Verify rollback target identity
+        run: >-
+          node scripts/verify-rollback-target.mjs
+          --run-json rollback-run.json
+          --artifacts-json rollback-artifacts.json
+          --metadata rollback-artifact/deploy-metadata.json
+          --commit-sha "${{ steps.target.outputs.commit_sha }}"
+          --deploy-run-id "${{ steps.target.outputs.deploy_run_id }}"
+
+      - name: Read validated rollback metadata
+        id: metadata
+        run: |
+          set -euo pipefail
+          {
+            echo "quality_run_id=$(jq -r '.qualityRunId' rollback-artifact/deploy-metadata.json)"
+            echo "build_time_utc=$(jq -r '.buildTimeUtc' rollback-artifact/deploy-metadata.json)"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Fetch public website consumer contract
+        run: |
+          set -euo pipefail
+
+          workflow_api_url="https://api.github.com/repos/${WEBSITE_REPO_FULL_NAME}/contents/.github/workflows/deploy.yml?ref=master"
+          workflow_status="$(curl -sS -L -o website-deploy-workflow.json -w '%{http_code}' \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'User-Agent: Conspectus-Mobile-Rollback' \
+            "${workflow_api_url}")"
+
+          if [ "${workflow_status}" != '200' ]; then
+            echo "Failed to read website deploy workflow from ${WEBSITE_REPO_FULL_NAME}." >&2
+            exit 1
+          fi
+
+      - name: Verify website consumer handoff contract
+        run: |
+          set -euo pipefail
+
+          node scripts/verify-website-consumer-contract.mjs \
+            --workflow-json website-deploy-workflow.json \
+            --producer-repo "${GITHUB_REPOSITORY}"
+
+      - name: Record validated dry-run evidence
+        if: github.event_name == 'pull_request' || !inputs.execute
+        run: |
+          {
+            echo '## Production rollback dry run'
+            echo
+            echo '- Result: PASS (no deployment dispatched)'
+            echo '- commitSha: ${{ steps.target.outputs.commit_sha }}'
+            echo '- deployRunId: ${{ steps.target.outputs.deploy_run_id }}'
+            echo '- qualityRunId: ${{ steps.metadata.outputs.quality_run_id }}'
+            echo '- artifactName: ${{ steps.target.outputs.artifact_name }}'
+            echo '- original buildTimeUtc: ${{ steps.metadata.outputs.build_time_utc }}'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Trigger deterministic website rollback handoff
+        if: github.event_name == 'workflow_dispatch' && inputs.execute
+        env:
+          DISPATCH_TOKEN: ${{ secrets.WEBSITE_REPO_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          cat > rollback-dispatch-payload.json <<EOF
+          {
+            "event_type": "conspectus-mobile-production-ready",
+            "client_payload": {
+              "commitSha": "${{ steps.target.outputs.commit_sha }}",
+              "deployRunId": "${{ steps.target.outputs.deploy_run_id }}",
+              "qualityRunId": "${{ steps.metadata.outputs.quality_run_id }}",
+              "artifactName": "${{ steps.target.outputs.artifact_name }}"
+            }
+          }
+          EOF
+
+          dispatch_status="$(curl -sS -o rollback-dispatch-response.txt -w '%{http_code}' \
+            -X POST \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${WEBSITE_REPO_FULL_NAME}/dispatches" \
+            --data-binary @rollback-dispatch-payload.json)"
+
+          if [ "${dispatch_status}" != '204' ]; then
+            echo "Rollback dispatch failed with HTTP ${dispatch_status}." >&2
+            cat rollback-dispatch-response.txt >&2 || true
+            exit 1
+          fi
+
+      - name: Verify executed rollback
+        if: github.event_name == 'workflow_dispatch' && inputs.execute
+        run: >-
+          node scripts/verify-production-deploy-smoke.mjs
+          --base-url "${PRODUCTION_APP_BASE_URL}"
+          --commit-sha "${{ steps.target.outputs.commit_sha }}"
+          --deploy-run-id "${{ steps.target.outputs.deploy_run_id }}"
+          --max-attempts 48
+          --retry-delay-seconds 10
+          --request-timeout-ms 10000
+          --deadline-seconds 480
+
+      - name: Record executed rollback evidence
+        if: github.event_name == 'workflow_dispatch' && inputs.execute
+        run: |
+          {
+            echo '## Production rollback'
+            echo
+            echo '- Result: PASS'
+            echo '- commitSha: ${{ steps.target.outputs.commit_sha }}'
+            echo '- deployRunId: ${{ steps.target.outputs.deploy_run_id }}'
+            echo '- qualityRunId: ${{ steps.metadata.outputs.quality_run_id }}'
+            echo '- production verification budget: 8 minutes'
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -26,7 +26,7 @@ on:
         type: boolean
 
 env:
-  PRODUCTION_APP_BASE_URL: ${{ vars.PRODUCTION_APP_BASE_URL || 'https://conspectus.jon2050.de/' }}
+  PRODUCTION_APP_BASE_URL: ${{ vars.PRODUCTION_APP_BASE_URL || 'https://jon2050.de/conspectus/' }}
   WEBSITE_REPO_FULL_NAME: ${{ vars.WEBSITE_REPO_FULL_NAME || 'Jon2050/Jon2050_Webpage' }}
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
@@ -186,6 +186,7 @@ jobs:
             echo '- qualityRunId: ${{ steps.metadata.outputs.quality_run_id }}'
             echo '- artifactName: ${{ steps.target.outputs.artifact_name }}'
             echo '- original buildTimeUtc: ${{ steps.metadata.outputs.build_time_utc }}'
+            echo '- productionUrl: ${{ env.PRODUCTION_APP_BASE_URL }}'
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Trigger deterministic website rollback handoff
@@ -242,5 +243,6 @@ jobs:
             echo '- commitSha: ${{ steps.target.outputs.commit_sha }}'
             echo '- deployRunId: ${{ steps.target.outputs.deploy_run_id }}'
             echo '- qualityRunId: ${{ steps.metadata.outputs.quality_run_id }}'
+            echo '- productionUrl: ${{ env.PRODUCTION_APP_BASE_URL }}'
             echo '- production verification budget: 8 minutes'
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Use these documents as the canonical sources for their topics:
   [docs/CI-CD-Pipelines.md](docs/CI-CD-Pipelines.md).
 - Release branch/tag strategy, approvals, release notes, and production verification:
   [docs/Release-Process.md](docs/Release-Process.md).
+- Deterministic two-repository production rollback and incident ownership:
+  [docs/Production-Rollback.md](docs/Production-Rollback.md).
 - MVP backlog index and issue completion rules:
   [docs/GitHub-Issues-MVP-Backlog.md](docs/GitHub-Issues-MVP-Backlog.md).
 - Desktop database and business-rule parity reference:

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -831,6 +831,12 @@ M8-08 implementation clarification:
 - GitHub enforces pull-request delivery, rebase-only linear history, and the strict `Quality Gate`; the release process additionally requires reviewer-agent approval, explicit human release-owner acceptance, and complete physical iOS/Android evidence.
 - Production remains a manual deployment of the qualified current `main` commit. The immutable `v<version>` tag and GitHub Release are published only for the exact commit whose production identity, Lighthouse gate, and post-deploy smoke checks passed.
 
+M8-09 implementation clarification:
+
+- Production rollback reuses an unexpired artifact from an exact successful `Deploy Production` run; operators provide its full `commitSha` and `deployRunId`, while workflow validation derives and verifies the artifact name and `qualityRunId` before any dispatch.
+- Pull-request and manual dry-run modes validate producer provenance, artifact metadata, and the current website-consumer contract without mutating production. Execute mode sends the validated existing handoff payload and requires live smoke checks to observe the rollback identity.
+- The website repository remains responsible for staged upload and atomic promotion. The producer rollback workflow performs no manual file copy or FTP operation and budgets eight minutes for live verification so the documented incident procedure can complete inside 15 minutes.
+
 Substeps:
 
 1. Security hardening:

--- a/docs/CI-CD-Pipelines.md
+++ b/docs/CI-CD-Pipelines.md
@@ -30,6 +30,9 @@ flowchart TD
   Production --> Website[Jon2050/Jon2050_Webpage deploy workflow]
   Production --> Smoke[Production smoke verification]
   Smoke --> ProductionLighthouse[Mobile Lighthouse production gate]
+  KnownGood[Known-good commitSha + deployRunId] --> Rollback[Rollback Production]
+  Rollback -->|validated existing artifact| Website
+  Rollback --> Smoke
 ```
 
 ## Fixed URLs
@@ -172,6 +175,35 @@ When a budget is exceeded:
   - the CSP keeps general JavaScript evaluation disabled while allowing the narrower WebAssembly permission required by sql.js plus the Microsoft login, Graph, and OneDrive download endpoints used by the app
   - Lighthouse runs only after production smoke observes the expected commit and deploy-run identity; a failure blocks release acceptance but does not attempt an automatic rollback
 
+### `Rollback Production`
+
+- File: [`.github/workflows/rollback-production.yml`](../.github/workflows/rollback-production.yml)
+- Trigger: pull requests that change the rollback contract, or manual dispatch with a known-good
+  `commitSha`, `deployRunId`, and explicit execute choice
+- Purpose:
+  - prove that a historical successful `main` production artifact is still available and unexpired
+  - verify the exact run provenance, artifact metadata, and current website-consumer contract
+  - support a no-mutation dry run before releases and before an incident rollback
+  - in execute mode, redispatch the validated existing artifact and require production smoke checks
+    to observe its exact identity
+- Depends on:
+  - an unexpired `conspectus-mobile-production-<commitSha>` artifact from the selected successful
+    `Deploy Production` run
+  - repository secret `WEBSITE_REPO_DISPATCH_TOKEN`
+  - the compatible `Jon2050/Jon2050_Webpage` consumer workflow
+- Failure behavior:
+  - rejects malformed inputs, non-`main` or unsuccessful producer runs, missing/expired artifacts,
+    metadata mismatches, consumer-contract drift, dispatch errors, and live identity mismatches
+  - never dispatches in pull-request or manual dry-run mode
+  - execution is main-only, serialized with production deployment, and never cancels an active run
+- Notes:
+  - rollback reuses immutable Actions artifacts and repository dispatch; it performs no manual FTP or
+    filesystem operation
+  - live verification retries for at most eight minutes, leaving time for the incident procedure in
+    [`Production-Rollback.md`](Production-Rollback.md) to complete inside 15 minutes
+  - artifact retention is 90 days, so release preparation must confirm at least one recent
+    known-good rollback target
+
 ### Lighthouse mobile release budgets
 
 Both deployment workflows run the pinned Lighthouse CLI three times with its mobile profile against
@@ -227,7 +259,7 @@ npm run check:lighthouse -- https://jon2050.github.io/Conspectus-Mobile/previews
 ### `conspectus-mobile-production-<commitSha>`
 
 - Producer: `Deploy Production`
-- Consumer: the website repository deploy workflow
+- Consumers: the website repository deploy workflow and `Rollback Production`
 - Required metadata file: `deploy-metadata.json`
 - Required Apache security configuration: `.htaccess`
 - Required static app-shell entrypoint: `index.html`

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -671,7 +671,7 @@ An issue is only considered done when:
 - Depends on: `M8-05, M8-06`
 - GitHub: [#89](https://github.com/Jon2050/Conspectus-Mobile/issues/89)
 
-### :green_circle: M8-09 Create rollback procedure for two-repo deployment
+### :white_check_mark: M8-09 Create rollback procedure for two-repo deployment
 
 - Label: `docs`
 - Milestone: `M8 - Hardening + QA + Release`

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -671,7 +671,7 @@ An issue is only considered done when:
 - Depends on: `M8-05, M8-06`
 - GitHub: [#89](https://github.com/Jon2050/Conspectus-Mobile/issues/89)
 
-### :white_check_mark: M8-09 Create rollback procedure for two-repo deployment
+### :green_circle: M8-09 Create rollback procedure for two-repo deployment
 
 - Label: `docs`
 - Milestone: `M8 - Hardening + QA + Release`

--- a/docs/Production-Rollback.md
+++ b/docs/Production-Rollback.md
@@ -1,0 +1,112 @@
+# Production Rollback
+
+This runbook restores the Conspectus Mobile production site from an immutable, previously
+successful deployment artifact. The producer workflow in this repository validates and dispatches
+the exact artifact; the website repository performs its existing staged upload and directory swap.
+Operators must not copy build files, edit FTP directories, or reconstruct artifacts manually.
+
+## When to roll back
+
+Start incident triage immediately when production has any of these conditions after a deployment:
+
+- the app route, manifest, service worker, or required install icons are unavailable;
+- `deploy-metadata.json` does not match the approved release identity;
+- sign-in, OneDrive synchronization, database reads, or transfer writes regress on the dedicated QA
+  account;
+- the production Lighthouse, security-policy, or post-deploy smoke gate fails after handoff began;
+- a data-integrity or security defect makes the deployed commit unsafe.
+
+The incident owner decides whether to roll back. Prefer rollback when the previous artifact is known
+good and forward repair cannot restore a safe service inside the same 15-minute response window.
+
+## Ownership and communication
+
+- **Incident owner:** declares rollback, freezes production deployments, owns the timeline, and
+  records the final decision.
+- **Producer operator:** selects the known-good `commitSha` and `deployRunId`, runs `Rollback
+Production`, and shares the workflow URL.
+- **Website operator:** watches the `Jon2050/Jon2050_Webpage` consumer workflow and intervenes only
+  if its repository credentials or hosting provider are unavailable.
+- **Communications owner:** posts the start, validated target, dispatch, verification result, and
+  resolution in the release/incident issue.
+
+One person may hold several roles, but every role and timestamp must be named in the incident record.
+
+## Select a known-good target
+
+Use a previous successful `Deploy Production` run whose production behavior was verified. Record:
+
+- full 40-character `commitSha`;
+- numeric `deployRunId` from the workflow URL;
+- its `conspectus-mobile-production-<commitSha>` artifact and expiry date;
+- linked Quality, production smoke, Lighthouse, and QA evidence.
+
+Do not use an expired artifact, a run from a branch other than `main`, a failed/incomplete run, or an
+identity without prior production evidence. If no suitable artifact remains inside the 90-day
+retention window, stop: this rollback path is unavailable and a newly qualified forward release is
+required.
+
+## Dry run
+
+Every change to the rollback contract is exercised automatically by the pull-request trigger in
+`.github/workflows/rollback-production.yml`. Before a planned release, also run **Rollback
+Production** manually from `main` with the selected `deploy_run_id`, `commit_sha`, and `execute =
+false`.
+
+The workflow must finish with a `Production rollback dry run` summary that matches all three deploy
+identity fields. It performs no dispatch and no production mutation. It verifies:
+
+1. exact successful producer-run provenance from `main`;
+2. one unexpired artifact named for the requested commit;
+3. artifact metadata (`commitSha`, `deployRunId`, `qualityRunId`, channel, base path, source branch);
+4. the current website consumer's repository-dispatch, staging, validation, and promotion contract.
+
+A missing secret, unavailable artifact, identity mismatch, or consumer-contract drift invalidates the
+target. Stop and fix the prerequisite; never bypass a failed dry run.
+
+## Execute rollback (target: under 15 minutes)
+
+1. **Minute 0-2 — declare and freeze.** The incident owner announces rollback, stops new production
+   runs, and posts the selected identity.
+2. **Minute 2-3 — start automation.** From the `main` branch Actions page, run **Rollback Production**
+   with the validated `deploy_run_id`, `commit_sha`, and `execute = true`.
+3. **Minute 3-6 — validate and dispatch.** The producer revalidates provenance, artifact metadata,
+   and the website consumer contract, then sends `conspectus-mobile-production-ready` with the exact
+   validated fields.
+4. **Minute 6-11 — stage and promote.** The website workflow downloads that producer artifact,
+   validates it, uploads only to `conspectus.__incoming`, and atomically promotes the staging
+   directory. Its short-lived backup protects a failed directory rename.
+5. **Minute 11-13 — verify.** The producer polls production for at most eight minutes and requires
+   the app route, manifest, service worker, icons, and `deploy-metadata.json` to expose the rollback
+   identity.
+6. **Minute 13-15 — communicate.** Record PASS/FAIL, both workflow URLs, live metadata, and the next
+   incident action.
+
+The workflow is serialized with production deployment and fails closed. Starting a second deploy or
+rollback does not cancel the active operation.
+
+## Verification and evidence
+
+After workflow success:
+
+- fetch `https://conspectus.jon2050.de/deploy-metadata.json` with normal TLS validation and confirm
+  `commitSha`, `deployRunId`, and `qualityRunId`;
+- open the app in a fresh browser profile and confirm the footer identity, manifest, service worker,
+  and install icons;
+- run the dedicated-QA-account sign-in, sync, Accounts, and Transfers smoke checks;
+- link the producer rollback run, website consumer run, live metadata, and manual result in the
+  incident/release issue;
+- keep the production freeze until the incident owner declares recovery.
+
+If automated verification fails after dispatch, production state is uncertain. Inspect the live
+metadata and both workflow logs, keep the incident open, and choose another validated artifact or a
+forward fix. Never claim rollback success from dispatch acceptance alone.
+
+## Repository responsibilities
+
+- `Jon2050/Conspectus-Mobile`: owns artifact identity, rollback target validation, dispatch, and live
+  identity smoke verification.
+- `Jon2050/Jon2050_Webpage`: owns artifact download, staging validation, FTP upload, and atomic
+  promotion of the Conspectus subdomain root.
+
+Changes to either side of this contract require a new dry run before the next release.

--- a/docs/Production-Rollback.md
+++ b/docs/Production-Rollback.md
@@ -63,10 +63,14 @@ identity fields. It performs no dispatch and no production mutation. It verifies
 1. exact successful producer-run provenance from `main`;
 2. one unexpired artifact named for the requested commit;
 3. artifact metadata (`commitSha`, `deployRunId`, `qualityRunId`, channel, base path, source branch);
-4. the current website consumer's repository-dispatch, staging, validation, and promotion contract.
+4. the current website consumer's repository-dispatch, staging, validation, promotion, and
+   restoration contract, published at
+   `https://jon2050.de/conspectus/conspectus-deploy-contract.json`.
 
-A missing secret, unavailable artifact, identity mismatch, or consumer-contract drift invalidates the
-target. Stop and fix the prerequisite; never bypass a failed dry run.
+The website repository validates this exact-schema descriptor against its private deploy workflow,
+publishes only that file on trusted `master` updates, and verifies the live copy. A missing or stale
+contract, unavailable artifact, identity mismatch, or consumer-contract drift invalidates the target.
+Stop and fix the prerequisite; never bypass a failed dry run.
 
 ## Execute rollback (target: under 15 minutes)
 

--- a/docs/Production-Rollback.md
+++ b/docs/Production-Rollback.md
@@ -46,6 +46,10 @@ identity without prior production evidence. If no suitable artifact remains insi
 retention window, stop: this rollback path is unavailable and a newly qualified forward release is
 required.
 
+Only artifacts built for `basePath=/conspectus/` are valid after the path migration. Earlier
+root-scoped artifacts cannot safely restore the current asset, manifest, or service-worker scope and
+must be replaced by a newly qualified forward release.
+
 ## Dry run
 
 Every change to the rollback contract is exercised automatically by the pull-request trigger in
@@ -89,7 +93,7 @@ rollback does not cancel the active operation.
 
 After workflow success:
 
-- fetch `https://conspectus.jon2050.de/deploy-metadata.json` with normal TLS validation and confirm
+- fetch `https://jon2050.de/conspectus/deploy-metadata.json` with normal TLS validation and confirm
   `commitSha`, `deployRunId`, and `qualityRunId`;
 - open the app in a fresh browser profile and confirm the footer identity, manifest, service worker,
   and install icons;
@@ -106,7 +110,7 @@ forward fix. Never claim rollback success from dispatch acceptance alone.
 
 - `Jon2050/Conspectus-Mobile`: owns artifact identity, rollback target validation, dispatch, and live
   identity smoke verification.
-- `Jon2050/Jon2050_Webpage`: owns artifact download, staging validation, FTP upload, and atomic
-  promotion of the Conspectus subdomain root.
+- `Jon2050/Jon2050_Webpage`: owns artifact download, staging validation, FTP upload, live identity
+  verification, and atomic promotion of the `/conspectus/` website subtree.
 
 Changes to either side of this contract require a new dry run before the next release.

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -38,9 +38,9 @@ comment. Do not maintain a second release checklist elsewhere.
 
 - [ ] Confirm every issue in the intended release scope is merged, its required checks are green,
       and known limitations are listed in the release notes.
-- [ ] Confirm the applicable rollback runbook is available. For the MVP, issue
-      [M8-09 / #90](https://github.com/Jon2050/Conspectus-Mobile/issues/90) owns the two-repository
-      rollback procedure.
+- [ ] Confirm the two-repository [`Production-Rollback.md`](Production-Rollback.md) runbook is
+      available and a no-mutation `Rollback Production` dry run passes for the selected known-good
+      `commitSha` and `deployRunId`. Link that workflow run in the release evidence.
 - [ ] Pull the current `main`, confirm its `Quality Gate` is successful, and create
       `release/v<version>` from that exact commit.
 - [ ] Update `package.json` and both root version fields in `package-lock.json` to the same unused

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.8.08",
+  "version": "0.8.09",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.8.08",
+      "version": "0.8.09",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.8.08",
+  "version": "0.8.09",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/scripts/deploy-utils.test.ts
+++ b/scripts/deploy-utils.test.ts
@@ -17,6 +17,10 @@ const deployProductionWorkflowPath = path.resolve(
   repositoryRootPath,
   '.github/workflows/deploy-production.yml',
 );
+const rollbackProductionWorkflowPath = path.resolve(
+  repositoryRootPath,
+  '.github/workflows/rollback-production.yml',
+);
 const qualityWorkflowPath = path.resolve(repositoryRootPath, '.github/workflows/quality.yml');
 const dependencyAuditWorkflowPath = path.resolve(
   repositoryRootPath,
@@ -196,6 +200,7 @@ describe('workflow action pinning', () => {
       dependencyAuditWorkflowPath,
       deployPreviewWorkflowPath,
       deployProductionWorkflowPath,
+      rollbackProductionWorkflowPath,
     ];
 
     for (const workflowPath of workflowPaths) {
@@ -254,5 +259,37 @@ describe('production workflow contracts', () => {
     expect(productionWorkflowSource).toContain(
       'echo "Missing repository variable VITE_AZURE_CLIENT_ID." >&2',
     );
+  });
+});
+
+describe('production rollback workflow contract', () => {
+  it('validates exact historical identity in dry-run mode before an explicit dispatch', () => {
+    const workflowSource = fs.readFileSync(rollbackProductionWorkflowPath, 'utf8');
+
+    expect(workflowSource).toContain('name: Rollback Production');
+    expect(workflowSource).toContain('pull_request:');
+    expect(workflowSource).toContain('workflow_dispatch:');
+    expect(workflowSource).toContain('deploy_run_id:');
+    expect(workflowSource).toContain('commit_sha:');
+    expect(workflowSource).toContain('execute:');
+    expect(workflowSource).toContain('name: Verify rollback target identity');
+    expect(workflowSource).toContain('node scripts/verify-rollback-target.mjs');
+    expect(workflowSource).toContain('name: Verify website consumer handoff contract');
+    expect(workflowSource).toContain('Result: PASS (no deployment dispatched)');
+    expect(workflowSource).toContain(
+      "if: github.event_name == 'workflow_dispatch' && inputs.execute",
+    );
+    expect(workflowSource).toContain('conspectus-mobile-production-ready');
+    expect(workflowSource).toContain('node scripts/verify-production-deploy-smoke.mjs');
+    expect(workflowSource).toContain('--max-attempts 48');
+    expect(workflowSource).toContain('--deadline-seconds 480');
+    expect(workflowSource).toContain('group: deploy-production');
+    expect(workflowSource).toContain('name: Fetch public website consumer contract');
+    const publicFetchStepStart = workflowSource.indexOf(
+      'name: Fetch public website consumer contract',
+    );
+    const publicFetchStepEnd = workflowSource.indexOf('\n      - name:', publicFetchStepStart);
+    const publicFetchStep = workflowSource.slice(publicFetchStepStart, publicFetchStepEnd);
+    expect(publicFetchStep).not.toContain('WEBSITE_REPO_DISPATCH_TOKEN');
   });
 });

--- a/scripts/deploy-utils.test.ts
+++ b/scripts/deploy-utils.test.ts
@@ -290,8 +290,11 @@ describe('production rollback workflow contract', () => {
     );
     const publicFetchStepEnd = workflowSource.indexOf('\n      - name:', publicFetchStepStart);
     const publicFetchStep = workflowSource.slice(publicFetchStepStart, publicFetchStepEnd);
-    expect(publicFetchStep).toContain('https://raw.githubusercontent.com/');
-    expect(publicFetchStep).toContain('base64 -w 0 website-deploy-workflow.yml');
+    expect(publicFetchStep).toContain('${PRODUCTION_APP_BASE_URL}conspectus-deploy-contract.json');
+    expect(publicFetchStep).toContain('--connect-timeout 10');
+    expect(publicFetchStep).toContain('--max-time 30');
+    expect(publicFetchStep).toContain('--retry 2');
+    expect(workflowSource).toContain('--contract-json website-deploy-contract.json');
     expect(publicFetchStep).not.toContain('WEBSITE_REPO_DISPATCH_TOKEN');
     expect(publicFetchStep).not.toContain('Authorization: Bearer');
   });

--- a/scripts/deploy-utils.test.ts
+++ b/scripts/deploy-utils.test.ts
@@ -290,6 +290,9 @@ describe('production rollback workflow contract', () => {
     );
     const publicFetchStepEnd = workflowSource.indexOf('\n      - name:', publicFetchStepStart);
     const publicFetchStep = workflowSource.slice(publicFetchStepStart, publicFetchStepEnd);
+    expect(publicFetchStep).toContain('https://raw.githubusercontent.com/');
+    expect(publicFetchStep).toContain('base64 -w 0 website-deploy-workflow.yml');
     expect(publicFetchStep).not.toContain('WEBSITE_REPO_DISPATCH_TOKEN');
+    expect(publicFetchStep).not.toContain('Authorization: Bearer');
   });
 });

--- a/scripts/verify-production-deploy-smoke.d.mts
+++ b/scripts/verify-production-deploy-smoke.d.mts
@@ -5,9 +5,11 @@ export interface SmokeCheckOptions {
   maxAttempts: number;
   retryDelaySeconds: number;
   requestTimeoutMs: number;
+  deadlineSeconds: number;
 }
 
 export type SleepFunction = (milliseconds: number) => Promise<void>;
+export type NowFunction = () => number;
 
 export function parseArgs(argv: string[]): SmokeCheckOptions;
 
@@ -15,6 +17,7 @@ export function runSmokeChecks(
   options: SmokeCheckOptions,
   fetchImpl?: typeof fetch,
   sleepImpl?: SleepFunction,
+  nowImpl?: NowFunction,
 ): Promise<void>;
 
 export function main(argv?: string[]): Promise<void>;

--- a/scripts/verify-production-deploy-smoke.mjs
+++ b/scripts/verify-production-deploy-smoke.mjs
@@ -36,6 +36,7 @@ export const parseArgs = (argv) => {
     maxAttempts: '24',
     retryDelaySeconds: '10',
     requestTimeoutMs: '10000',
+    deadlineSeconds: '0',
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -60,6 +61,7 @@ export const parseArgs = (argv) => {
   const maxAttempts = Number(args.maxAttempts);
   const retryDelaySeconds = Number(args.retryDelaySeconds);
   const requestTimeoutMs = Number(args.requestTimeoutMs);
+  const deadlineSeconds = Number(args.deadlineSeconds);
 
   assert(
     Number.isInteger(maxAttempts) && maxAttempts > 0,
@@ -73,6 +75,10 @@ export const parseArgs = (argv) => {
     Number.isInteger(requestTimeoutMs) && requestTimeoutMs > 0,
     '--request-timeout-ms must be a positive integer.',
   );
+  assert(
+    Number.isInteger(deadlineSeconds) && deadlineSeconds >= 0,
+    '--deadline-seconds must be a non-negative integer.',
+  );
   return {
     baseUrl: normalizeBaseUrl(args.baseUrl),
     commitSha: args.commitSha,
@@ -80,6 +86,7 @@ export const parseArgs = (argv) => {
     maxAttempts,
     retryDelaySeconds,
     requestTimeoutMs,
+    deadlineSeconds,
   };
 };
 
@@ -206,18 +213,20 @@ const ensureManifestInstallability = (manifestText, options) => {
   return iconEntries.map((entry) => entry.url);
 };
 
-const fetchWithTimeout = async (fetchImpl, url, requestTimeoutMs) => {
+const fetchWithTimeout = async (fetchImpl, url, requestTimeoutMs, readBody = false) => {
   const controller = new AbortController();
   const timeoutHandle = setTimeout(() => controller.abort(), requestTimeoutMs);
 
   try {
-    return await fetchImpl(url, {
+    const response = await fetchImpl(url, {
       redirect: 'follow',
       signal: controller.signal,
       headers: {
         accept: 'text/html,*/*;q=0.9',
       },
     });
+    const bodyText = readBody ? await response.text() : '';
+    return { response, bodyText };
   } finally {
     clearTimeout(timeoutHandle);
   }
@@ -251,11 +260,40 @@ const createChecks = (options, setManifestIconUrls, setAppleTouchIconUrl) => [
   },
 ];
 
-export const runSmokeChecks = async (options, fetchImpl = fetch, sleepImpl = delay) => {
+export const runSmokeChecks = async (
+  options,
+  fetchImpl = fetch,
+  sleepImpl = delay,
+  nowImpl = Date.now,
+) => {
   const contextLabel = buildContextLabel(options);
+  const deadlineSeconds = options.deadlineSeconds ?? 0;
+  const deadlineAt = deadlineSeconds > 0 ? nowImpl() + deadlineSeconds * 1000 : 0;
   let lastErrors = [];
 
+  const throwDeadlineError = () => {
+    throw new Error(
+      `[verify-production-deploy-smoke] ${contextLabel} exceeded the ${deadlineSeconds}s wall-clock deadline. Last errors: ${lastErrors.join(' | ')}`,
+    );
+  };
+
+  const resolveRequestTimeoutMs = () => {
+    if (deadlineAt === 0) {
+      return options.requestTimeoutMs;
+    }
+
+    const remainingMs = deadlineAt - nowImpl();
+    if (remainingMs <= 0) {
+      throwDeadlineError();
+    }
+
+    return Math.min(options.requestTimeoutMs, remainingMs);
+  };
+
   for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
+    if (deadlineAt > 0 && nowImpl() >= deadlineAt) {
+      throwDeadlineError();
+    }
     let manifestIconUrls = [];
     let appleTouchIconUrl = '';
     const checks = createChecks(
@@ -274,7 +312,12 @@ export const runSmokeChecks = async (options, fetchImpl = fetch, sleepImpl = del
 
     for (const check of checks) {
       try {
-        const response = await fetchWithTimeout(fetchImpl, check.url, options.requestTimeoutMs);
+        const { response, bodyText } = await fetchWithTimeout(
+          fetchImpl,
+          check.url,
+          resolveRequestTimeoutMs(),
+          Boolean(check.validateBody),
+        );
         assert(response.status === 200, `${check.name} returned HTTP ${response.status}.`);
 
         if (check.validateResponse) {
@@ -282,7 +325,6 @@ export const runSmokeChecks = async (options, fetchImpl = fetch, sleepImpl = del
         }
 
         if (check.validateBody) {
-          const bodyText = await response.text();
           check.validateBody(bodyText);
         }
 
@@ -303,10 +345,10 @@ export const runSmokeChecks = async (options, fetchImpl = fetch, sleepImpl = del
           appleTouchIconUrl.length > 0,
           'apple-touch-icon URL missing from bootstrap validation context.',
         );
-        const appleTouchIconResponse = await fetchWithTimeout(
+        const { response: appleTouchIconResponse } = await fetchWithTimeout(
           fetchImpl,
           appleTouchIconUrl,
-          options.requestTimeoutMs,
+          resolveRequestTimeoutMs(),
         );
         assert(
           appleTouchIconResponse.status === 200,
@@ -326,7 +368,11 @@ export const runSmokeChecks = async (options, fetchImpl = fetch, sleepImpl = del
     if (lastErrors.length === 0) {
       for (const iconUrl of manifestIconUrls) {
         try {
-          const iconResponse = await fetchWithTimeout(fetchImpl, iconUrl, options.requestTimeoutMs);
+          const { response: iconResponse } = await fetchWithTimeout(
+            fetchImpl,
+            iconUrl,
+            resolveRequestTimeoutMs(),
+          );
           assert(
             iconResponse.status === 200,
             `manifest icon returned HTTP ${iconResponse.status}.`,
@@ -344,17 +390,27 @@ export const runSmokeChecks = async (options, fetchImpl = fetch, sleepImpl = del
     }
 
     if (lastErrors.length === 0) {
+      if (deadlineAt > 0 && nowImpl() >= deadlineAt) {
+        throwDeadlineError();
+      }
       console.log(
         `[verify-production-deploy-smoke] ${contextLabel} all deployment smoke checks passed for ${options.baseUrl}`,
       );
       return;
     }
 
+    if (deadlineAt > 0 && nowImpl() >= deadlineAt) {
+      throwDeadlineError();
+    }
+
     if (attempt < options.maxAttempts) {
       console.log(
         `[verify-production-deploy-smoke] ${contextLabel} attempt ${attempt}/${options.maxAttempts} failed; retrying in ${options.retryDelaySeconds}s.`,
       );
-      await sleepImpl(options.retryDelaySeconds * 1000);
+      const retryDelayMs = options.retryDelaySeconds * 1000;
+      const boundedRetryDelayMs =
+        deadlineAt > 0 ? Math.min(retryDelayMs, Math.max(0, deadlineAt - nowImpl())) : retryDelayMs;
+      await sleepImpl(boundedRetryDelayMs);
     }
   }
 

--- a/scripts/verify-production-deploy-smoke.test.ts
+++ b/scripts/verify-production-deploy-smoke.test.ts
@@ -9,6 +9,7 @@ const baseOptions = {
   maxAttempts: 1,
   retryDelaySeconds: 0,
   requestTimeoutMs: 1000,
+  deadlineSeconds: 0,
 };
 
 const appHtml = `<!doctype html>
@@ -403,7 +404,71 @@ describe('verify-production-deploy-smoke script', () => {
       maxAttempts: 24,
       retryDelaySeconds: 10,
       requestTimeoutMs: 10000,
+      deadlineSeconds: 0,
     });
+  });
+
+  it('enforces a wall-clock deadline across sequential checks and retries', async () => {
+    let currentTimeMs = 0;
+    const fetchMock = vi.fn(async () => {
+      currentTimeMs += 600;
+      return asResponse(503, 'unavailable');
+    }) as FetchMock;
+    const sleepMock = vi.fn(async (delayMs: number) => {
+      currentTimeMs += delayMs;
+    });
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(
+      runSmokeChecks(
+        {
+          ...baseOptions,
+          maxAttempts: 20,
+          retryDelaySeconds: 10,
+          deadlineSeconds: 1,
+        },
+        fetchMock,
+        sleepMock,
+        () => currentTimeMs,
+      ),
+    ).rejects.toThrow('exceeded the 1s wall-clock deadline');
+    expect(sleepMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the timeout active while reading a stalled response body', async () => {
+    let bodyRequestWasAborted = false;
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      if (resolveUrl(input) !== 'https://conspectus.jon2050.de/') {
+        return asResponse(503, 'unavailable');
+      }
+
+      const stalledBody = new ReadableStream({
+        start(controller) {
+          init?.signal?.addEventListener('abort', () => {
+            bodyRequestWasAborted = true;
+            controller.error(new DOMException('Request aborted', 'AbortError'));
+          });
+        },
+      });
+      return new Response(stalledBody, { status: 200 });
+    }) as FetchMock;
+    const sleepMock = vi.fn(async () => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(
+      runSmokeChecks(
+        {
+          ...baseOptions,
+          requestTimeoutMs: 20,
+          deadlineSeconds: 1,
+        },
+        fetchMock,
+        sleepMock,
+      ),
+    ).rejects.toThrow('check=app-route');
+    expect(bodyRequestWasAborted).toBe(true);
   });
 
   it('rejects non-https base URLs', () => {

--- a/scripts/verify-production-deploy-smoke.test.ts
+++ b/scripts/verify-production-deploy-smoke.test.ts
@@ -459,7 +459,7 @@ describe('verify-production-deploy-smoke script', () => {
   it('keeps the timeout active while reading a stalled response body', async () => {
     let bodyRequestWasAborted = false;
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      if (resolveUrl(input) !== 'https://conspectus.jon2050.de/') {
+      if (resolveUrl(input) !== 'https://jon2050.de/conspectus/') {
         return asResponse(503, 'unavailable');
       }
 

--- a/scripts/verify-rollback-target.mjs
+++ b/scripts/verify-rollback-target.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+// Verifies that a historical production run and artifact are safe deterministic rollback inputs.
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REQUIRED_ARGS = new Set(['runJson', 'artifactsJson', 'metadata', 'commitSha', 'deployRunId']);
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const parseArgs = (argv) => {
+  const args = {
+    runJson: '',
+    artifactsJson: '',
+    metadata: '',
+    commitSha: '',
+    deployRunId: '',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+    if (!current.startsWith('--')) {
+      continue;
+    }
+
+    const key = current.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    if (!(key in args)) {
+      continue;
+    }
+
+    args[key] = argv[index + 1] ?? '';
+    index += 1;
+  }
+
+  for (const requiredArg of REQUIRED_ARGS) {
+    assert(args[requiredArg], `Missing required --${requiredArg} argument.`);
+  }
+
+  return args;
+};
+
+const readJson = (filePath) => {
+  const absolutePath = path.resolve(process.cwd(), filePath);
+  assert(fs.existsSync(absolutePath), `Missing expected file: ${absolutePath}`);
+  return JSON.parse(fs.readFileSync(absolutePath, 'utf8').replace(/^\uFEFF/, ''));
+};
+
+const verifyRun = (run, expected) => {
+  assert(
+    String(run.id) === expected.deployRunId,
+    `Producer run id mismatch. Expected "${expected.deployRunId}", got "${run.id}".`,
+  );
+  assert(
+    String(run.head_sha) === expected.commitSha,
+    `Producer run commit mismatch. Expected "${expected.commitSha}", got "${run.head_sha}".`,
+  );
+  assert(
+    run.head_branch === 'main',
+    `Producer run must originate from main; got "${run.head_branch}".`,
+  );
+  assert(
+    run.conclusion === 'success',
+    `Producer run must be completed successfully; got "${run.conclusion}".`,
+  );
+  assert(
+    run.path === '.github/workflows/deploy-production.yml',
+    `Producer run must use ".github/workflows/deploy-production.yml"; got "${run.path}".`,
+  );
+  assert(
+    run.event === 'workflow_dispatch',
+    `Producer run must use the "workflow_dispatch" event; got "${run.event}".`,
+  );
+};
+
+const verifyArtifact = (artifactsResponse, expectedArtifactName) => {
+  const artifacts = Array.isArray(artifactsResponse.artifacts) ? artifactsResponse.artifacts : [];
+  const matches = artifacts.filter((artifact) => artifact?.name === expectedArtifactName);
+
+  assert(
+    matches.length === 1,
+    `Expected exactly one rollback artifact named "${expectedArtifactName}", found ${matches.length}.`,
+  );
+  assert(matches[0].expired !== true, `Rollback artifact "${expectedArtifactName}" is expired.`);
+};
+
+const verifyMetadata = (metadata, expected) => {
+  assert(metadata.channel === 'production', 'Rollback metadata channel must be "production".');
+  assert(metadata.basePath === '/', 'Rollback metadata basePath must be "/".');
+  assert(metadata.sourceBranch === 'main', 'Rollback metadata sourceBranch must be "main".');
+  assert(
+    String(metadata.commitSha) === expected.commitSha,
+    `Rollback metadata commit mismatch. Expected "${expected.commitSha}", got "${metadata.commitSha}".`,
+  );
+  assert(
+    String(metadata.deployRunId) === expected.deployRunId,
+    `Rollback metadata deploy run mismatch. Expected "${expected.deployRunId}", got "${metadata.deployRunId}".`,
+  );
+  assert(
+    String(metadata.qualityRunId ?? '').trim().length > 0,
+    'Rollback metadata qualityRunId is required.',
+  );
+};
+
+const main = () => {
+  const args = parseArgs(process.argv.slice(2));
+  const expected = {
+    commitSha: args.commitSha,
+    deployRunId: args.deployRunId,
+  };
+  const artifactName = `conspectus-mobile-production-${args.commitSha}`;
+
+  verifyRun(readJson(args.runJson), expected);
+  verifyArtifact(readJson(args.artifactsJson), artifactName);
+  verifyMetadata(readJson(args.metadata), expected);
+
+  console.log(
+    `[verify-rollback-target] commitSha=${args.commitSha} deployRunId=${args.deployRunId} verified artifact "${artifactName}".`,
+  );
+};
+
+main();

--- a/scripts/verify-rollback-target.mjs
+++ b/scripts/verify-rollback-target.mjs
@@ -89,7 +89,10 @@ const verifyArtifact = (artifactsResponse, expectedArtifactName) => {
 
 const verifyMetadata = (metadata, expected) => {
   assert(metadata.channel === 'production', 'Rollback metadata channel must be "production".');
-  assert(metadata.basePath === '/', 'Rollback metadata basePath must be "/".');
+  assert(
+    metadata.basePath === '/conspectus/',
+    'Rollback metadata basePath must be "/conspectus/".',
+  );
   assert(metadata.sourceBranch === 'main', 'Rollback metadata sourceBranch must be "main".');
   assert(
     String(metadata.commitSha) === expected.commitSha,

--- a/scripts/verify-rollback-target.test.ts
+++ b/scripts/verify-rollback-target.test.ts
@@ -34,7 +34,7 @@ const createFixture = (overrides = {}) => {
     },
     metadata: {
       channel: 'production',
-      basePath: '/',
+      basePath: '/conspectus/',
       sourceBranch: 'main',
       commitSha: 'abc123',
       qualityRunId: '1001',
@@ -144,7 +144,7 @@ describe('verify-rollback-target script', () => {
     const fixture = createFixture({
       metadata: {
         channel: 'production',
-        basePath: '/',
+        basePath: '/conspectus/',
         sourceBranch: 'main',
         commitSha: 'wrong-sha',
         qualityRunId: '1001',
@@ -156,6 +156,27 @@ describe('verify-rollback-target script', () => {
       const result = runVerifier(fixture.paths);
       expect(result.status).toBe(1);
       expect(result.stderr).toContain('Rollback metadata commit mismatch');
+    } finally {
+      rmSync(fixture.fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('rejects a legacy root-scoped production artifact', () => {
+    const fixture = createFixture({
+      metadata: {
+        channel: 'production',
+        basePath: '/',
+        sourceBranch: 'main',
+        commitSha: 'abc123',
+        qualityRunId: '1001',
+        deployRunId: '2002',
+      },
+    });
+
+    try {
+      const result = runVerifier(fixture.paths);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('basePath must be "/conspectus/"');
     } finally {
       rmSync(fixture.fixturePath, { force: true, recursive: true });
     }

--- a/scripts/verify-rollback-target.test.ts
+++ b/scripts/verify-rollback-target.test.ts
@@ -1,0 +1,163 @@
+// Covers deterministic production rollback target validation and fail-closed rejection cases.
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const scriptsDirectoryPath = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRootPath = path.resolve(scriptsDirectoryPath, '..');
+const verifierPath = path.resolve(scriptsDirectoryPath, 'verify-rollback-target.mjs');
+
+const createFixture = (overrides = {}) => {
+  const fixturePath = mkdtempSync(path.join(tmpdir(), 'verify-rollback-target-'));
+  const paths = {
+    run: path.join(fixturePath, 'run.json'),
+    artifacts: path.join(fixturePath, 'artifacts.json'),
+    metadata: path.join(fixturePath, 'deploy-metadata.json'),
+  };
+  const values = {
+    run: {
+      id: 2002,
+      head_sha: 'abc123',
+      head_branch: 'main',
+      conclusion: 'success',
+      path: '.github/workflows/deploy-production.yml',
+      event: 'workflow_dispatch',
+    },
+    artifacts: {
+      artifacts: [
+        { name: 'conspectus-mobile-production-abc123', expired: false },
+        { name: 'lighthouse-production-abc123', expired: false },
+      ],
+    },
+    metadata: {
+      channel: 'production',
+      basePath: '/',
+      sourceBranch: 'main',
+      commitSha: 'abc123',
+      qualityRunId: '1001',
+      deployRunId: '2002',
+    },
+    ...overrides,
+  };
+
+  writeFileSync(paths.run, JSON.stringify(values.run));
+  writeFileSync(paths.artifacts, JSON.stringify(values.artifacts));
+  writeFileSync(paths.metadata, JSON.stringify(values.metadata));
+
+  return { fixturePath, paths };
+};
+
+const runVerifier = (paths: { run: string; artifacts: string; metadata: string }) =>
+  spawnSync(
+    'node',
+    [
+      verifierPath,
+      '--run-json',
+      paths.run,
+      '--artifacts-json',
+      paths.artifacts,
+      '--metadata',
+      paths.metadata,
+      '--commit-sha',
+      'abc123',
+      '--deploy-run-id',
+      '2002',
+    ],
+    { cwd: repositoryRootPath, encoding: 'utf8' },
+  );
+
+describe('verify-rollback-target script', () => {
+  it('accepts one unexpired production artifact and ignores unrelated run artifacts', () => {
+    const fixture = createFixture();
+
+    try {
+      const result = runVerifier(fixture.paths);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('commitSha=abc123 deployRunId=2002 verified artifact');
+    } finally {
+      rmSync(fixture.fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('rejects a run that did not successfully complete from main', () => {
+    const fixture = createFixture({
+      run: {
+        id: 2002,
+        head_sha: 'abc123',
+        head_branch: 'feature/test',
+        conclusion: 'failure',
+        path: '.github/workflows/deploy-production.yml',
+        event: 'workflow_dispatch',
+      },
+    });
+
+    try {
+      const result = runVerifier(fixture.paths);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('must originate from main');
+    } finally {
+      rmSync(fixture.fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('rejects a missing or expired exact production artifact', () => {
+    const fixture = createFixture({
+      artifacts: {
+        artifacts: [{ name: 'conspectus-mobile-production-abc123', expired: true }],
+      },
+    });
+
+    try {
+      const result = runVerifier(fixture.paths);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('is expired');
+    } finally {
+      rmSync(fixture.fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('rejects a successful main run from another workflow', () => {
+    const fixture = createFixture({
+      run: {
+        id: 2002,
+        head_sha: 'abc123',
+        head_branch: 'main',
+        conclusion: 'success',
+        path: '.github/workflows/quality.yml',
+        event: 'push',
+      },
+    });
+
+    try {
+      const result = runVerifier(fixture.paths);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('must use ".github/workflows/deploy-production.yml"');
+    } finally {
+      rmSync(fixture.fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('rejects rollback metadata that does not match the requested identity', () => {
+    const fixture = createFixture({
+      metadata: {
+        channel: 'production',
+        basePath: '/',
+        sourceBranch: 'main',
+        commitSha: 'wrong-sha',
+        qualityRunId: '1001',
+        deployRunId: '2002',
+      },
+    });
+
+    try {
+      const result = runVerifier(fixture.paths);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Rollback metadata commit mismatch');
+    } finally {
+      rmSync(fixture.fixturePath, { force: true, recursive: true });
+    }
+  });
+});

--- a/scripts/verify-website-consumer-contract.mjs
+++ b/scripts/verify-website-consumer-contract.mjs
@@ -3,7 +3,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const REQUIRED_ARGS = new Set(['workflowJson', 'producerRepo']);
+const REQUIRED_ARGS = new Set(['producerRepo']);
 const REQUIRED_PAYLOAD_FIELDS = ['commitSha', 'deployRunId', 'qualityRunId', 'artifactName'];
 const REQUIRED_CONTRACT_MARKERS = [
   'repository_dispatch',
@@ -21,6 +21,19 @@ const REQUIRED_CONTRACT_MARKERS = [
   'mv ./www/conspectus.__incoming ./www/conspectus',
   'mv ./www/conspectus.__backup ./www/conspectus',
 ];
+const EXPECTED_PUBLIC_CONTRACT = Object.freeze({
+  schemaVersion: 1,
+  eventType: 'conspectus-mobile-production-ready',
+  requiredPayloadFields: ['commitSha', 'deployRunId', 'qualityRunId', 'artifactName'],
+  basePath: '/conspectus/',
+  stagingBaseUrl: 'https://jon2050.de/conspectus.__incoming/',
+  liveBaseUrl: 'https://jon2050.de/conspectus/',
+  stagingDirectory: './www/conspectus.__incoming',
+  liveDirectory: './www/conspectus',
+  backupDirectory: './www/conspectus.__backup',
+  promotionMode: 'atomic-directory-swap',
+  rollbackMode: 'restore-backup-directory',
+});
 
 const assert = (condition, message) => {
   if (!condition) {
@@ -30,6 +43,7 @@ const assert = (condition, message) => {
 
 const parseArgs = (argv) => {
   const args = {
+    contractJson: '',
     workflowJson: '',
     producerRepo: '',
   };
@@ -53,7 +67,41 @@ const parseArgs = (argv) => {
     assert(args[requiredArg], `Missing required --${requiredArg} argument.`);
   }
 
+  assert(
+    Boolean(args.contractJson) !== Boolean(args.workflowJson),
+    'Provide exactly one of --contract-json or --workflow-json.',
+  );
+
   return args;
+};
+
+const verifyPublicContract = (contract, expectedProducerRepo) => {
+  assert(contract && typeof contract === 'object', 'Consumer contract must be a JSON object.');
+  const expectedFields = ['producerRepo', ...Object.keys(EXPECTED_PUBLIC_CONTRACT)].sort();
+  const actualFields = Object.keys(contract).sort();
+  assert(
+    JSON.stringify(actualFields) === JSON.stringify(expectedFields),
+    'Consumer contract fields must exactly match the versioned schema.',
+  );
+  assert(
+    contract.producerRepo === expectedProducerRepo,
+    `Consumer contract producerRepo must be "${expectedProducerRepo}".`,
+  );
+
+  for (const [field, expectedValue] of Object.entries(EXPECTED_PUBLIC_CONTRACT)) {
+    const actualValue = contract[field];
+    if (Array.isArray(expectedValue)) {
+      assert(
+        Array.isArray(actualValue) && JSON.stringify(actualValue) === JSON.stringify(expectedValue),
+        `Consumer contract ${field} mismatch.`,
+      );
+      continue;
+    }
+    assert(
+      actualValue === expectedValue,
+      `Consumer contract ${field} must be ${JSON.stringify(expectedValue)}.`,
+    );
+  }
 };
 
 const readJson = (filePath) => {
@@ -111,10 +159,13 @@ const verifyConsumerContract = (workflowYaml, expectedProducerRepo) => {
 
 const main = () => {
   const args = parseArgs(process.argv.slice(2));
-  const contentsResponse = readJson(args.workflowJson);
-  const workflowYaml = decodeWorkflowYaml(contentsResponse);
-
-  verifyConsumerContract(workflowYaml, args.producerRepo);
+  if (args.contractJson) {
+    verifyPublicContract(readJson(args.contractJson), args.producerRepo);
+  } else {
+    const contentsResponse = readJson(args.workflowJson);
+    const workflowYaml = decodeWorkflowYaml(contentsResponse);
+    verifyConsumerContract(workflowYaml, args.producerRepo);
+  }
 
   console.log(
     `[verify-website-consumer-contract] verified /conspectus/ consumer handoff contract for producer repo "${args.producerRepo}".`,

--- a/scripts/verify-website-consumer-contract.test.ts
+++ b/scripts/verify-website-consumer-contract.test.ts
@@ -28,6 +28,21 @@ const encodeWorkflowPayload = (workflowYaml: string) =>
     2,
   );
 
+const createValidPublicContract = () => ({
+  schemaVersion: 1,
+  producerRepo: 'Jon2050/Conspectus-Mobile',
+  eventType: 'conspectus-mobile-production-ready',
+  requiredPayloadFields: ['commitSha', 'deployRunId', 'qualityRunId', 'artifactName'],
+  basePath: '/conspectus/',
+  stagingBaseUrl: 'https://jon2050.de/conspectus.__incoming/',
+  liveBaseUrl: 'https://jon2050.de/conspectus/',
+  stagingDirectory: './www/conspectus.__incoming',
+  liveDirectory: './www/conspectus',
+  backupDirectory: './www/conspectus.__backup',
+  promotionMode: 'atomic-directory-swap',
+  rollbackMode: 'restore-backup-directory',
+});
+
 const createValidWorkflow = () =>
   [
     'name: Deploy to FTP',
@@ -70,6 +85,72 @@ const createValidWorkflow = () =>
   ].join('\n');
 
 describe('verify-website-consumer-contract script', () => {
+  it('accepts the public live consumer contract', () => {
+    const fixturePath = createFixtureDirectory();
+    const contractJsonPath = path.join(fixturePath, 'contract.json');
+
+    try {
+      writeFileSync(contractJsonPath, JSON.stringify(createValidPublicContract()));
+      const result = runVerifier([
+        '--contract-json',
+        contractJsonPath,
+        '--producer-repo',
+        'Jon2050/Conspectus-Mobile',
+      ]);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('verified /conspectus/ consumer');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('rejects a legacy live consumer base path', () => {
+    const fixturePath = createFixtureDirectory();
+    const contractJsonPath = path.join(fixturePath, 'contract.json');
+
+    try {
+      writeFileSync(
+        contractJsonPath,
+        JSON.stringify({ ...createValidPublicContract(), basePath: '/conspectus/webapp/' }),
+      );
+      const result = runVerifier([
+        '--contract-json',
+        contractJsonPath,
+        '--producer-repo',
+        'Jon2050/Conspectus-Mobile',
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('basePath');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('rejects unexpected public contract fields', () => {
+    const fixturePath = createFixtureDirectory();
+    const contractJsonPath = path.join(fixturePath, 'contract.json');
+
+    try {
+      writeFileSync(
+        contractJsonPath,
+        JSON.stringify({ ...createValidPublicContract(), internalNote: 'do not publish' }),
+      );
+      const result = runVerifier([
+        '--contract-json',
+        contractJsonPath,
+        '--producer-repo',
+        'Jon2050/Conspectus-Mobile',
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('exactly match');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
   it('accepts a workflow that matches the producer/consumer handoff contract', () => {
     const fixturePath = createFixtureDirectory();
     const workflowJsonPath = path.join(fixturePath, 'workflow.json');


### PR DESCRIPTION
## Linked issue

Closes #90.

## Outcome

Adds a deterministic, CI-only rollback across the Conspectus-Mobile producer and private website consumer for the production path `https://jon2050.de/conspectus/`.

## Changes

- add the pinned `Rollback Production` workflow with credential-free pull-request/manual dry runs and explicit main-only execution
- validate successful `Deploy Production` provenance, exact `commitSha` and `deployRunId`, artifact identity/expiry, and deploy metadata
- validate the website consumer through its exact-schema live contract at `/conspectus/conspectus-deploy-contract.json`
- reuse the website repository's staged atomic handoff and require live identity verification when execution is explicitly requested
- enforce bounded contract requests and an eight-minute global production smoke deadline
- document trigger conditions, ownership, communication, fail-closed behavior, and an under-15-minute operating timeline
- bump the app version to `0.8.09` and mark M8-09 complete after verified dry-run evidence

Companion website contract publication: Jon2050/Jon2050_Webpage#28.

## Acceptance evidence

- [x] deterministic rollback target uses immutable `deployRunId` and `commitSha`
- [x] procedure contains no manual FTP copy or production filesystem operation
- [x] execution is budgeted under 15 minutes and serialized with production deployment
- [x] pull-request dry run passed without dispatch or production mutation: https://github.com/Jon2050/Conspectus-Mobile/actions/runs/29586419784
- [x] website `master` published and revalidated the live consumer contract: https://github.com/Jon2050/Jon2050_Webpage/actions/runs/29586108690

## Verification

- `npm run audit:dependencies` — configured high/critical threshold passed; two moderate development advisories remain
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` — 461 app tests and 109 script tests passed
- `npm run build`
- `npm run check:bundle-size`
- `npm run test:e2e` — 131 passed and 1 expected skip on the implementation state
- GitHub Quality run `29586416389` — passed, including E2E and aggregate Quality Gate
- independent local reviewer — APPROVED after all findings were resolved

## Risk notes

- no runtime application behavior changes are introduced by this issue
- rollback artifacts remain subject to the existing 90-day retention window
- the dispatch credential is used only by trusted explicit execution; pull-request dry runs fetch the public live contract without credentials
- unrelated local edits to `docs/prompts/Task-Prompt-Template.md` are excluded
