### PR TITLE
[M8-11] Establish authoritative release blocker tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Use these documents as the canonical sources for their topics:
   [docs/auth/Entra-App-Registration.md](docs/auth/Entra-App-Registration.md).
 - CI/CD workflow behavior, artifacts, and failure modes:
   [docs/CI-CD-Pipelines.md](docs/CI-CD-Pipelines.md).
+- Current release readiness, serious blockers, and clearing conditions:
+  [RELEASE-BLOCKERS.md](RELEASE-BLOCKERS.md).
 - Release branch/tag strategy, approvals, release notes, and production verification:
   [docs/Release-Process.md](docs/Release-Process.md).
 - Deterministic two-repository production rollback and incident ownership:

--- a/RELEASE-BLOCKERS.md
+++ b/RELEASE-BLOCKERS.md
@@ -1,0 +1,143 @@
+# Release Blockers
+
+This is the authoritative working file for Conspectus-Mobile release readiness. The MVP must not
+be announced or marked complete while any blocker below is open. Release-execution actions that
+clear RB-04 may begin only after prerequisite blockers RB-01 through RB-03 are cleared. The backlog
+remains the implementation index; [`docs/Release-Process.md`](docs/Release-Process.md) remains the
+execution runbook.
+
+Last verified: 2026-07-17
+
+## Current decision
+
+**NOT READY FOR RELEASE**
+
+| ID    | Serious release blocker                                   | Status | Cleared only when                                                                                                               |
+| ----- | --------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| RB-01 | Runtime security headers are absent                       | Open   | #82 and #120 meet their production acceptance criteria or an explicit security/product decision formally changes those criteria |
+| RB-02 | Production Microsoft sign-in is not verified              | Open   | The Entra SPA redirects are verified and a real production sign-in returns to `/conspectus/`                                    |
+| RB-03 | Physical-device QA and install icon are unresolved        | Open   | Every required iOS/Android scenario passes on the exact candidate and #106 is resolved                                          |
+| RB-04 | No qualified, approved, deployed release candidate exists | Open   | The full release process, final review, exact-SHA deployment, tag, and GitHub Release are complete                              |
+
+## RB-01 — Runtime security headers are absent
+
+### Why this seriously blocks release
+
+The production app handles authentication and a personal financial database. Its HTML document
+contains a CSP fallback, but the live response currently supplies only HSTS—not runtime
+`Content-Security-Policy`, `X-Content-Type-Options`, or `Referrer-Policy` headers. A document CSP
+cannot provide every header-only protection, and the current acceptance criteria in
+[#82](https://github.com/Jon2050/Conspectus-Mobile/issues/82) and
+[#120](https://github.com/Jon2050/Conspectus-Mobile/issues/120) explicitly require the real
+production hosting stack to deliver and verify these headers. Describing this as complete would be
+factually incorrect.
+
+### How to fix it
+
+1. Provide a production edge or hosting capability that can set deterministic response headers.
+2. Apply the canonical CSP plus `X-Content-Type-Options: nosniff` and the agreed referrer policy to
+   every app-route response.
+3. Re-enable strict live header assertions in the cross-repository smoke contract.
+4. Run a complete production deployment and verify the headers directly against
+   `https://jon2050.de/conspectus/` on repeated requests.
+5. Close #82 and #120 only after their production evidence is linked.
+
+An explicit product/security decision may instead change the acceptance criteria and retain the
+document CSP as a known limitation. That is risk acceptance, not a technical fix, and must be
+documented before it can clear this blocker.
+
+### Why it is not fixed already
+
+AllDomains Free Hosting does not provide PHP and has ignored the artifact-owned `.htaccess`
+header directives in live responses. The prepared application and website contracts work, but the
+free hosting layer cannot enforce the required response headers. No paid package was purchased,
+and moving the domain behind another edge/proxy would be a material infrastructure and security
+decision that must not be made implicitly.
+
+## RB-02 — Production Microsoft sign-in is not verified
+
+### Why this seriously blocks release
+
+Microsoft redirect URI matching is exact. If the Entra SPA registration lacks
+`https://jon2050.de/conspectus/`, or still depends on a retired production URI, users can reach the
+app but cannot complete sign-in. Authentication and OneDrive binding are core MVP functions, so a
+release without an authoritative configuration check and real sign-in smoke would be unusable for
+its primary purpose.
+
+### How to fix it
+
+1. Authenticate to Microsoft Entra with an account that can manage application
+   `94c434a2-a0ad-485e-90a6-660a08dd8a48`.
+2. Verify the SPA redirect list contains exactly the required production URI
+   `https://jon2050.de/conspectus/` and local URI; retain documented optional preview entries only
+   if they are still used.
+3. Remove retired production redirects for the deleted subdomain and nested `/webapp/` path.
+4. Use the dedicated QA Microsoft account to sign in on production and verify the callback returns
+   to `/conspectus/` without a loop or configuration error.
+
+### Why it is not fixed already
+
+The existing Azure CLI refresh token expired. Several device-login attempts expired or remained
+unapproved at the password/passkey/MFA step, so the registration could not be read or changed
+authoritatively. Account secrets and MFA require the human account owner; they cannot be bypassed
+or entered by automation.
+
+## RB-03 — Physical-device QA and install icon are unresolved
+
+### Why this seriously blocks release
+
+iOS Safari, installed iOS PWAs, Android Chrome, and installed Android PWAs differ in installation,
+service-worker lifecycle, storage, authentication, viewport handling, and network recovery.
+Automated desktop-browser tests cannot establish those platform behaviors. In addition,
+[#106](https://github.com/Jon2050/Conspectus-Mobile/issues/106) reports a cropped/off-center
+home-screen icon, directly conflicting with the required `QA-01` result. The remaining scenarios
+exercise real OneDrive reads and writes, upload interruption, offline protection, and expired
+session recovery; failure could lose trust or create duplicate financial writes.
+
+### How to fix it
+
+1. Correct the install icon padding/centering and supply appropriate maskable icon metadata, then
+   verify the built manifest and Apple touch icon.
+2. Create the exact release candidate and freeze its shared preview slot.
+3. Run every scenario in [`docs/Manual-Device-QA.md`](docs/Manual-Device-QA.md) on a physical iPhone
+   and a supported physical Android phone using the disposable QA account/database.
+4. Attach the required screenshots, device/browser versions, candidate identity, failures, and
+   successful reruns to the release pull request.
+5. Resolve #106 and record `PASS` for every required matrix cell.
+
+### Why it is not fixed already
+
+The known icon defect has not received a reviewed asset change, and the required evidence needs
+physical devices, interactive Microsoft authentication, and a disposable OneDrive fixture.
+Browser emulation would not satisfy the committed release gate.
+
+## RB-04 — No qualified, approved, deployed release candidate exists
+
+### Why this seriously blocks release
+
+The current repository `main` and its required checks are green, but production still identifies
+an older commit. There is no release-candidate PR, completed final M8 review, physical QA evidence,
+human `APPROVED FOR RELEASE` decision, exact-SHA production deployment, immutable version tag, or
+GitHub Release. Publishing now would detach the announced version from the code and evidence that
+were actually deployed.
+
+### How to fix it
+
+After RB-01 through RB-03 are cleared:
+
+1. Complete [#114](https://github.com/Jon2050/Conspectus-Mobile/issues/114), create
+   `docs/m8_post_review.md`, and resolve every release-relevant finding.
+2. Follow [`docs/Release-Process.md`](docs/Release-Process.md) from an exact green `main` commit:
+   create the release branch, set the unused version, prepare notes, and run the full local,
+   reviewer, CI, preview, Lighthouse, and physical-device gates.
+3. Obtain the recorded human release approval, rebase-merge the release PR, and deploy that exact
+   resulting `main` SHA manually.
+4. Verify production metadata, authentication, disposable-database reads/writes, Lighthouse,
+   monitoring, and rollback evidence.
+5. Only then create the annotated tag and GitHub Release and close
+   [#92](https://github.com/Jon2050/Conspectus-Mobile/issues/92).
+
+### Why it is not fixed already
+
+The upstream security, authentication, icon, and device gates are still open. The release process
+correctly forbids creating a successful tag or release merely because repository CI is green.

--- a/docs/Architecture-and-Implementation-Plan.md
+++ b/docs/Architecture-and-Implementation-Plan.md
@@ -843,6 +843,11 @@ M8-10 implementation clarification:
 - Monitor state retains the consecutive-failure count and last-known-success `commitSha`, `deployRunId`, and `qualityRunId`. A single transient failure records evidence without alerting; the second consecutive failure opens one GitHub incident with deploy-run and immutable artifact links.
 - Successful checks reset the counter and close the monitor incident with recovery evidence. Controlled manual failures exercise the same real smoke path before simulating the failure, making alert creation and recovery verifiable without breaking production.
 
+M8-11 release-readiness clarification:
+
+- `RELEASE-BLOCKERS.md` is the single working source for serious release blockers, their evidence, and their clearing conditions. The backlog remains the implementation index and `docs/Release-Process.md` remains the ordered release runbook.
+- A green repository gate does not by itself make the product releasable. Runtime security policy, authoritative production authentication, physical-device QA, and exact-candidate approval/deployment evidence must all be cleared before tagging or closing the final release issue.
+
 Substeps:
 
 1. Security hardening:

--- a/docs/GitHub-Issues-MVP-Backlog.md
+++ b/docs/GitHub-Issues-MVP-Backlog.md
@@ -5,6 +5,10 @@ Scope includes only MVP.
 Detailed implementation steps and acceptance criteria must live in the corresponding GitHub issue for each entry.
 For each backlog entry below, open the linked GitHub issue for detailed implementation guidance and acceptance criteria.
 
+[`RELEASE-BLOCKERS.md`](../RELEASE-BLOCKERS.md) is the authoritative working file for release
+readiness. An issue can be implementation-complete without making the product releasable; any open
+release blocker must be cleared before M8-11 can be marked done.
+
 ## Issue Status Legend
 
 - `:green_circle:` Open
@@ -607,13 +611,17 @@ An issue is only considered done when:
 - Depends on: `M4-04, M4-05, M4-07, M4-08, M7-01`
 - GitHub: [#211](https://github.com/Jon2050/Conspectus-Mobile/issues/211)
 
-### :white_check_mark: M8-01 Implement CSP and security headers for PWA path
+### :yellow_circle: M8-01 Implement CSP and security headers for PWA path
 
 - Label: `security`
 - Milestone: `M8 - Hardening + QA + Release`
 - Summary: Work includes CSP compatible with Svelte/Vite build output and headers for PWA route on website hosting. It also covers Validate service worker and manifest still function.
 - Depends on: `M2-04`
 - GitHub: [#82](https://github.com/Jon2050/Conspectus-Mobile/issues/82)
+- Not done: The document CSP and artifact validation are implemented, but Free Hosting does not
+  emit the required runtime security headers. The comprehensive production follow-up is tracked in
+  [#120](https://github.com/Jon2050/Conspectus-Mobile/issues/120) and release blocker RB-01 in
+  [`RELEASE-BLOCKERS.md`](../RELEASE-BLOCKERS.md).
 
 ### :white_check_mark: M8-02 Implement PWA Service Worker Update Flow
 
@@ -687,13 +695,16 @@ An issue is only considered done when:
 - Depends on: `M2-05`
 - GitHub: [#91](https://github.com/Jon2050/Conspectus-Mobile/issues/91)
 
-### :green_circle: M8-11 Final MVP release issue
+### :yellow_circle: M8-11 Final MVP release issue
 
 - Label: `feature`
 - Milestone: `M8 - Hardening + QA + Release`
 - Summary: Work includes all milestone issues are closed and Execute release checklist and deployment. It also covers release notes and known limitations.
 - Depends on: `all milestone issues`
 - GitHub: [#92](https://github.com/Jon2050/Conspectus-Mobile/issues/92)
+- Not done: Serious security, production-authentication, physical-device/icon, and final
+  qualification gates remain open. Their evidence and clearing conditions are maintained only in
+  [`RELEASE-BLOCKERS.md`](../RELEASE-BLOCKERS.md).
 
 ### :white_check_mark: M8-12 Clean GitHub Actions, CI/CD pipeline
 
@@ -702,6 +713,9 @@ An issue is only considered done when:
 - Summary: Work includes clarifying GitHub Actions names and responsibilities and ensuring preview deploys only run after successful `Quality` runs. It also covers reusable `Quality` deploy artifacts, a manual production deploy workflow that reuses the published artifact for the current `main` commit, and maintained CI/CD documentation in `docs/CI-CD-Pipelines.md`.
 - Depends on: `M1-08, M2-00, M2-08`
 - GitHub: [#131](https://github.com/Jon2050/Conspectus-Mobile/issues/131)
+- Done clarification: This completed CI/CD cleanup issue is distinct from the later open security
+  issue [#120](https://github.com/Jon2050/Conspectus-Mobile/issues/120), whose title also uses the
+  M8-12 prefix. #120 is tracked with M8-01 under release blocker RB-01.
 
 # Future feature ideas
 

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -5,6 +5,13 @@ release and keep the completed checklist and all linked evidence in the release 
 [`Manual-Device-QA.md`](Manual-Device-QA.md) supplies the required physical-device sub-gate; it
 does not replace this end-to-end checklist.
 
+[`../RELEASE-BLOCKERS.md`](../RELEASE-BLOCKERS.md) is the authoritative release-readiness working
+file. A candidate may be created to gather the evidence required to clear a blocker, but do not
+approve, merge, deploy, tag, or publish it while a prerequisite blocker (RB-01 through RB-03)
+remains open. Once only RB-04 remains, follow this runbook to perform and record the actions that
+clear it. Update the blocker file with evidence as blockers are cleared instead of maintaining
+another blocker list.
+
 ## Release identity and ownership
 
 - Use an unused semantic version from `package.json`; `package-lock.json` must contain the same


### PR DESCRIPTION
## Summary

- establish `RELEASE-BLOCKERS.md` as the authoritative release-readiness working file
- document only four serious blockers, including why each blocks release, how to clear it, and why it remains open
- reconcile the backlog so all 76 completed entries are marked done and the two incomplete entries explain their remaining work
- link the blocker tracker from the documentation map, architecture plan, and release runbook

## Verification

- `npm run format`
- local Markdown link validation for every changed file
- `npm run lint`
- `npm run typecheck`
- `npm run test` (67 application files / 461 tests and 15 script files / 121 tests)
- `npm run build`
- `git diff --check`
- independent repository-template review: APPROVED
- verified issue states for #82, #92, #106, #114, #120, and #131
- verified current production response headers

## Release status

This documentation change does not declare the MVP releasable and does not close M8-11. The current decision remains `NOT READY FOR RELEASE` until RB-01 through RB-04 are cleared.

Relates to #92, #82, #120, #106, and #114.

Agent: Codex
