### PR TITLE
Migrate production PWA to jon2050.de/conspectus/

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -60,7 +60,7 @@
 - [ ] Screenshots are included for UI changes.
 - [ ] Risk and rollback notes are documented.
 - [ ] No secrets, tokens, or credentials were added to the repository.
-- [ ] No unintended path/base URL changes were introduced (production must remain rooted at `https://conspectus.jon2050.de/`).
+- [ ] No unintended path/base URL changes were introduced (production must remain rooted at `https://jon2050.de/conspectus/`).
 
 ## Merge And Cleanup (PR Path)
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   VITE_AZURE_CLIENT_ID: ${{ vars.VITE_AZURE_CLIENT_ID }}
-  PRODUCTION_APP_BASE_URL: ${{ vars.PRODUCTION_APP_BASE_URL || 'https://conspectus.jon2050.de/' }}
+  PRODUCTION_APP_BASE_URL: ${{ vars.PRODUCTION_APP_BASE_URL || 'https://jon2050.de/conspectus/' }}
   WEBSITE_REPO_FULL_NAME: ${{ vars.WEBSITE_REPO_FULL_NAME || 'Jon2050/Jon2050_Webpage' }}
   PRODUCTION_SMOKE_MAX_ATTEMPTS: '24'
   PRODUCTION_SMOKE_RETRY_DELAY_SECONDS: '10'
@@ -127,7 +127,7 @@ jobs:
           node scripts/verify-build-channel.mjs
           --dist dist
           --channel production
-          --base /
+          --base /conspectus/
 
       - name: Resolve production handoff identity
         id: handoff
