### PR TITLE
Remove unused translations

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -47,8 +47,7 @@
     "countFound": "{count} Transfers gefunden.",
     "emptyBox": "Es gibt keine Transfers für diesen Monat.",
     "primaryIncome": "EINNAHMEN",
-    "primarySpendings": "AUSGABEN",
-    "buyplace": "Geschäft"
+    "primarySpendings": "AUSGABEN"
   },
   "addTransfer": {
     "title": "Neuer Transfer",
@@ -204,18 +203,9 @@
       "unknown": "Unbekannt"
     }
   },
-  "deploymentInfo": {
-    "title": "Deployment-Info",
-    "version": "Version",
-    "commit": "Commit",
-    "build": "Build"
-  },
   "loadingPlaceholder": {
     "title": "Lade...",
     "description": "Dein mobiler Arbeitsplatz wird vorbereitet."
-  },
-  "toast": {
-    "dismiss": "Schließen"
   },
   "sync": {
     "startup": {
@@ -224,11 +214,7 @@
       "onlineChanged": "Neueste DB von OneDrive heruntergeladen.",
       "fileMissing": "Die ausgewählte OneDrive-Datenbank ist am gespeicherten Pfad nicht mehr verfügbar. Wähle in den Einstellungen eine andere Datenbank aus.",
       "completed": "DB-Synchronisation abgeschlossen.",
-      "failed": "Start-Synchronisation fehlgeschlagen.",
-      "failedUnexpected": "Start-Synchronisation unerwartet fehlgeschlagen. Bitte prüfe die Browser-Konsole und versuche es erneut."
-    },
-    "upload": {
-      "uploading": "Datenbank wird auf OneDrive hochgeladen..."
+      "failed": "Start-Synchronisation fehlgeschlagen."
     },
     "dbRuntimeError": {
       "initFailed": "Konnte lokale SQLite-Laufzeitumgebung nicht initialisieren. Lade die App neu.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -47,8 +47,7 @@
     "countFound": "{count} transfers found.",
     "emptyBox": "There are no transfers recorded for this month.",
     "primaryIncome": "INCOME",
-    "primarySpendings": "SPENDINGS",
-    "buyplace": "Store"
+    "primarySpendings": "SPENDINGS"
   },
   "addTransfer": {
     "title": "New Transfer",
@@ -204,18 +203,9 @@
       "unknown": "Unknown"
     }
   },
-  "deploymentInfo": {
-    "title": "Deployment Info",
-    "version": "Version",
-    "commit": "Commit",
-    "build": "Build"
-  },
   "loadingPlaceholder": {
     "title": "Loading...",
     "description": "Preparing your mobile workspace."
-  },
-  "toast": {
-    "dismiss": "Dismiss"
   },
   "sync": {
     "startup": {
@@ -224,11 +214,7 @@
       "onlineChanged": "Downloaded the latest DB from OneDrive.",
       "fileMissing": "The selected OneDrive database is no longer available at its saved path. Select another DB file in Settings.",
       "completed": "DB sync completed.",
-      "failed": "Startup sync failed.",
-      "failedUnexpected": "Startup sync failed unexpectedly. Check the browser console and retry."
-    },
-    "upload": {
-      "uploading": "Uploading database to OneDrive..."
+      "failed": "Startup sync failed."
     },
     "dbRuntimeError": {
       "initFailed": "Failed to initialize the local SQLite runtime. Reload the app and try syncing again.",


### PR DESCRIPTION
## Summary

- remove eight translation keys that are not referenced by the production app
- keep the German and English locale key sets aligned

## Impact

No application behavior changes. This only removes unreachable locale strings from `src/i18n/de.json` and `src/i18n/en.json`.

## Validation

- `npm run check:local`
- JSON parsing validation
- pre-commit lint-staged formatting