### PR TITLE
[M8-10] Upload hidden monitor evidence

### DIFF
--- a/.github/workflows/post-deploy-monitor.yml
+++ b/.github/workflows/post-deploy-monitor.yml
@@ -125,6 +125,7 @@ jobs:
         with:
           name: post-deploy-monitor-${{ github.run_id }}-${{ github.run_attempt }}
           path: .post-deploy-monitor/
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 30
 

--- a/scripts/post-deploy-monitor-workflow.test.ts
+++ b/scripts/post-deploy-monitor-workflow.test.ts
@@ -57,6 +57,7 @@ describe('post-deploy monitor workflow contract', () => {
     expect(workflowSource).toContain('scripts/run-post-deploy-monitor.mjs');
     expect(workflowSource).toContain('scripts/format-post-deploy-monitor-alert.mjs');
     expect(workflowSource).toContain('post-deploy-monitor-${{ github.run_id }}');
+    expect(workflowSource).toContain('include-hidden-files: true');
     expect(workflowSource).toContain('retention-days: 30');
   });
 });


### PR DESCRIPTION
## Summary

- include dot-prefixed post-deploy monitor evidence in the GitHub artifact upload
- add a workflow contract assertion so the operational requirement cannot regress

## Production evidence

Run [29589554982](https://github.com/Jon2050/Conspectus-Mobile/actions/runs/29589554982) completed the real smoke and issue-lifecycle steps successfully, then failed because `actions/upload-artifact` excludes hidden paths by default. The evidence directory is `.post-deploy-monitor/`; this change explicitly enables hidden-file upload while retaining `if-no-files-found: error`.

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (461 app tests and 121 script tests passed)
- required local reviewer: APPROVED

Relates to #91.