@@ -144,7 +144,7 @@ jobs:
           cat > dist/deploy-metadata.json <<EOF
           {
             "channel": "production",
-            "basePath": "/",
+            "basePath": "/conspectus/",
             "sourceBranch": "main",
             "commitSha": "${{ steps.target.outputs.commit_sha }}",
             "buildTimeUtc": "${{ steps.handoff.outputs.build_time_utc }}",

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ CI test report view in GitHub:
 - `Deploy Preview` runs automatically after a successful `Quality` push run and publishes:
   - `main` to [https://jon2050.github.io/Conspectus-Mobile/previews/main/](https://jon2050.github.io/Conspectus-Mobile/previews/main/)
   - every non-`main` branch to [https://jon2050.github.io/Conspectus-Mobile/previews/test/](https://jon2050.github.io/Conspectus-Mobile/previews/test/)
-- `Deploy Production` is manual, only from `main`, and deploys the current `main` commit to [https://conspectus.jon2050.de/](https://conspectus.jon2050.de/) after confirming a successful `Quality` run for that commit.
+- `Deploy Production` is manual, only from `main`, and deploys the current `main` commit to [https://jon2050.de/conspectus/](https://jon2050.de/conspectus/) after confirming a successful `Quality` run for that commit.
 - GitHub may also show `pages-build-deployment`; that is the GitHub-managed Pages publisher for the `gh-pages` branch, not a project-owned pipeline, and it cannot be renamed in the current branch-based Pages setup.
 
 Detailed workflow behavior, artifacts, and failure modes live in

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -29,7 +29,7 @@ Canonical sections by topic:
 - Account type support: **Microsoft personal accounts only**.
 - Platform: **PWA**, no native iOS/Android apps.
 - Backend: **none** (frontend-only).
-- Hosting: `https://conspectus.jon2050.de` (HTTPS available).
+- Hosting: `https://jon2050.de/conspectus` (HTTPS available).
 - OneDrive file selection: ask once, store binding locally.
 - Settings must include local reset/rebind option.
 - Offline database viewing and editing: **not supported**; Settings remains available for recovery.
@@ -282,10 +282,10 @@ Substeps:
      - `main` branch -> `/previews/main/`
      - every non-`main` branch -> `/previews/test/`
 2. Confirm final public route:
-   - `conspectus.jon2050.de/`
+   - `jon2050.de/conspectus/`
 3. Configure Vite/PWA build paths per channel:
    - preview: fixed-slot base path and `start_url` (`/previews/main/` or `/previews/test/`)
-   - production: `/` base path and `start_url`
+   - production: `/conspectus/` base path and `start_url`
    - service worker scope isolation for both channels
 4. Add deploy target structure compatible with existing website static hosting.
 5. Add minimal "PWA shell smoke" page to verify:
@@ -317,7 +317,7 @@ Deliverables:
 Exit criteria:
 
 - Successful `main` pushes update `/previews/main/`; successful non-`main` pushes update `/previews/test/`.
-- PWA opens correctly at `https://conspectus.jon2050.de/`.
+- PWA opens correctly at `https://jon2050.de/conspectus/`.
 - Install prompt/service worker/manifest behavior is testable on mobile devices.
 - Successful manual production deploy runs from `main` produce traceable production artifacts for website consumption.
 
@@ -331,7 +331,7 @@ Substeps:
 
 1. Register Entra app for SPA redirect flow (personal accounts).
 2. Configure redirect URIs:
-   - `https://conspectus.jon2050.de/` (production)
+   - `https://jon2050.de/conspectus/` (production)
    - `http://localhost:5173/` (local development)
 3. Implement MSAL bootstrapping and login state store.
 4. Implement sign-in and sign-out UX.
@@ -791,7 +791,7 @@ Goal: release with confidence on iOS and Android.
 
 M8-01 implementation clarification:
 
-- The PWA is deployed as a static application at the root of `conspectus.jon2050.de`. Its enforceable baseline policy lives in the `index.html` CSP and referrer-policy meta tags; `public/.htaccess` supplies optional defense-in-depth headers when Apache `mod_headers` is available.
+- The PWA is deployed as a static application in the `/conspectus/` subtree of `jon2050.de`. Its enforceable baseline policy lives in the `index.html` CSP and referrer-policy meta tags; `public/.htaccess` supplies optional defense-in-depth headers when Apache `mod_headers` is available.
 - The document CSP permits only the Svelte/Vite and runtime capabilities the app currently needs, including the narrower `script-src 'wasm-unsafe-eval'` permission for sql.js and explicit Microsoft login, Graph, and short-lived OneDrive download endpoints.
 - The optional Apache header CSP matches the document policy and adds `frame-ancestors 'none'`, plus `X-Content-Type-Options: nosniff` and `Referrer-Policy: strict-origin-when-cross-origin`. No PHP runtime is required by the production artifact.
 - The website consumer validates and preserves the artifact-owned files, then requests the public staging path before promotion to prove that the static app shell and its document policy are live. Local Playwright serving exercises the stricter optional header contract; post-deploy smoke checks use the policy that the free hosting package can enforce.
@@ -961,7 +961,7 @@ Recommended:
    - branch previews hosted from this repo on GitHub paths for development validation
    - main-only production artifact handoff for website deployment
 3. Build and deploy static output directly to:
-   - `conspectus.jon2050.de/`
+   - `jon2050.de/conspectus/`
 4. Keep website repo independent; add simple link to PWA route.
 
 Rejected alternatives for MVP (authoritative decision is section `8.3`):
@@ -980,7 +980,7 @@ Pipeline stages:
    - `/previews/main/` for `main`
    - `/previews/test/` for non-`main` branches.
 4. `Deploy Production` is started manually from `main`, requires a successful `Quality` run for the current `main` commit, builds and verifies the production `dist`, adds deployment metadata, publishes one immutable production artifact, dispatches the website repository, and runs production smoke checks against the live site.
-5. Website repo consumes the production artifact from `Deploy Production` and deploys to `conspectus.jon2050.de/`.
+5. Website repo consumes the production artifact from `Deploy Production` and deploys to `jon2050.de/conspectus/`.
 6. GitHub Pages also runs a GitHub-managed `pages-build-deployment` workflow when the `gh-pages` branch is published; this repository does not own or rename that workflow.
 
 ## 8.3 Approved Cross-Repo Deployment Architecture (M2-01)
@@ -1007,7 +1007,7 @@ Producer/consumer CI contract (automation-only, no manual copy):
    - Artifact name format: `conspectus-mobile-production-<commitSha>`.
    - Artifact payload is `dist/` and MUST include `deploy-metadata.json` with:
      - `channel` (`production`)
-     - `basePath` (`/`)
+     - `basePath` (`/conspectus/`)
      - `sourceBranch`
      - `commitSha`
      - `buildTimeUtc`
@@ -1020,16 +1020,16 @@ Producer/consumer CI contract (automation-only, no manual copy):
      - Producer workflow secret `WEBSITE_REPO_DISPATCH_TOKEN` is required for contract verification and dispatch.
      - Producer workflow variable `WEBSITE_REPO_FULL_NAME` may override the default consumer target (`Jon2050/Jon2050_Webpage`).
    - Post-deploy production smoke checks MUST run inside `Deploy Production` after the handoff dispatch succeeds.
-   - Smoke checks MUST target the production app base URL (`https://conspectus.jon2050.de/` by default; override via `PRODUCTION_APP_BASE_URL` repository variable), fail closed, verify deployed `deploy-metadata.json` identity fields (`commitSha`, `deployRunId`) against expected handoff context, and include deploy identity context in logs.
+   - Smoke checks MUST target the production app base URL (`https://jon2050.de/conspectus/` by default; override via `PRODUCTION_APP_BASE_URL` repository variable), fail closed, verify deployed `deploy-metadata.json` identity fields (`commitSha`, `deployRunId`) against expected handoff context, and include deploy identity context in logs.
 2. Consumer (website repository):
    - Trigger on `repository_dispatch` (`conspectus-mobile-production-ready`) and read payload fields as the single source of artifact identity.
    - Resolve artifact deterministically via GitHub Actions API using `deployRunId`:
      - List artifacts for that run and select exact `artifactName`.
      - Download artifact archive from the same run.
    - Consumer token MUST have `actions:read` access to `Conspectus-Mobile` artifacts.
-   - Validate `deploy-metadata.json` before publish (channel is `production`, base path is `/`, identity fields present).
+   - Validate `deploy-metadata.json` before publish (channel is `production`, base path is `/conspectus/`, identity fields present).
    - Validate identity match (`deploy-metadata.commitSha == dispatch.commitSha`, `deploy-metadata.deployRunId == dispatch.deployRunId`).
-   - Perform atomic replacement of the `conspectus/` subdomain root from the artifact contents.
+   - Perform atomic replacement of the website's `conspectus/` subtree from the artifact contents.
    - Fail deployment if artifact download or metadata validation fails.
    - Implementation note (M2-04): consumer automation is implemented in website repo workflow `.github/workflows/deploy.yml` on branch `master` in `Jon2050/Jon2050_Webpage`, with metadata validation script `scripts/validate-conspectus-deploy-metadata.mjs`.
    - Consumer credential note (M2-04): website repo secret `CONSPECTUS_MOBILE_ARTIFACT_TOKEN` must provide `actions:read` access to `Jon2050/Conspectus-Mobile` artifacts.
@@ -1078,7 +1078,7 @@ Privacy principle:
 MVP deliverables:
 
 1. Installable PWA on iOS/Android.
-2. Early integrated deployment on `conspectus.jon2050.de/` for device testing.
+2. Early integrated deployment on `jon2050.de/conspectus/` for device testing.
 3. OneDrive-authenticated access to selected SQLite DB.
 4. eTag-verified cached database reuse during online startup.
 5. Accounts view.

--- a/docs/CI-CD-Pipelines.md
+++ b/docs/CI-CD-Pipelines.md
@@ -36,7 +36,7 @@ flowchart TD
 
 - Main preview: `https://jon2050.github.io/Conspectus-Mobile/previews/main/`
 - Shared non-main preview: `https://jon2050.github.io/Conspectus-Mobile/previews/test/`
-- Production: `https://conspectus.jon2050.de/`
+- Production: `https://jon2050.de/conspectus/`
 
 ## Workflows
 
@@ -164,10 +164,10 @@ When a budget is exceeded:
   - fails if dispatch is rejected or if production smoke verification does not observe the expected `deploy-metadata.json`
   - fails if Lighthouse collection, live PWA checks, or a release threshold fails
 - Notes:
-  - rebuilds the app for production because the production base URL (`/`) differs from the preview URLs
+  - rebuilds the app for production because the production base path (`/conspectus/`) differs from the preview URLs
   - the website repo target defaults to `Jon2050/Jon2050_Webpage` and can be overridden with `WEBSITE_REPO_FULL_NAME`
-  - production smoke target defaults to `https://conspectus.jon2050.de/` and can be overridden with `PRODUCTION_APP_BASE_URL`
-  - the production artifact is a static root PWA for `conspectus.jon2050.de`; the website consumer validates `index.html`, the document CSP, and the optional `.htaccess` defense-in-depth headers before upload
+  - production smoke target defaults to `https://jon2050.de/conspectus/` and can be overridden with `PRODUCTION_APP_BASE_URL`
+  - the production artifact is a static PWA scoped to `/conspectus/` on `jon2050.de`; the website consumer validates `index.html`, the document CSP, and the optional `.htaccess` defense-in-depth headers before upload
   - production smoke validates the live document CSP and referrer-policy meta tag without requiring PHP or hosting-package response-header support
   - the CSP keeps general JavaScript evaluation disabled while allowing the narrower WebAssembly permission required by sql.js plus the Microsoft login, Graph, and OneDrive download endpoints used by the app
   - Lighthouse runs only after production smoke observes the expected commit and deploy-run identity; a failure blocks release acceptance but does not attempt an automatic rollback

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -164,11 +164,11 @@ An issue is only considered done when:
 - Depends on: `M1-08, M2-00`
 - GitHub: [#14](https://github.com/Jon2050/Conspectus-Mobile/issues/14)
 
-### :white_check_mark: M2-02 Configure Vite base path for `/conspectus/webapp/`
+### :white_check_mark: M2-02 Configure Vite base path for `/conspectus/`
 
 - Label: `feature`
 - Milestone: `M2 - Website Integration + Early Deploy`
-- Summary: Work includes production base path to /conspectus/webapp/ and routes, assets, manifest, and service worker scope. It also covers tests for generated asset URLs.
+- Summary: Work includes production base path to /conspectus/ and routes, assets, manifest, and service worker scope. It also covers tests for generated asset URLs.
 - Depends on: `M2-01`
 - GitHub: [#15](https://github.com/Jon2050/Conspectus-Mobile/issues/15)
 
@@ -184,7 +184,7 @@ An issue is only considered done when:
 
 - Label: `infra`
 - Milestone: `M2 - Website Integration + Early Deploy`
-- Summary: Work includes CI job in website repo to fetch approved PWA artifact and files to conspectus/webapp/ output location. It also covers deterministic payload-driven artifact resolution, metadata identity validation, staged atomic replacement with rollback attempt, and fail-closed behavior.
+- Summary: Work includes CI job in website repo to fetch approved PWA artifact and files to conspectus/ output location. It also covers deterministic payload-driven artifact resolution, metadata identity validation, staged atomic replacement with rollback attempt, and fail-closed behavior.
 - Depends on: `M2-03`
 - GitHub: [#19](https://github.com/Jon2050/Conspectus-Mobile/issues/19)
 

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -92,9 +92,9 @@ comment. Do not maintain a second release checklist elsewhere.
 - [ ] Require the complete workflow to succeed: fresh dependency audit, production build and path
       verification, immutable artifact publication, website-consumer contract check, deterministic
       handoff, production identity smoke check, and production Lighthouse gate.
-- [ ] Verify `https://conspectus.jon2050.de/deploy-metadata.json` reports the expected `commitSha`,
+- [ ] Verify `https://jon2050.de/conspectus/deploy-metadata.json` reports the expected `commitSha`,
       `deployRunId`, `qualityRunId`, `sourceBranch`, and `buildTimeUtc`.
-- [ ] Open `https://conspectus.jon2050.de/` and confirm the app shell, manifest, icons, and service
+- [ ] Open `https://jon2050.de/conspectus/` and confirm the app shell, manifest, icons, and service
       worker load without path or policy errors and the footer matches the released version and
       deployed build time.
 - [ ] On the required physical iOS and Android devices, confirm the installed PWA discovers and

--- a/docs/auth/Entra-App-Registration.md
+++ b/docs/auth/Entra-App-Registration.md
@@ -21,10 +21,9 @@ Create or update an app registration with the following values:
    - `Single-page application (SPA)`
 3. Redirect URIs:
    - `http://localhost:5173/`
-   - `https://conspectus.jon2050.de/`
+   - `https://jon2050.de/conspectus/`
 
-After the subdomain deployment is live and verified, remove the retired
-`https://jon2050.de/conspectus/webapp/` redirect URI if it is still registered.
+Remove every retired production redirect URI after the exact current URI above has been verified.
 
 Optional for GitHub Pages preview login:
 

--- a/docs/m2_post_review.md
+++ b/docs/m2_post_review.md
@@ -156,7 +156,7 @@ All remaining findings that are not yet fixed, organized by severity and categor
    - Without `cancel-in-progress`, multiple pushes to the same branch queue redundant Quality runs. This wastes CI minutes and delays feedback.
    - **Fix:** Add a `concurrency` block at the workflow top level, matching the pattern used in `deploy-channels.yml` (line 19). Use `group: quality-${{ github.head_ref || github.ref }}` with `cancel-in-progress: true`.
 
-9. ~~**Website-repo-side expectations (M2-04/M2-06) cannot be fully validated from this repository alone.**~~ **RESOLVED** - Added `scripts/verify-website-consumer-contract.mjs` with unit tests and wired it into `.github/workflows/website-deploy-smoke.yml` to validate consumer workflow contract markers (dispatch trigger/type, payload identity fields, producer repo binding, metadata validation step, and `conspectus/webapp` target path) against `Jon2050/Jon2050_Webpage/.github/workflows/deploy.yml` on successful `main` deploy flows.
+9. ~~**Website-repo-side expectations (M2-04/M2-06) cannot be fully validated from this repository alone.**~~ **RESOLVED** - Added `scripts/verify-website-consumer-contract.mjs` with unit tests and wired it into `.github/workflows/website-deploy-smoke.yml` to validate consumer workflow contract markers (dispatch trigger/type, payload identity fields, producer repo binding, metadata validation step, and `conspectus` target path) against `Jon2050/Jon2050_Webpage/.github/workflows/deploy.yml` on successful `main` deploy flows.
 
 #### Security
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 const resolveAppBasePath = (): string => {
   const configuredBasePath = process.env.PLAYWRIGHT_APP_BASE_PATH?.trim();
   if (!configuredBasePath) {
-    return '/';
+    return '/conspectus/';
   }
 
   const withLeadingSlash = configuredBasePath.startsWith('/')

--- a/pr-body.txt
+++ b/pr-body.txt
@@ -41,7 +41,7 @@
 - [x] Screenshots are included for UI changes.
 - [x] Risk and rollback notes are documented.
 - [x] No secrets, tokens, or credentials were added to the repository.
-- [x] No breaking path/base URL changes were introduced (must preserve `/conspectus/webapp/` deployment path behavior).
+- [x] The intentional production path migration to `/conspectus/` is documented and covered by contract tests.
 
 ## Merge And Cleanup (PR Path)
 

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,4 @@
-# Applies optional defense-in-depth headers at the root of conspectus.jon2050.de.
+# Applies optional defense-in-depth headers to the /conspectus/ production subtree.
 # The document CSP in index.html remains authoritative when mod_headers is unavailable.
 DirectoryIndex index.html
 

--- a/scripts/deploy-utils.test.ts
+++ b/scripts/deploy-utils.test.ts
@@ -42,7 +42,7 @@ describe('normalizeBasePath', () => {
   });
 
   it('handles nested paths', () => {
-    expect(normalizeBasePath('/conspectus/webapp')).toBe('/conspectus/webapp/');
+    expect(normalizeBasePath('/conspectus')).toBe('/conspectus/');
   });
 
   it('normalizes an empty string to a single slash', () => {

--- a/scripts/serve-static-dist.test.ts
+++ b/scripts/serve-static-dist.test.ts
@@ -36,9 +36,7 @@ describe('resolveRequestPath', () => {
   });
 
   it('rejects requests outside the configured base path', () => {
-    expect(
-      resolveRequestPath('/conspectus/webapp/', '/Conspectus-Mobile/previews/test/'),
-    ).toBeNull();
+    expect(resolveRequestPath('/conspectus/', '/Conspectus-Mobile/previews/test/')).toBeNull();
   });
 
   it('rejects directory traversal attempts', () => {

--- a/scripts/verify-production-deploy-smoke.test.ts
+++ b/scripts/verify-production-deploy-smoke.test.ts
@@ -3,7 +3,7 @@ import { parseArgs, runSmokeChecks } from './verify-production-deploy-smoke.mjs'
 import { DOCUMENT_CSP, PRODUCTION_CSP } from './security-policy.mjs';
 
 const baseOptions = {
-  baseUrl: 'https://conspectus.jon2050.de/',
+  baseUrl: 'https://jon2050.de/conspectus/',
   commitSha: 'abc123',
   deployRunId: '2002',
   maxAttempts: 1,
@@ -16,17 +16,17 @@ const appHtml = `<!doctype html>
   <head>
     <meta http-equiv="Content-Security-Policy" content="${DOCUMENT_CSP}" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/icons/moneysack180x180.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/conspectus/icons/moneysack180x180.png" />
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/assets/index.js"></script>
+    <script type="module" src="/conspectus/assets/index.js"></script>
   </body>
 </html>`;
 
 const validDeployMetadata = JSON.stringify({
   channel: 'production',
-  basePath: '/',
+  basePath: '/conspectus/',
   commitSha: 'abc123',
   deployRunId: '2002',
 });
@@ -71,7 +71,7 @@ const createFetchByUrl = (responses: Record<string, MockHttpResponse>): FetchMoc
   }) as FetchMock;
 
 const createHealthyResponses = (): Record<string, MockHttpResponse> => ({
-  'https://conspectus.jon2050.de/': {
+  'https://jon2050.de/conspectus/': {
     status: 200,
     body: appHtml,
     headers: {
@@ -80,11 +80,11 @@ const createHealthyResponses = (): Record<string, MockHttpResponse> => ({
       'referrer-policy': 'strict-origin-when-cross-origin',
     },
   },
-  'https://conspectus.jon2050.de/manifest.webmanifest': {
+  'https://jon2050.de/conspectus/manifest.webmanifest': {
     status: 200,
     body: JSON.stringify({
-      start_url: '/',
-      scope: '/',
+      start_url: '/conspectus/',
+      scope: '/conspectus/',
       icons: [
         {
           src: 'icons/moneysack64x64.png',
@@ -109,31 +109,31 @@ const createHealthyResponses = (): Record<string, MockHttpResponse> => ({
       ],
     }),
   },
-  'https://conspectus.jon2050.de/sw.js': {
+  'https://jon2050.de/conspectus/sw.js': {
     status: 200,
     body: 'self.addEventListener("install", () => {});',
   },
-  'https://conspectus.jon2050.de/deploy-metadata.json': {
+  'https://jon2050.de/conspectus/deploy-metadata.json': {
     status: 200,
     body: validDeployMetadata,
   },
-  'https://conspectus.jon2050.de/icons/moneysack180x180.png': {
+  'https://jon2050.de/conspectus/icons/moneysack180x180.png': {
     status: 200,
     body: 'icon-bytes',
   },
-  'https://conspectus.jon2050.de/icons/moneysack64x64.png': {
+  'https://jon2050.de/conspectus/icons/moneysack64x64.png': {
     status: 200,
     body: 'icon-bytes',
   },
-  'https://conspectus.jon2050.de/icons/moneysack192x192.png': {
+  'https://jon2050.de/conspectus/icons/moneysack192x192.png': {
     status: 200,
     body: 'icon-bytes',
   },
-  'https://conspectus.jon2050.de/icons/moneysack256x256.png': {
+  'https://jon2050.de/conspectus/icons/moneysack256x256.png': {
     status: 200,
     body: 'icon-bytes',
   },
-  'https://conspectus.jon2050.de/icons/moneysack512x512.png': {
+  'https://jon2050.de/conspectus/icons/moneysack512x512.png': {
     status: 200,
     body: 'icon-bytes',
   },
@@ -160,7 +160,7 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails when manifest URL check is not HTTP 200', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/manifest.webmanifest'] = {
+    responses['https://jon2050.de/conspectus/manifest.webmanifest'] = {
       status: 404,
       body: 'missing',
     };
@@ -176,7 +176,7 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails when service worker URL check is not HTTP 200', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/sw.js'] = {
+    responses['https://jon2050.de/conspectus/sw.js'] = {
       status: 404,
       body: 'missing',
     };
@@ -192,7 +192,7 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails HTML sanity check when bootstrap markers are missing', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/'] = {
+    responses['https://jon2050.de/conspectus/'] = {
       status: 200,
       body: '<!doctype html><html><body><main>Missing app root</main></body></html>',
     };
@@ -208,7 +208,7 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails when app route is missing moneybag apple-touch-icon link', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/'] = {
+    responses['https://jon2050.de/conspectus/'] = {
       status: 200,
       body: appHtml.replace(/<link rel="apple-touch-icon"[^>]+\/>/u, ''),
     };
@@ -224,7 +224,7 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails when app-route HTML is missing the Content-Security-Policy meta tag', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/'].body = appHtml.replace(
+    responses['https://jon2050.de/conspectus/'].body = appHtml.replace(
       /<meta http-equiv="Content-Security-Policy"[^>]+\/>/u,
       '',
     );
@@ -240,7 +240,7 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails when the CSP omits WebAssembly and OneDrive download permissions', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/'].body = appHtml.replace(
+    responses['https://jon2050.de/conspectus/'].body = appHtml.replace(
       DOCUMENT_CSP,
       "default-src 'self'; script-src 'self'; connect-src 'self' https://login.microsoftonline.com https://graph.microsoft.com",
     );
@@ -256,7 +256,7 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails when app-route HTML has an invalid referrer policy', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/'].body = appHtml.replace(
+    responses['https://jon2050.de/conspectus/'].body = appHtml.replace(
       'strict-origin-when-cross-origin',
       'unsafe-url',
     );
@@ -272,7 +272,7 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails when apple touch icon URL is not reachable', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/icons/moneysack180x180.png'] = {
+    responses['https://jon2050.de/conspectus/icons/moneysack180x180.png'] = {
       status: 404,
       body: 'missing',
     };
@@ -288,11 +288,31 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails when deploy metadata identity does not match expected deploy context', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/deploy-metadata.json'] = {
+    responses['https://jon2050.de/conspectus/deploy-metadata.json'] = {
+      status: 200,
+      body: JSON.stringify({
+        basePath: '/conspectus/',
+        commitSha: 'different-sha',
+        deployRunId: '2002',
+      }),
+    };
+    const fetchMock = createFetchByUrl(responses);
+    const sleepMock = vi.fn(async () => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await expect(runSmokeChecks(baseOptions, fetchMock, sleepMock)).rejects.toThrow(
+      'check=deploy-metadata',
+    );
+  });
+
+  it('fails when deploy metadata reports a legacy root base path', async () => {
+    const responses = createHealthyResponses();
+    responses['https://jon2050.de/conspectus/deploy-metadata.json'] = {
       status: 200,
       body: JSON.stringify({
         basePath: '/',
-        commitSha: 'different-sha',
+        commitSha: 'abc123',
         deployRunId: '2002',
       }),
     };
@@ -311,7 +331,7 @@ describe('verify-production-deploy-smoke script', () => {
     let manifestAttempts = 0;
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const resolvedUrl = resolveUrl(input);
-      if (resolvedUrl === 'https://conspectus.jon2050.de/manifest.webmanifest') {
+      if (resolvedUrl === 'https://jon2050.de/conspectus/manifest.webmanifest') {
         manifestAttempts += 1;
         if (manifestAttempts === 1) {
           return asResponse(503, 'temporarily unavailable');
@@ -346,11 +366,11 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails when required moneybag manifest icons are missing', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/manifest.webmanifest'] = {
+    responses['https://jon2050.de/conspectus/manifest.webmanifest'] = {
       status: 200,
       body: JSON.stringify({
-        start_url: '/',
-        scope: '/',
+        start_url: '/conspectus/',
+        scope: '/conspectus/',
         icons: [
           {
             src: 'icons/moneysack64x64.png',
@@ -372,7 +392,7 @@ describe('verify-production-deploy-smoke script', () => {
 
   it('fails when one manifest icon URL is not reachable', async () => {
     const responses = createHealthyResponses();
-    responses['https://conspectus.jon2050.de/icons/moneysack512x512.png'] = {
+    responses['https://jon2050.de/conspectus/icons/moneysack512x512.png'] = {
       status: 404,
       body: 'missing',
     };
@@ -389,7 +409,7 @@ describe('verify-production-deploy-smoke script', () => {
   it('normalizes cli args and applies numeric defaults', () => {
     const args = parseArgs([
       '--base-url',
-      'https://conspectus.jon2050.de',
+      'https://jon2050.de/conspectus',
       '--commit-sha',
       'abc123',
       '--deploy-run-id',
@@ -397,7 +417,7 @@ describe('verify-production-deploy-smoke script', () => {
     ]);
 
     expect(args).toEqual({
-      baseUrl: 'https://conspectus.jon2050.de/',
+      baseUrl: 'https://jon2050.de/conspectus/',
       commitSha: 'abc123',
       deployRunId: '2002',
       maxAttempts: 24,
@@ -410,7 +430,7 @@ describe('verify-production-deploy-smoke script', () => {
     expect(() =>
       parseArgs([
         '--base-url',
-        'http://jon2050.de/conspectus/webapp',
+        'http://jon2050.de/conspectus',
         '--commit-sha',
         'abc123',
         '--deploy-run-id',

--- a/scripts/verify-production-handoff.mjs
+++ b/scripts/verify-production-handoff.mjs
@@ -79,8 +79,8 @@ const verifyMetadata = (metadata, expectedValues) => {
     `Metadata channel mismatch. Expected "production", got "${metadata.channel}".`,
   );
   assert(
-    metadata.basePath === '/',
-    `Metadata basePath mismatch. Expected "/", got "${metadata.basePath}".`,
+    metadata.basePath === '/conspectus/',
+    `Metadata basePath mismatch. Expected "/conspectus/", got "${metadata.basePath}".`,
   );
   assert(metadata.sourceBranch, 'Metadata sourceBranch is required.');
   if (expectedValues.sourceBranch) {

--- a/scripts/verify-production-handoff.test.ts
+++ b/scripts/verify-production-handoff.test.ts
@@ -60,7 +60,7 @@ describe('verify-production-handoff script', () => {
       });
       writeJson(metadataPath, {
         channel: 'production',
-        basePath: '/',
+        basePath: '/conspectus/',
         sourceBranch: 'main',
         commitSha: 'abc123',
         buildTimeUtc: '2026-03-01T10:20:30Z',
@@ -91,6 +91,45 @@ describe('verify-production-handoff script', () => {
     }
   });
 
+  it('rejects legacy production base metadata', () => {
+    const fixturePath = createFixtureDirectory();
+    const artifactsPath = path.join(fixturePath, 'artifacts.json');
+    const metadataPath = path.join(fixturePath, 'deploy-metadata.json');
+    const artifactName = 'conspectus-mobile-production-abc123';
+
+    try {
+      writeJson(artifactsPath, { artifacts: [{ name: artifactName }] });
+      writeJson(metadataPath, {
+        channel: 'production',
+        basePath: '/',
+        sourceBranch: 'main',
+        commitSha: 'abc123',
+        buildTimeUtc: '2026-03-01T10:20:30Z',
+        qualityRunId: '1001',
+        deployRunId: '2002',
+      });
+
+      const result = runVerifierFailure([
+        '--artifacts-json',
+        artifactsPath,
+        '--metadata',
+        metadataPath,
+        '--artifact-name',
+        artifactName,
+        '--commit-sha',
+        'abc123',
+        '--quality-run-id',
+        '1001',
+        '--deploy-run-id',
+        '2002',
+      ]);
+
+      expect(result.stderr).toContain('Expected "/conspectus/"');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
   it('fails when more than one artifact is present for the deploy run', () => {
     const fixturePath = createFixtureDirectory();
     const artifactsPath = path.join(fixturePath, 'artifacts.json');
@@ -103,7 +142,7 @@ describe('verify-production-handoff script', () => {
       });
       writeJson(metadataPath, {
         channel: 'production',
-        basePath: '/',
+        basePath: '/conspectus/',
         sourceBranch: 'main',
         commitSha: 'abc123',
         buildTimeUtc: '2026-03-01T10:20:30Z',
@@ -146,7 +185,7 @@ describe('verify-production-handoff script', () => {
       });
       writeJson(metadataPath, {
         channel: 'production',
-        basePath: '/',
+        basePath: '/conspectus/',
         sourceBranch: 'main',
         commitSha: 'abc123',
         buildTimeUtc: '2026-03-01T10:20:30Z',
@@ -189,7 +228,7 @@ describe('verify-production-handoff script', () => {
       });
       writeJson(metadataPath, {
         channel: 'production',
-        basePath: '/',
+        basePath: '/conspectus/',
         sourceBranch: 'main',
         commitSha: 'wrong-sha',
         buildTimeUtc: '2026-03-01T10:20:30Z',
@@ -232,7 +271,7 @@ describe('verify-production-handoff script', () => {
       });
       writeJson(metadataPath, {
         channel: 'production',
-        basePath: '/',
+        basePath: '/conspectus/',
         sourceBranch: 'feature/test',
         commitSha: 'abc123',
         buildTimeUtc: '2026-03-01T10:20:30Z',

--- a/scripts/verify-website-consumer-contract.mjs
+++ b/scripts/verify-website-consumer-contract.mjs
@@ -12,10 +12,14 @@ const REQUIRED_CONTRACT_MARKERS = [
   'validate-conspectus-deploy-metadata.mjs',
   'validate-conspectus-security-headers.mjs',
   'verify-conspectus-staging-response.mjs',
+  'verify-conspectus-live-response.mjs',
+  'EXPECTED_BASE_PATH: /conspectus/',
+  'https://jon2050.de/conspectus/',
   '${incoming_dir}/.htaccess',
   '${incoming_dir}/index.html',
   './www/conspectus.__incoming/',
   'mv ./www/conspectus.__incoming ./www/conspectus',
+  'mv ./www/conspectus.__backup ./www/conspectus',
 ];
 
 const assert = (condition, message) => {
@@ -113,7 +117,7 @@ const main = () => {
   verifyConsumerContract(workflowYaml, args.producerRepo);
 
   console.log(
-    `[verify-website-consumer-contract] verified consumer handoff contract for producer repo "${args.producerRepo}".`,
+    `[verify-website-consumer-contract] verified /conspectus/ consumer handoff contract for producer repo "${args.producerRepo}".`,
   );
 };
 

--- a/scripts/verify-website-consumer-contract.test.ts
+++ b/scripts/verify-website-consumer-contract.test.ts
@@ -40,6 +40,7 @@ const createValidWorkflow = () =>
     "    if: github.event_name == 'repository_dispatch'",
     '    env:',
     '      PRODUCER_REPO: Jon2050/Conspectus-Mobile',
+    "      CONSPECTUS_LIVE_BASE_URL: ${{ vars.CONSPECTUS_LIVE_BASE_URL || 'https://jon2050.de/conspectus/' }}",
     '    steps:',
     '      - name: Validate dispatch payload and token',
     '        env:',
@@ -51,8 +52,10 @@ const createValidWorkflow = () =>
     '        run: |',
     '          run_url="https://api.github.com/repos/${PRODUCER_REPO}/actions/runs/${DEPLOY_RUN_ID}"',
     '      - name: Validate deploy metadata and identity',
+    '        env:',
+    '          EXPECTED_BASE_PATH: /conspectus/',
     '        run: node ./scripts/validate-conspectus-deploy-metadata.mjs ./pwa-artifact/deploy-metadata.json',
-    '      - name: Stage Conspectus subdomain root',
+    '      - name: Stage Conspectus website subtree',
     '        run: |',
     '          node ./scripts/validate-conspectus-security-headers.mjs "${incoming_dir}/.htaccess"',
     '          test -f "${incoming_dir}/index.html"',
@@ -60,6 +63,10 @@ const createValidWorkflow = () =>
     '          mv ./www/conspectus.__incoming ./www/conspectus',
     '      - name: Verify staged static PWA response',
     '        run: node ./scripts/verify-conspectus-staging-response.mjs',
+    '      - name: Verify promoted PWA identity and resources',
+    '        run: node ./scripts/verify-conspectus-live-response.mjs',
+    '      - name: Restore previous PWA after failed live verification',
+    '        run: mv ./www/conspectus.__backup ./www/conspectus',
   ].join('\n');
 
 describe('verify-website-consumer-contract script', () => {
@@ -82,7 +89,9 @@ describe('verify-website-consumer-contract script', () => {
       }
 
       expect(result.status).toBe(0);
-      expect(result.stdout).toContain('[verify-website-consumer-contract] verified consumer');
+      expect(result.stdout).toContain(
+        '[verify-website-consumer-contract] verified /conspectus/ consumer',
+      );
     } finally {
       rmSync(fixturePath, { force: true, recursive: true });
     }
@@ -212,6 +221,56 @@ describe('verify-website-consumer-contract script', () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain('verify-conspectus-staging-response.mjs');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('fails when the consumer does not bind metadata to the production subtree', () => {
+    const fixturePath = createFixtureDirectory();
+    const workflowJsonPath = path.join(fixturePath, 'workflow.json');
+
+    try {
+      const invalidWorkflow = createValidWorkflow().replace(
+        'EXPECTED_BASE_PATH: /conspectus/',
+        'EXPECTED_BASE_PATH: /',
+      );
+      writeFileSync(workflowJsonPath, encodeWorkflowPayload(invalidWorkflow));
+
+      const result = runVerifier([
+        '--workflow-json',
+        workflowJsonPath,
+        '--producer-repo',
+        'Jon2050/Conspectus-Mobile',
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('EXPECTED_BASE_PATH: /conspectus/');
+    } finally {
+      rmSync(fixturePath, { force: true, recursive: true });
+    }
+  });
+
+  it('fails when the consumer cannot verify and restore a promoted deployment', () => {
+    const fixturePath = createFixtureDirectory();
+    const workflowJsonPath = path.join(fixturePath, 'workflow.json');
+
+    try {
+      const invalidWorkflow = createValidWorkflow().replace(
+        'verify-conspectus-live-response.mjs',
+        'skip-live-response-validation.mjs',
+      );
+      writeFileSync(workflowJsonPath, encodeWorkflowPayload(invalidWorkflow));
+
+      const result = runVerifier([
+        '--workflow-json',
+        workflowJsonPath,
+        '--producer-repo',
+        'Jon2050/Conspectus-Mobile',
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('verify-conspectus-live-response.mjs');
     } finally {
       rmSync(fixturePath, { force: true, recursive: true });
     }

--- a/scripts/viteConfig.test.ts
+++ b/scripts/viteConfig.test.ts
@@ -51,15 +51,15 @@ describe('resolveBasePath', () => {
     ).toBe('/previews/test/');
   });
 
-  it('uses the Conspectus subdomain root for production', () => {
-    expect(resolveBasePath({ DEPLOY_CHANNEL: 'production' })).toBe('/');
+  it('uses the Conspectus website subtree for production', () => {
+    expect(resolveBasePath({ DEPLOY_CHANNEL: 'production' })).toBe('/conspectus/');
   });
 
   it('serves local development at the registered localhost redirect root', () => {
     expect(
       resolveViteBasePath(
         {
-          VITE_DEPLOY_BASE_PATH: '/conspectus/webapp/',
+          VITE_DEPLOY_BASE_PATH: '/custom-deploy/',
         },
         'serve',
         'development',
@@ -69,10 +69,10 @@ describe('resolveBasePath', () => {
 
   it('preserves configured base paths for builds and production preview', () => {
     const environment = {
-      VITE_DEPLOY_BASE_PATH: '/conspectus/webapp/',
+      VITE_DEPLOY_BASE_PATH: '/custom-deploy/',
     };
 
-    expect(resolveViteBasePath(environment, 'build', 'production')).toBe('/conspectus/webapp/');
-    expect(resolveViteBasePath(environment, 'serve', 'production')).toBe('/conspectus/webapp/');
+    expect(resolveViteBasePath(environment, 'build', 'production')).toBe('/custom-deploy/');
+    expect(resolveViteBasePath(environment, 'serve', 'production')).toBe('/custom-deploy/');
   });
 });

--- a/src/auth/msalAuthClient.test.ts
+++ b/src/auth/msalAuthClient.test.ts
@@ -118,8 +118,8 @@ const createMockMsalInstance = (options: MockMsalOptions = {}) => {
 describe('createAuthClient', () => {
   it('pins redirect handling to the resolved app root', () => {
     expect(resolveAuthRedirectUri('http://localhost:5173', '/')).toBe('http://localhost:5173/');
-    expect(resolveAuthRedirectUri('https://conspectus.jon2050.de', '/')).toBe(
-      'https://conspectus.jon2050.de/',
+    expect(resolveAuthRedirectUri('https://jon2050.de', '/conspectus/')).toBe(
+      'https://jon2050.de/conspectus/',
     );
     expect(
       resolveAuthRedirectUri('https://jon2050.github.io', '/Conspectus-Mobile/previews/test/'),
@@ -127,7 +127,7 @@ describe('createAuthClient', () => {
   });
 
   it('uses the same explicit URI for sign-in callbacks and post-logout navigation', () => {
-    const redirectUri = 'https://conspectus.jon2050.de/';
+    const redirectUri = 'https://jon2050.de/conspectus/';
 
     expect(createMsalConfiguration('client-id', redirectUri).auth).toMatchObject({
       clientId: 'client-id',
@@ -329,12 +329,12 @@ describe('createAuthClient', () => {
     const client = createAuthClient({ msalInstance: mockMsal.instance });
 
     await client.initialize();
-    await client.reauthenticate('https://conspectus.jon2050.de/#/transfers');
+    await client.reauthenticate('https://jon2050.de/conspectus/#/transfers');
 
     expect(mockMsal.acquireTokenRedirect).toHaveBeenCalledWith({
       account: activeAccount,
       scopes: ['Files.ReadWrite'],
-      redirectStartPage: 'https://conspectus.jon2050.de/#/transfers',
+      redirectStartPage: 'https://jon2050.de/conspectus/#/transfers',
     });
     expect(mockMsal.loginRedirect).not.toHaveBeenCalled();
   });

--- a/src/shared/config/buildInfo.test.ts
+++ b/src/shared/config/buildInfo.test.ts
@@ -11,9 +11,7 @@ import {
 
 describe('buildInfo', () => {
   it('resolves the deploy metadata path relative to the configured app base path', () => {
-    expect(resolveDeployMetadataUrl('/conspectus/webapp/')).toBe(
-      '/conspectus/webapp/deploy-metadata.json',
-    );
+    expect(resolveDeployMetadataUrl('/conspectus/')).toBe('/conspectus/deploy-metadata.json');
     expect(resolveDeployMetadataUrl('/Conspectus-Mobile/previews/test')).toBe(
       '/Conspectus-Mobile/previews/test/deploy-metadata.json',
     );
@@ -29,7 +27,7 @@ describe('buildInfo', () => {
 
     await expect(
       loadBuildInfo({
-        baseUrl: '/conspectus/webapp/',
+        baseUrl: '/conspectus/',
         fetch: fetchImplementation,
       }),
     ).resolves.toEqual({
@@ -37,7 +35,7 @@ describe('buildInfo', () => {
       buildTimeUtc: '2026-03-11T03:05:00Z',
     });
 
-    expect(fetchImplementation).toHaveBeenCalledWith('/conspectus/webapp/deploy-metadata.json', {
+    expect(fetchImplementation).toHaveBeenCalledWith('/conspectus/deploy-metadata.json', {
       headers: {
         accept: 'application/json',
       },
@@ -67,7 +65,7 @@ describe('buildInfo', () => {
 
     await expect(
       loadBuildInfo({
-        baseUrl: '/conspectus/webapp/',
+        baseUrl: '/conspectus/',
         fetch: fetchImplementation,
       }),
     ).resolves.toEqual(getFallbackBuildInfo());

--- a/src/shared/config/runtimeEnv.test.ts
+++ b/src/shared/config/runtimeEnv.test.ts
@@ -21,11 +21,11 @@ describe('loadRuntimeEnv', () => {
     expect(
       loadRuntimeEnv({
         VITE_AZURE_CLIENT_ID: ' client-id ',
-        VITE_DEPLOY_BASE_PATH: ' /conspectus/webapp/ ',
+        VITE_DEPLOY_BASE_PATH: ' /conspectus/ ',
       }),
     ).toEqual({
       VITE_AZURE_CLIENT_ID: 'client-id',
-      VITE_DEPLOY_BASE_PATH: '/conspectus/webapp/',
+      VITE_DEPLOY_BASE_PATH: '/conspectus/',
     });
   });
 

--- a/tests/e2e/support/app-test-harness.ts
+++ b/tests/e2e/support/app-test-harness.ts
@@ -4,7 +4,7 @@ import type { Page } from '@playwright/test';
 export const resolveAppBasePath = (): string => {
   const configuredBasePath = process.env.PLAYWRIGHT_APP_BASE_PATH?.trim();
   if (!configuredBasePath) {
-    return '/';
+    return '/conspectus/';
   }
 
   const withLeadingSlash = configuredBasePath.startsWith('/')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ import { loadEnv } from 'vite';
 // @ts-expect-error -- .mjs import has no type declarations
 import { normalizeBasePath, toPreviewSlug } from './scripts/deploy-utils.mjs';
 
-const DEFAULT_PRODUCTION_BASE_PATH = '/';
+const DEFAULT_PRODUCTION_BASE_PATH = '/conspectus/';
 const LIGHT_APP_THEME_COLOR = '#f3f4f6';
 export const PWA_REGISTER_TYPE = 'prompt' as const;
 const PACKAGE_JSON_URL = new URL('./package.json', import.meta.url);


### PR DESCRIPTION
## Summary

- migrate the production PWA base, manifest/service-worker scope, metadata, smoke checks, and Entra documentation to `https://jon2050.de/conspectus/`
- preserve GitHub preview paths and local development behavior
- reject legacy root and `/conspectus/webapp/` production artifacts in producer/consumer contract tests
- make the local Playwright production harness exercise `/conspectus/`
- remove all subdomain deployment references from active code and documentation

## Why

The free AllDomains certificate covers `jon2050.de` and `www.jon2050.de`, but not `conspectus.jon2050.de`. The release can use the already-hosted `/conspectus/` subtree without purchasing another package.

## Cross-repository dependency

Website consumer PR Jon2050/Jon2050_Webpage#27 was merged first. It validates `/conspectus/` metadata, performs atomic FTP promotion, verifies live identity/resources with bounded deadlines, and restores its backup on failure.

## Validation

- `npm run audit:dependencies`
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (461 app tests and 97 script tests)
- exact production build plus `verify-build-channel --base /conspectus/`
- `npm run check:bundle-size`
- `npm run test:e2e` (131 passed, 1 skipped)
- independent read-only cross-repository review: APPROVED

## Release impact and rollback

The first successful `/conspectus/` deployment becomes the new rollback baseline. Legacy root/subdomain artifacts are intentionally incompatible and must not be selected after cutover. The website consumer preserves and restores the prior FTP subtree if promotion verification fails.
