### PR TITLE
fix: restore Microsoft sessions automatically

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,9 +92,17 @@ Authentication behavior:
 1. Initialize MSAL and process any redirect result before route handling can discard it.
 2. Restore the active account deterministically from the redirect result, current active account,
    or cached accounts.
-3. Acquire Graph tokens silently first.
-4. Surface an explicit reauthentication action when interaction is required; preserve the route
-   that requested recovery.
+3. When MSAL has no cached account, use a token-free account hint retained for up to 30 days to
+   attempt one promptless Microsoft session restoration per browser session.
+4. Acquire Graph tokens silently first. If Microsoft requires interaction after an active session
+   expires, attempt one promptless redirect recovery while preserving the requesting route.
+5. Keep the existing explicit sign-in or reauthentication action as the fallback when Microsoft
+   cannot restore the session without user interaction.
+
+The app-owned restoration record contains only the MSAL home-account ID, login hint, and expiry;
+access, refresh, and ID tokens remain owned by MSAL and are never copied into app storage. Explicit
+sign-out clears the record. The 30-day window controls only whether Conspectus attempts restoration:
+Microsoft can still require interaction earlier because of account, browser, or tenant policy.
 
 The selected OneDrive database binding contains `driveId`, `itemId`, filename, and parent path. It
 is persisted per Microsoft account so switching accounts cannot reuse another account's binding.
@@ -172,11 +180,13 @@ reuse, and application operation:
 - schema-versioned selected-file bindings;
 - cached database bytes and their matching eTag/sync metadata;
 - MSAL-managed authentication state;
+- the token-free authentication restoration hint described above;
 - PWA/service-worker caches and short-lived UI state.
 
 Confirmed local reset clears app-owned bindings, database snapshots, and app cache data after
 closing active Dexie connections. It intentionally preserves the Microsoft authentication session
-so the user can rebind without an unnecessary sign-in. Sign-out remains a separate explicit action.
+and restoration hint so the user can rebind without an unnecessary sign-in. Sign-out remains a
+separate explicit action.
 
 ## PWA lifecycle and deployment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4684,16 +4684,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6284,43 +6284,16 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
-      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-2.0.2.tgz",
+      "integrity": "sha512-qiTS+zFS40hGcaPnunc1VBkcaiEBdMSughI6Jfm5ojSNUnn28vpfftIm/q7SIjLf6Ws+l8DMWlnzlZV/f8GKAA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "minimatch": "^10.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "20 || >=22"
       }
     },
     "node_modules/fill-range": {

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
     "dexie": "^4.3.0",
     "sql.js": "^1.14.1",
     "svelte-i18n": "^4.0.1"
+  },
+  "overrides": {
+    "filelist": "2.0.2"
   }
 }

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -15,7 +15,7 @@ Expected public interfaces (`src/auth/index.ts`):
 
 - `AuthAccount`: signed-in account identity surfaced to UI/state layers.
 - `AuthSession`: deterministic auth state snapshot (`isAuthenticated` + account).
-- `AuthClient`: bootstrap/login/logout/token and active-account re-authentication API used by higher-level modules.
+- `AuthClient`: bootstrap/login/logout/token, promptless session restoration, and active-account re-authentication API used by higher-level modules.
 - `createAuthClient`: factory that hides MSAL details behind the `AuthClient` interface.
 - `AuthErrorCode` and `AuthError`: normalized, provider-agnostic auth failure model.
 
@@ -23,6 +23,10 @@ M3 implementation target:
 
 - Keep MSAL-specific details behind `AuthClient`.
 - Use silent-first token acquisition (`acquireTokenSilent`) and return `interaction_required` when user re-auth is needed.
+- Retain only a token-free account ID/login hint for up to 30 days and use it for one promptless
+  Microsoft session-restoration attempt per browser session when MSAL has no cached account.
 - Recover expired Graph sessions with `acquireTokenRedirect`, pinned to the active account and the requesting app route.
 - Restore active account in deterministic order: redirect result account, current active account, then cached account fallback.
+- Clear the restoration hint on explicit sign-out; Microsoft policy may still require interactive
+  sign-in before the 30-day eligibility window ends.
 - Return stable session and error shapes so feature code does not depend on MSAL internals.

--- a/src/auth/authSessionResumeStore.test.ts
+++ b/src/auth/authSessionResumeStore.test.ts
@@ -1,0 +1,137 @@
+// Verifies token-free resume metadata expiry, validation, and once-per-session redirect claims.
+import { describe, expect, it } from 'vitest';
+
+import {
+  AUTH_SESSION_RESUME_ATTEMPT_STORAGE_KEY,
+  AUTH_SESSION_RESUME_STORAGE_KEY,
+  AUTH_SESSION_RESUME_TTL_MS,
+  createAuthSessionResumeStore,
+} from './authSessionResumeStore';
+
+const createMemoryStorage = () => {
+  const values = new Map<string, string>();
+
+  return {
+    getItem: (key: string): string | null => values.get(key) ?? null,
+    setItem: (key: string, value: string): void => {
+      values.set(key, value);
+    },
+    removeItem: (key: string): void => {
+      values.delete(key);
+    },
+    readRaw: (key: string): string | null => values.get(key) ?? null,
+  };
+};
+
+describe('auth session resume store', () => {
+  it('persists only a normalized account hint for thirty days', () => {
+    const localStorage = createMemoryStorage();
+    const sessionStorage = createMemoryStorage();
+    const nowEpochMs = Date.UTC(2026, 6, 26);
+    const store = createAuthSessionResumeStore({
+      localStorage,
+      sessionStorage,
+      now: () => nowEpochMs,
+    });
+
+    store.save('  home-account  ', '  person@example.com  ');
+
+    expect(store.read()).toEqual({
+      homeAccountId: 'home-account',
+      loginHint: 'person@example.com',
+      expiresAtEpochMs: nowEpochMs + AUTH_SESSION_RESUME_TTL_MS,
+    });
+    expect(JSON.parse(localStorage.readRaw(AUTH_SESSION_RESUME_STORAGE_KEY) ?? '{}')).toEqual({
+      version: 1,
+      homeAccountId: 'home-account',
+      loginHint: 'person@example.com',
+      expiresAtEpochMs: nowEpochMs + AUTH_SESSION_RESUME_TTL_MS,
+    });
+    expect(localStorage.readRaw(AUTH_SESSION_RESUME_STORAGE_KEY)).not.toContain('accessToken');
+    expect(localStorage.readRaw(AUTH_SESSION_RESUME_STORAGE_KEY)).not.toContain('refreshToken');
+    expect(localStorage.readRaw(AUTH_SESSION_RESUME_STORAGE_KEY)).not.toContain('idToken');
+  });
+
+  it('accepts the record before expiry and removes it at the expiry boundary', () => {
+    const localStorage = createMemoryStorage();
+    const sessionStorage = createMemoryStorage();
+    let nowEpochMs = 10_000;
+    const store = createAuthSessionResumeStore({
+      localStorage,
+      sessionStorage,
+      now: () => nowEpochMs,
+    });
+
+    store.save('home-account', 'person@example.com');
+    nowEpochMs += AUTH_SESSION_RESUME_TTL_MS - 1;
+    expect(store.read()?.homeAccountId).toBe('home-account');
+
+    nowEpochMs += 1;
+    expect(store.read()).toBeNull();
+    expect(localStorage.readRaw(AUTH_SESSION_RESUME_STORAGE_KEY)).toBeNull();
+  });
+
+  it.each([
+    'not-json',
+    JSON.stringify({ version: 1 }),
+    JSON.stringify({
+      version: 1,
+      homeAccountId: 'home-account',
+      loginHint: ' ',
+      expiresAtEpochMs: 20_000,
+    }),
+    JSON.stringify({
+      version: 2,
+      homeAccountId: 'home-account',
+      loginHint: 'person@example.com',
+      expiresAtEpochMs: 20_000,
+    }),
+  ])('removes malformed resume data', (rawValue) => {
+    const localStorage = createMemoryStorage();
+    localStorage.setItem(AUTH_SESSION_RESUME_STORAGE_KEY, rawValue);
+    const store = createAuthSessionResumeStore({
+      localStorage,
+      sessionStorage: createMemoryStorage(),
+      now: () => 10_000,
+    });
+
+    expect(store.read()).toBeNull();
+    expect(localStorage.readRaw(AUTH_SESSION_RESUME_STORAGE_KEY)).toBeNull();
+  });
+
+  it('claims at most one automatic redirect per browser session', () => {
+    const sessionStorage = createMemoryStorage();
+    const store = createAuthSessionResumeStore({
+      localStorage: createMemoryStorage(),
+      sessionStorage,
+    });
+
+    expect(store.claimAttempt('home-account', 'session_resume')).toBe(true);
+    expect(store.claimAttempt('home-account', 'session_resume')).toBe(false);
+    expect(store.claimAttempt('another-account', 'token_recovery')).toBe(false);
+    expect(store.readAttempt()).toEqual({
+      homeAccountId: 'home-account',
+      kind: 'session_resume',
+    });
+
+    store.clearAttempt();
+
+    expect(sessionStorage.readRaw(AUTH_SESSION_RESUME_ATTEMPT_STORAGE_KEY)).toBeNull();
+    expect(store.claimAttempt('another-account', 'token_recovery')).toBe(true);
+  });
+
+  it('fails closed when session storage cannot persist the loop guard', () => {
+    const store = createAuthSessionResumeStore({
+      localStorage: createMemoryStorage(),
+      sessionStorage: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('blocked');
+        },
+        removeItem: () => {},
+      },
+    });
+
+    expect(store.claimAttempt('home-account', 'session_resume')).toBe(false);
+  });
+});

--- a/src/auth/authSessionResumeStore.ts
+++ b/src/auth/authSessionResumeStore.ts
@@ -1,0 +1,235 @@
+// Persists token-free account hints and guards automatic Microsoft session restoration redirects.
+export const AUTH_SESSION_RESUME_STORAGE_KEY = 'conspectus.authSessionResume';
+export const AUTH_SESSION_RESUME_ATTEMPT_STORAGE_KEY = 'conspectus.authSessionResumeAttempt';
+export const AUTH_SESSION_RESUME_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+const RESUME_RECORD_VERSION = 1;
+const RESUME_ATTEMPT_VERSION = 1;
+
+type StorageAdapter = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+export type AuthSessionResumeAttemptKind = 'session_resume' | 'token_recovery';
+
+export interface AuthSessionResumeRecord {
+  readonly homeAccountId: string;
+  readonly loginHint: string;
+  readonly expiresAtEpochMs: number;
+}
+
+export interface AuthSessionResumeAttempt {
+  readonly homeAccountId: string;
+  readonly kind: AuthSessionResumeAttemptKind;
+}
+
+export interface AuthSessionResumeStore {
+  read(): AuthSessionResumeRecord | null;
+  save(homeAccountId: string, loginHint: string): void;
+  clear(): void;
+  readAttempt(): AuthSessionResumeAttempt | null;
+  claimAttempt(homeAccountId: string, kind: AuthSessionResumeAttemptKind): boolean;
+  clearAttempt(): void;
+}
+
+interface CreateAuthSessionResumeStoreOptions {
+  readonly localStorage?: StorageAdapter | null;
+  readonly sessionStorage?: StorageAdapter | null;
+  readonly now?: () => number;
+}
+
+interface PersistedResumeRecord {
+  readonly version: typeof RESUME_RECORD_VERSION;
+  readonly homeAccountId: string;
+  readonly loginHint: string;
+  readonly expiresAtEpochMs: number;
+}
+
+interface PersistedResumeAttempt {
+  readonly version: typeof RESUME_ATTEMPT_VERSION;
+  readonly homeAccountId: string;
+  readonly kind: AuthSessionResumeAttemptKind;
+}
+
+const normalizeNonEmptyString = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
+const parseResumeRecord = (value: unknown, nowEpochMs: number): AuthSessionResumeRecord | null => {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  const candidate = value as Partial<PersistedResumeRecord>;
+  const homeAccountId = normalizeNonEmptyString(candidate.homeAccountId);
+  const loginHint = normalizeNonEmptyString(candidate.loginHint);
+  if (
+    candidate.version !== RESUME_RECORD_VERSION ||
+    homeAccountId === null ||
+    loginHint === null ||
+    typeof candidate.expiresAtEpochMs !== 'number' ||
+    !Number.isFinite(candidate.expiresAtEpochMs) ||
+    candidate.expiresAtEpochMs <= nowEpochMs
+  ) {
+    return null;
+  }
+
+  return {
+    homeAccountId,
+    loginHint,
+    expiresAtEpochMs: candidate.expiresAtEpochMs,
+  };
+};
+
+const parseResumeAttempt = (value: unknown): AuthSessionResumeAttempt | null => {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  const candidate = value as Partial<PersistedResumeAttempt>;
+  const homeAccountId = normalizeNonEmptyString(candidate.homeAccountId);
+  if (
+    candidate.version !== RESUME_ATTEMPT_VERSION ||
+    homeAccountId === null ||
+    (candidate.kind !== 'session_resume' && candidate.kind !== 'token_recovery')
+  ) {
+    return null;
+  }
+
+  return {
+    homeAccountId,
+    kind: candidate.kind,
+  };
+};
+
+const readJson = (storage: StorageAdapter | null, key: string): unknown => {
+  if (storage === null) {
+    return null;
+  }
+
+  try {
+    const rawValue = storage.getItem(key);
+    return rawValue === null ? null : JSON.parse(rawValue);
+  } catch {
+    return null;
+  }
+};
+
+const removeItem = (storage: StorageAdapter | null, key: string): void => {
+  try {
+    storage?.removeItem(key);
+  } catch {
+    // Storage failures must not break the authentication flow.
+  }
+};
+
+const resolveStorage = (name: 'localStorage' | 'sessionStorage'): StorageAdapter | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window[name];
+  } catch {
+    return null;
+  }
+};
+
+export const createAuthSessionResumeStore = (
+  options: CreateAuthSessionResumeStoreOptions = {},
+): AuthSessionResumeStore => {
+  const localStorage =
+    options.localStorage === undefined ? resolveStorage('localStorage') : options.localStorage;
+  const sessionStorage =
+    options.sessionStorage === undefined
+      ? resolveStorage('sessionStorage')
+      : options.sessionStorage;
+  const now = options.now ?? Date.now;
+
+  return {
+    read(): AuthSessionResumeRecord | null {
+      const record = parseResumeRecord(
+        readJson(localStorage, AUTH_SESSION_RESUME_STORAGE_KEY),
+        now(),
+      );
+      if (record === null) {
+        removeItem(localStorage, AUTH_SESSION_RESUME_STORAGE_KEY);
+      }
+      return record;
+    },
+
+    save(homeAccountId: string, loginHint: string): void {
+      const normalizedHomeAccountId = normalizeNonEmptyString(homeAccountId);
+      const normalizedLoginHint = normalizeNonEmptyString(loginHint);
+      if (
+        localStorage === null ||
+        normalizedHomeAccountId === null ||
+        normalizedLoginHint === null
+      ) {
+        return;
+      }
+
+      const payload: PersistedResumeRecord = {
+        version: RESUME_RECORD_VERSION,
+        homeAccountId: normalizedHomeAccountId,
+        loginHint: normalizedLoginHint,
+        expiresAtEpochMs: now() + AUTH_SESSION_RESUME_TTL_MS,
+      };
+
+      try {
+        localStorage.setItem(AUTH_SESSION_RESUME_STORAGE_KEY, JSON.stringify(payload));
+      } catch {
+        // Authentication remains usable without automatic cross-session restoration.
+      }
+    },
+
+    clear(): void {
+      removeItem(localStorage, AUTH_SESSION_RESUME_STORAGE_KEY);
+    },
+
+    readAttempt(): AuthSessionResumeAttempt | null {
+      const attempt = parseResumeAttempt(
+        readJson(sessionStorage, AUTH_SESSION_RESUME_ATTEMPT_STORAGE_KEY),
+      );
+      if (attempt === null) {
+        removeItem(sessionStorage, AUTH_SESSION_RESUME_ATTEMPT_STORAGE_KEY);
+      }
+      return attempt;
+    },
+
+    claimAttempt(homeAccountId: string, kind: AuthSessionResumeAttemptKind): boolean {
+      const normalizedHomeAccountId = normalizeNonEmptyString(homeAccountId);
+      if (
+        sessionStorage === null ||
+        normalizedHomeAccountId === null ||
+        this.readAttempt() !== null
+      ) {
+        return false;
+      }
+
+      const payload: PersistedResumeAttempt = {
+        version: RESUME_ATTEMPT_VERSION,
+        homeAccountId: normalizedHomeAccountId,
+        kind,
+      };
+
+      try {
+        sessionStorage.setItem(AUTH_SESSION_RESUME_ATTEMPT_STORAGE_KEY, JSON.stringify(payload));
+        const claimedAttempt = this.readAttempt();
+        return (
+          claimedAttempt?.homeAccountId === normalizedHomeAccountId && claimedAttempt.kind === kind
+        );
+      } catch {
+        removeItem(sessionStorage, AUTH_SESSION_RESUME_ATTEMPT_STORAGE_KEY);
+        return false;
+      }
+    },
+
+    clearAttempt(): void {
+      removeItem(sessionStorage, AUTH_SESSION_RESUME_ATTEMPT_STORAGE_KEY);
+    },
+  };
+};

--- a/src/auth/index.test.ts
+++ b/src/auth/index.test.ts
@@ -55,6 +55,7 @@ describe('auth barrel contract', () => {
         initialize: expect.any(Function),
         getSession: expect.any(Function),
         signIn: expect.any(Function),
+        attemptSessionResume: expect.any(Function),
         reauthenticate: expect.any(Function),
         signOut: expect.any(Function),
         getAccessToken: expect.any(Function),

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -20,6 +20,7 @@ export interface AuthClient {
   initialize(): Promise<void>;
   getSession(): AuthSession;
   signIn(): Promise<void>;
+  attemptSessionResume(redirectStartPage: string): Promise<boolean>;
   reauthenticate(redirectStartPage: string): Promise<void>;
   signOut(): Promise<void>;
   getAccessToken(scopes: readonly string[]): Promise<string>;
@@ -32,5 +33,15 @@ export interface AuthError {
 }
 
 export { createAuthClient } from './msalAuthClient';
+export {
+  AUTH_SESSION_RESUME_STORAGE_KEY,
+  createAuthSessionResumeStore,
+} from './authSessionResumeStore';
+export type {
+  AuthSessionResumeAttempt,
+  AuthSessionResumeAttemptKind,
+  AuthSessionResumeRecord,
+  AuthSessionResumeStore,
+} from './authSessionResumeStore';
 export { AUTH_OIDC_SCOPES, GRAPH_ONEDRIVE_FILE_SCOPES, AUTH_REQUEST_SCOPES } from './scopes';
 export type { AuthRequestScope } from './scopes';

--- a/src/auth/msalAuthClient.test.ts
+++ b/src/auth/msalAuthClient.test.ts
@@ -13,6 +13,10 @@ import {
   createMsalConfiguration,
   resolveAuthRedirectUri,
 } from './msalAuthClient';
+import {
+  AUTH_SESSION_RESUME_ATTEMPT_STORAGE_KEY,
+  createAuthSessionResumeStore,
+} from './authSessionResumeStore';
 import { AUTH_REQUEST_SCOPES } from './scopes';
 
 type CreateAuthClientArg = NonNullable<Parameters<typeof createAuthClient>[0]>;
@@ -20,11 +24,13 @@ type MsalInstance = NonNullable<CreateAuthClientArg['msalInstance']>;
 
 interface MockMsalOptions {
   readonly redirectResult?: AuthenticationResult | null;
+  readonly handleRedirectError?: unknown;
   readonly initialActiveAccount?: AccountInfo | null;
   readonly cachedAccounts?: AccountInfo[];
   readonly silentResult?: AuthenticationResult;
   readonly silentError?: unknown;
   readonly redirectError?: unknown;
+  readonly loginRedirectError?: unknown;
   readonly logoutError?: unknown;
 }
 
@@ -35,6 +41,7 @@ const createAccount = (username: string, homeAccountId: string): AccountInfo => 
   username,
   localAccountId: `${homeAccountId}-local`,
   name: `Name ${username}`,
+  loginHint: username,
 });
 
 const createAuthenticationResult = (
@@ -60,13 +67,23 @@ const createMockMsalInstance = (options: MockMsalOptions = {}) => {
   const cachedAccounts = options.cachedAccounts ?? [];
 
   const initialize = vi.fn(async () => {});
-  const handleRedirectPromise = vi.fn(async () => options.redirectResult ?? null);
+  const handleRedirectPromise = vi.fn(async () => {
+    if (options.handleRedirectError !== undefined) {
+      throw options.handleRedirectError;
+    }
+
+    return options.redirectResult ?? null;
+  });
   const getActiveAccount = vi.fn(() => activeAccount);
   const setActiveAccount = vi.fn((account: AccountInfo | null) => {
     activeAccount = account;
   });
   const getAllAccounts = vi.fn(() => [...cachedAccounts]);
-  const loginRedirect = vi.fn(async () => {});
+  const loginRedirect = vi.fn(async () => {
+    if (options.loginRedirectError !== undefined) {
+      throw options.loginRedirectError;
+    }
+  });
   const acquireTokenRedirect = vi.fn(async () => {
     if (options.redirectError !== undefined) {
       throw options.redirectError;
@@ -113,6 +130,32 @@ const createMockMsalInstance = (options: MockMsalOptions = {}) => {
     acquireTokenSilent,
     getActiveAccountValue: (): AccountInfo | null => activeAccount,
   };
+};
+
+const createMemoryStorage = () => {
+  const values = new Map<string, string>();
+
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      values.set(key, value);
+    },
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+  };
+};
+
+const createResumeStoreHarness = () => {
+  const localStorage = createMemoryStorage();
+  const sessionStorage = createMemoryStorage();
+  const store = createAuthSessionResumeStore({
+    localStorage,
+    sessionStorage,
+    now: () => Date.parse('2026-07-26T12:00:00.000Z'),
+  });
+
+  return { localStorage, sessionStorage, store };
 };
 
 describe('createAuthClient', () => {
@@ -181,6 +224,88 @@ describe('createAuthClient', () => {
     await client.initialize();
 
     expect(mockMsal.getActiveAccountValue()).toEqual(accountA);
+  });
+
+  it('automatically attempts a promptless session resume from a valid stored hint', async () => {
+    const resumeHarness = createResumeStoreHarness();
+    resumeHarness.store.save('remembered-home', 'remembered@example.com');
+    const mockMsal = createMockMsalInstance();
+    const client = createAuthClient({
+      msalInstance: mockMsal.instance,
+      sessionResumeStore: resumeHarness.store,
+      redirectStartPageResolver: () => 'https://conspectus.local/#/accounts',
+    });
+
+    await client.initialize();
+
+    expect(mockMsal.loginRedirect).toHaveBeenCalledWith({
+      scopes: [...AUTH_REQUEST_SCOPES],
+      prompt: 'none',
+      loginHint: 'remembered@example.com',
+      redirectStartPage: 'https://conspectus.local/#/accounts',
+    });
+    expect(resumeHarness.store.readAttempt()).toEqual({
+      homeAccountId: 'remembered-home',
+      kind: 'session_resume',
+    });
+  });
+
+  it('does not automatically resume without a valid stored hint', async () => {
+    const resumeHarness = createResumeStoreHarness();
+    const mockMsal = createMockMsalInstance();
+    const client = createAuthClient({
+      msalInstance: mockMsal.instance,
+      sessionResumeStore: resumeHarness.store,
+    });
+
+    await client.initialize();
+
+    expect(mockMsal.loginRedirect).not.toHaveBeenCalled();
+  });
+
+  it('stops a failed promptless session resume without creating a redirect loop', async () => {
+    const resumeHarness = createResumeStoreHarness();
+    resumeHarness.store.save('remembered-home', 'remembered@example.com');
+    resumeHarness.store.claimAttempt('remembered-home', 'session_resume');
+    const mockMsal = createMockMsalInstance({
+      handleRedirectError: new InteractionRequiredAuthError(
+        InteractionRequiredAuthErrorCodes.loginRequired,
+        'login required',
+      ),
+    });
+    const client = createAuthClient({
+      msalInstance: mockMsal.instance,
+      sessionResumeStore: resumeHarness.store,
+    });
+
+    await client.initialize();
+
+    expect(client.getSession().isAuthenticated).toBe(false);
+    expect(resumeHarness.store.read()).toBeNull();
+    expect(mockMsal.loginRedirect).not.toHaveBeenCalled();
+  });
+
+  it('persists the redirect account hint and clears the automatic attempt marker', async () => {
+    const resumeHarness = createResumeStoreHarness();
+    resumeHarness.store.claimAttempt('redirect-home', 'session_resume');
+    const redirectAccount = createAccount('redirect@example.com', 'redirect-home');
+    const mockMsal = createMockMsalInstance({
+      redirectResult: createAuthenticationResult(redirectAccount),
+    });
+    const client = createAuthClient({
+      msalInstance: mockMsal.instance,
+      sessionResumeStore: resumeHarness.store,
+    });
+
+    await client.initialize();
+
+    expect(resumeHarness.store.read()).toMatchObject({
+      homeAccountId: 'redirect-home',
+      loginHint: 'redirect@example.com',
+    });
+    expect(
+      resumeHarness.sessionStorage.getItem(AUTH_SESSION_RESUME_ATTEMPT_STORAGE_KEY),
+    ).toBeNull();
   });
 
   it('acquires token silently when a session exists', async () => {
@@ -299,6 +424,9 @@ describe('createAuthClient', () => {
     const client = createAuthClient({ msalInstance: mockMsal.instance });
 
     await expect(client.signIn()).rejects.toMatchObject({ code: 'not_initialized' });
+    await expect(client.attemptSessionResume('https://conspectus.local/')).rejects.toMatchObject({
+      code: 'not_initialized',
+    });
     await expect(client.signOut()).rejects.toMatchObject({ code: 'not_initialized' });
     await expect(client.getAccessToken(['Files.ReadWrite'])).rejects.toMatchObject({
       code: 'not_initialized',
@@ -339,6 +467,35 @@ describe('createAuthClient', () => {
     expect(mockMsal.loginRedirect).not.toHaveBeenCalled();
   });
 
+  it('attempts token recovery automatically only once per browser session', async () => {
+    const resumeHarness = createResumeStoreHarness();
+    const activeAccount = createAccount('active@example.com', 'active-home');
+    const mockMsal = createMockMsalInstance({
+      initialActiveAccount: activeAccount,
+    });
+    const client = createAuthClient({
+      msalInstance: mockMsal.instance,
+      sessionResumeStore: resumeHarness.store,
+    });
+
+    await client.initialize();
+
+    await expect(client.attemptSessionResume('https://conspectus.local/#/transfers')).resolves.toBe(
+      true,
+    );
+    await expect(client.attemptSessionResume('https://conspectus.local/#/transfers')).resolves.toBe(
+      false,
+    );
+
+    expect(mockMsal.acquireTokenRedirect).toHaveBeenCalledTimes(1);
+    expect(mockMsal.acquireTokenRedirect).toHaveBeenCalledWith({
+      account: activeAccount,
+      scopes: ['Files.ReadWrite'],
+      prompt: 'none',
+      redirectStartPage: 'https://conspectus.local/#/transfers',
+    });
+  });
+
   it('requires the existing active account for safe re-authentication', async () => {
     const mockMsal = createMockMsalInstance();
     const client = createAuthClient({ msalInstance: mockMsal.instance });
@@ -375,17 +532,24 @@ describe('createAuthClient', () => {
   });
 
   it('clears active account and logs out against the active account context', async () => {
+    const resumeHarness = createResumeStoreHarness();
     const activeAccount = createAccount('active@example.com', 'active-home');
     const mockMsal = createMockMsalInstance({
       initialActiveAccount: activeAccount,
     });
-    const client = createAuthClient({ msalInstance: mockMsal.instance });
+    const client = createAuthClient({
+      msalInstance: mockMsal.instance,
+      sessionResumeStore: resumeHarness.store,
+    });
 
     await client.initialize();
+    await client.attemptSessionResume('https://conspectus.local/#/settings');
     await client.signOut();
 
     expect(mockMsal.setActiveAccount).toHaveBeenLastCalledWith(null);
     expect(mockMsal.logoutRedirect).toHaveBeenCalledWith({ account: activeAccount });
+    expect(resumeHarness.store.read()).toBeNull();
+    expect(resumeHarness.store.readAttempt()).toBeNull();
   });
 
   it('restores the prior active account when sign-out fails', async () => {

--- a/src/auth/msalAuthClient.ts
+++ b/src/auth/msalAuthClient.ts
@@ -15,6 +15,10 @@ import {
 import { loadRuntimeEnv } from '@shared';
 
 import type { AuthAccount, AuthClient, AuthErrorCode, AuthSession } from './index';
+import {
+  createAuthSessionResumeStore,
+  type AuthSessionResumeStore,
+} from './authSessionResumeStore';
 import { AUTH_REQUEST_SCOPES, GRAPH_ONEDRIVE_FILE_SCOPES } from './scopes';
 
 const MSAL_CONSUMERS_AUTHORITY = 'https://login.microsoftonline.com/consumers';
@@ -33,6 +37,8 @@ type MsalInstance = {
 
 export interface CreateAuthClientOptions {
   readonly msalInstance?: MsalInstance;
+  readonly sessionResumeStore?: AuthSessionResumeStore;
+  readonly redirectStartPageResolver?: () => string;
 }
 
 class AuthClientError extends Error {
@@ -190,6 +196,16 @@ const toAuthAccount = (account: AccountInfo | null): AuthAccount | null => {
   };
 };
 
+const resolveAccountLoginHint = (account: AccountInfo): string | null => {
+  const loginHint = account.loginHint?.trim();
+  if (loginHint) {
+    return loginHint;
+  }
+
+  const username = account.username.trim();
+  return username.length > 0 ? username : null;
+};
+
 export const resolveAuthRedirectUri = (origin: string, appBasePath: string): string =>
   new URL(appBasePath, `${origin.replace(/\/+$/u, '')}/`).toString();
 
@@ -231,6 +247,9 @@ const ensureActiveAccount = (msalInstance: MsalInstance): AccountInfo => {
 
 export const createAuthClient = (options: CreateAuthClientOptions = {}): AuthClient => {
   let msalInstance: MsalInstance | null = options.msalInstance ?? null;
+  const sessionResumeStore = options.sessionResumeStore ?? createAuthSessionResumeStore();
+  const redirectStartPageResolver =
+    options.redirectStartPageResolver ?? (() => window.location.href);
   let isInitialized = false;
 
   const resolveMsalInstance = (): MsalInstance => {
@@ -248,6 +267,13 @@ export const createAuthClient = (options: CreateAuthClientOptions = {}): AuthCli
     }
   };
 
+  const persistAccountResumeHint = (account: AccountInfo): void => {
+    const loginHint = resolveAccountLoginHint(account);
+    if (loginHint !== null) {
+      sessionResumeStore.save(account.homeAccountId, loginHint);
+    }
+  };
+
   return {
     async initialize(): Promise<void> {
       if (isInitialized) {
@@ -257,12 +283,71 @@ export const createAuthClient = (options: CreateAuthClientOptions = {}): AuthCli
       try {
         const resolvedMsalInstance = resolveMsalInstance();
         await resolvedMsalInstance.initialize();
-        const redirectResult = await resolvedMsalInstance.handleRedirectPromise();
+        const pendingAutomaticAttempt = sessionResumeStore.readAttempt();
+        let redirectResult: AuthenticationResult | null;
+
+        try {
+          redirectResult = await resolvedMsalInstance.handleRedirectPromise();
+        } catch (error) {
+          const normalizedError = normalizeAuthError(error, 'Failed to initialize authentication.');
+          if (pendingAutomaticAttempt !== null && normalizedError.code === 'interaction_required') {
+            if (pendingAutomaticAttempt.kind === 'session_resume') {
+              sessionResumeStore.clear();
+            }
+
+            const preferredAccount = resolvePreferredAccount(resolvedMsalInstance, null);
+            if (preferredAccount !== null) {
+              resolvedMsalInstance.setActiveAccount(preferredAccount);
+              persistAccountResumeHint(preferredAccount);
+            }
+            isInitialized = true;
+            return;
+          }
+
+          throw normalizedError;
+        }
+
         const preferredAccount = resolvePreferredAccount(resolvedMsalInstance, redirectResult);
         if (preferredAccount !== null) {
           resolvedMsalInstance.setActiveAccount(preferredAccount);
+          persistAccountResumeHint(preferredAccount);
+        }
+        if (redirectResult?.account !== null && redirectResult?.account !== undefined) {
+          sessionResumeStore.clearAttempt();
         }
         isInitialized = true;
+
+        if (preferredAccount !== null || sessionResumeStore.readAttempt() !== null) {
+          return;
+        }
+
+        const resumeRecord = sessionResumeStore.read();
+        if (
+          resumeRecord === null ||
+          !sessionResumeStore.claimAttempt(resumeRecord.homeAccountId, 'session_resume')
+        ) {
+          return;
+        }
+
+        const resumeRequest: RedirectRequest = {
+          scopes: [...AUTH_REQUEST_SCOPES],
+          prompt: 'none',
+          loginHint: resumeRecord.loginHint,
+          redirectStartPage: redirectStartPageResolver(),
+        };
+
+        try {
+          await resolvedMsalInstance.loginRedirect(resumeRequest);
+        } catch (error) {
+          const normalizedError = normalizeAuthError(error, 'Session restoration failed.');
+          if (normalizedError.code === 'interaction_required') {
+            sessionResumeStore.clear();
+            return;
+          }
+
+          isInitialized = false;
+          throw normalizedError;
+        }
       } catch (error) {
         throw normalizeAuthError(error, 'Failed to initialize authentication.');
       }
@@ -285,6 +370,7 @@ export const createAuthClient = (options: CreateAuthClientOptions = {}): AuthCli
 
     async signIn(): Promise<void> {
       assertInitialized();
+      sessionResumeStore.clearAttempt();
 
       const signInRequest: RedirectRequest = {
         scopes: [...AUTH_REQUEST_SCOPES],
@@ -298,8 +384,53 @@ export const createAuthClient = (options: CreateAuthClientOptions = {}): AuthCli
       }
     },
 
+    async attemptSessionResume(redirectStartPage: string): Promise<boolean> {
+      assertInitialized();
+
+      const resolvedMsalInstance = resolveMsalInstance();
+      const activeAccount = resolvedMsalInstance.getActiveAccount();
+      const resumeRecord = activeAccount === null ? sessionResumeStore.read() : null;
+      const homeAccountId = activeAccount?.homeAccountId ?? resumeRecord?.homeAccountId ?? null;
+      const attemptKind = activeAccount === null ? 'session_resume' : 'token_recovery';
+
+      if (homeAccountId === null || !sessionResumeStore.claimAttempt(homeAccountId, attemptKind)) {
+        return false;
+      }
+
+      try {
+        if (activeAccount !== null) {
+          await resolvedMsalInstance.acquireTokenRedirect({
+            account: activeAccount,
+            scopes: [...GRAPH_ONEDRIVE_FILE_SCOPES],
+            prompt: 'none',
+            redirectStartPage,
+          });
+        } else if (resumeRecord !== null) {
+          await resolvedMsalInstance.loginRedirect({
+            scopes: [...AUTH_REQUEST_SCOPES],
+            prompt: 'none',
+            loginHint: resumeRecord.loginHint,
+            redirectStartPage,
+          });
+        }
+
+        return true;
+      } catch (error) {
+        const normalizedError = normalizeAuthError(error, 'Session restoration failed.');
+        if (normalizedError.code === 'interaction_required') {
+          if (activeAccount === null) {
+            sessionResumeStore.clear();
+          }
+          return false;
+        }
+
+        throw normalizedError;
+      }
+    },
+
     async reauthenticate(redirectStartPage: string): Promise<void> {
       assertInitialized();
+      sessionResumeStore.clearAttempt();
 
       const resolvedMsalInstance = resolveMsalInstance();
       const activeAccount = ensureActiveAccount(resolvedMsalInstance);
@@ -323,6 +454,8 @@ export const createAuthClient = (options: CreateAuthClientOptions = {}): AuthCli
       const activeAccount = resolvedMsalInstance.getActiveAccount();
       const logoutRequest = activeAccount !== null ? { account: activeAccount } : undefined;
 
+      sessionResumeStore.clear();
+      sessionResumeStore.clearAttempt();
       resolvedMsalInstance.setActiveAccount(null);
 
       try {
@@ -330,6 +463,7 @@ export const createAuthClient = (options: CreateAuthClientOptions = {}): AuthCli
       } catch (error) {
         if (activeAccount !== null) {
           resolvedMsalInstance.setActiveAccount(activeAccount);
+          persistAccountResumeHint(activeAccount);
         }
         throw normalizeAuthError(error, 'Sign-out failed.');
       }
@@ -357,6 +491,7 @@ export const createAuthClient = (options: CreateAuthClientOptions = {}): AuthCli
         const tokenResult = await resolvedMsalInstance.acquireTokenSilent(tokenRequest);
         if (tokenResult.account !== null) {
           resolvedMsalInstance.setActiveAccount(tokenResult.account);
+          persistAccountResumeHint(tokenResult.account);
         }
         return tokenResult.accessToken;
       } catch (error) {

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -169,6 +169,24 @@
     }
   };
 
+  const attemptAutomaticTokenRecovery = async (): Promise<void> => {
+    if (authRecoveryIsPending) {
+      return;
+    }
+
+    authRecoveryIsPending = true;
+    authRecoveryError = null;
+
+    try {
+      const redirectStartPage = new URL(toRouteHash(currentRoute), window.location.href).toString();
+      await resolveAppAuthClient().attemptSessionResume(redirectStartPage);
+    } catch (error) {
+      authRecoveryError = toRecoveryErrorMessage(error);
+    } finally {
+      authRecoveryIsPending = false;
+    }
+  };
+
   const retryPendingTransfer = (): void => {
     void addTransferSaveController.retry($_, pendingTransferIsOffline);
   };
@@ -261,6 +279,9 @@
 
       applyStartupFreshnessDecision(syncStateStore, decision);
       logStartupFreshnessDecision(decision, binding?.name ?? null);
+      if (decision.kind === 'error' && decision.branch === 'online_auth_expired') {
+        void attemptAutomaticTokenRecovery();
+      }
     } catch (error) {
       if (!appShellIsMounted || syncId !== currentSyncId) {
         return;

--- a/src/features/app-shell/authClientResolver.test.ts
+++ b/src/features/app-shell/authClientResolver.test.ts
@@ -19,6 +19,7 @@ const createStubAuthClient = (): AuthClient => {
     initialize: vi.fn(async () => {}),
     getSession: () => session,
     signIn: vi.fn(async () => {}),
+    attemptSessionResume: vi.fn(async () => false),
     reauthenticate: vi.fn(async () => {}),
     signOut: vi.fn(async () => {}),
     getAccessToken: vi.fn(async () => 'token'),

--- a/src/features/app-shell/graphClientResolver.test.ts
+++ b/src/features/app-shell/graphClientResolver.test.ts
@@ -23,6 +23,7 @@ const createStubAuthClient = (): AuthClient => ({
     account: null,
   })),
   signIn: vi.fn(async () => {}),
+  attemptSessionResume: vi.fn(async () => false),
   reauthenticate: vi.fn(async () => {}),
   signOut: vi.fn(async () => {}),
   getAccessToken: vi.fn(async () => 'token'),

--- a/src/features/app-shell/routes/settingsAuthController.test.ts
+++ b/src/features/app-shell/routes/settingsAuthController.test.ts
@@ -46,6 +46,7 @@ const createMockAuthClientHarness = (): MockAuthClientHarness => {
     session = SIGNED_IN_SESSION;
   });
   const reauthenticate = vi.fn(async () => {});
+  const attemptSessionResume = vi.fn(async () => false);
   const signOut = vi.fn(async () => {
     session = SIGNED_OUT_SESSION;
   });
@@ -54,6 +55,7 @@ const createMockAuthClientHarness = (): MockAuthClientHarness => {
   const client: AuthClient = {
     initialize,
     signIn,
+    attemptSessionResume,
     reauthenticate,
     signOut,
     getAccessToken,

--- a/src/features/app-shell/routes/settingsCacheStoreResolver.test.ts
+++ b/src/features/app-shell/routes/settingsCacheStoreResolver.test.ts
@@ -39,6 +39,9 @@ describe('settings cache store resolver', () => {
       appCacheStore: { readSnapshot: appCacheStoreReadSnapshot },
       closeAppCacheStoreConnections,
     }));
+    vi.doMock('@auth', () => ({
+      AUTH_SESSION_RESUME_STORAGE_KEY: 'conspectus.authSessionResume',
+    }));
   });
 
   afterEach(() => {
@@ -80,6 +83,7 @@ describe('settings cache store resolver', () => {
   it('clears app-owned storage, CacheStorage, and IndexedDB entries by default', async () => {
     const localStorage = createMemoryStorage({
       'conspectus.selectedDriveItemBinding': '{"value":1}',
+      'conspectus.authSessionResume': '{"version":1}',
       'other-app-key': 'keep',
     });
     const sessionStorage = createMemoryStorage({
@@ -106,6 +110,7 @@ describe('settings cache store resolver', () => {
     await resolveSettingsCacheStore().clearAll();
 
     expect(localStorage.getItem('conspectus.selectedDriveItemBinding')).toBeNull();
+    expect(localStorage.getItem('conspectus.authSessionResume')).toBe('{"version":1}');
     expect(localStorage.getItem('other-app-key')).toBe('keep');
     expect(sessionStorage.getItem('conspectus.session')).toBeNull();
     expect(sessionStorage.getItem('untouched')).toBe('keep');

--- a/src/features/app-shell/routes/settingsCacheStoreResolver.ts
+++ b/src/features/app-shell/routes/settingsCacheStoreResolver.ts
@@ -1,5 +1,6 @@
 // Resolves the cache store used by Settings local-reset actions, with localhost-only test override support.
 import { appCacheStore, closeAppCacheStoreConnections, type CacheStore } from '@cache';
+import { AUTH_SESSION_RESUME_STORAGE_KEY } from '@auth';
 
 export type SettingsCacheStore = Pick<CacheStore, 'readSnapshot' | 'clearAll'>;
 
@@ -20,17 +21,20 @@ const defaultCacheStore: SettingsCacheStore = {
 
     const errors: unknown[] = [];
 
-    const clearConspectusStorageKeys = (storage: Storage): void => {
+    const clearConspectusStorageKeys = (
+      storage: Storage,
+      preservedKeys: ReadonlySet<string> = new Set(),
+    ): void => {
       for (let index = storage.length - 1; index >= 0; index -= 1) {
         const key = storage.key(index);
-        if (key !== null && key.startsWith('conspectus.')) {
+        if (key !== null && key.startsWith('conspectus.') && !preservedKeys.has(key)) {
           storage.removeItem(key);
         }
       }
     };
 
     try {
-      clearConspectusStorageKeys(window.localStorage);
+      clearConspectusStorageKeys(window.localStorage, new Set([AUTH_SESSION_RESUME_STORAGE_KEY]));
     } catch (error) {
       errors.push(error);
     }

--- a/src/graph/graphClient.test.ts
+++ b/src/graph/graphClient.test.ts
@@ -21,6 +21,7 @@ const createAuthClient = (accessTokenResult: string | Error = 'graph-token') => 
     },
   })),
   signIn: vi.fn(async () => {}),
+  attemptSessionResume: vi.fn(async () => false),
   reauthenticate: vi.fn(async () => {}),
   signOut: vi.fn(async () => {}),
   getAccessToken: vi.fn(async () => {

--- a/src/graph/index.test.ts
+++ b/src/graph/index.test.ts
@@ -17,6 +17,7 @@ const createMinimalAuthClient = (): AuthClient => ({
     },
   })),
   signIn: vi.fn(async () => {}),
+  attemptSessionResume: vi.fn(async () => false),
   reauthenticate: vi.fn(async () => {}),
   signOut: vi.fn(async () => {}),
   getAccessToken: vi.fn(async () => 'graph-access-token'),

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -956,12 +956,42 @@ test('fails fast on non-retryable startup metadata errors and surfaces the clear
   expect(await getGraphDownloadCallCount(page)).toBe(0);
 });
 
-test('starts one safe re-authentication and preserves the current screen after token expiry', async ({
+test('restores a remembered Microsoft session before startup sync without a sign-in click', async ({
+  page,
+}) => {
+  await installMockAuthClient(page, {
+    resumeSessionOnInitialize: true,
+  });
+  await installMockGraphClient(page);
+  await installMockCacheStore(page);
+  await installMockDbRuntime(page, {
+    accountRows: [{ accountId: 1, name: 'Remembered account', amountCents: 1_000 }],
+  });
+  await installPersistedBinding(page);
+  await installMockStartupNetworkState(page, true);
+
+  await page.goto(appPath('#/accounts'));
+
+  await expect(page.getByText('Remembered account')).toBeVisible();
+  const startupResumeCount = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          __CONSPECTUS_STARTUP_SESSION_RESUME_COUNT__?: number;
+        }
+      ).__CONSPECTUS_STARTUP_SESSION_RESUME_COUNT__,
+  );
+  expect(startupResumeCount).toBe(1);
+  expect(await getGraphMetadataCallCount(page)).toBe(1);
+});
+
+test('starts one automatic promptless recovery and preserves the current screen after token expiry', async ({
   page,
 }) => {
   await installMockAuthClient(page, {
     startAuthenticated: true,
-    reauthenticateDelayMs: 250,
+    attemptSessionResumeDelayMs: 250,
+    attemptSessionResumeResult: true,
   });
   await installMockGraphClient(page, {
     metadataErrorSequence: [
@@ -987,15 +1017,28 @@ test('starts one safe re-authentication and preserves the current screen after t
   const recoveryButton = page.getByTestId('stale-token-recovery-button');
   const previousUrl = page.url();
   await expect(recoveryButton).toBeVisible();
-  await recoveryButton.evaluate((button) => {
-    button.click();
-    button.click();
-  });
-  await expect(recoveryButton).toBeDisabled();
-  await expect(recoveryButton).toHaveAttribute('aria-busy', 'true');
-  await expect(recoveryButton).toBeEnabled();
-
-  const redirectStartPages = await page.evaluate(
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __CONSPECTUS_SESSION_RESUME_START_PAGES__?: string[];
+            }
+          ).__CONSPECTUS_SESSION_RESUME_START_PAGES__,
+      ),
+    )
+    .toEqual([previousUrl]);
+  const sessionResumeStartPages = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          __CONSPECTUS_SESSION_RESUME_START_PAGES__?: string[];
+        }
+      ).__CONSPECTUS_SESSION_RESUME_START_PAGES__,
+  );
+  expect(sessionResumeStartPages).toEqual([previousUrl]);
+  const interactiveStartPages = await page.evaluate(
     () =>
       (
         window as typeof window & {
@@ -1003,7 +1046,7 @@ test('starts one safe re-authentication and preserves the current screen after t
         }
       ).__CONSPECTUS_REAUTHENTICATE_START_PAGES__,
   );
-  expect(redirectStartPages).toEqual([previousUrl]);
+  expect(interactiveStartPages).toEqual([]);
   await expect(page).toHaveURL(previousUrl);
   await expect(page.getByTestId('route-transfers')).toBeVisible();
 });

--- a/tests/e2e/support/app-test-harness.ts
+++ b/tests/e2e/support/app-test-harness.ts
@@ -199,16 +199,20 @@ export const inspectTransferMonthSwipeMove = async (
 export type MockAuthClientOptions = {
   readonly initializeDelayMs?: number;
   readonly signInDelayMs?: number;
+  readonly attemptSessionResumeDelayMs?: number;
   readonly reauthenticateDelayMs?: number;
   readonly signOutDelayMs?: number;
   readonly consumeRedirectHashOnInitialize?: boolean;
   readonly failInitialize?: boolean;
   readonly failSignIn?: boolean;
+  readonly failAttemptSessionResume?: boolean;
   readonly failReauthenticate?: boolean;
   readonly failSignOut?: boolean;
   readonly failGetAccessToken?: boolean;
   readonly getAccessTokenErrorCode?: string;
   readonly startAuthenticated?: boolean;
+  readonly resumeSessionOnInitialize?: boolean;
+  readonly attemptSessionResumeResult?: boolean;
 };
 
 export type MockGraphError = {
@@ -312,9 +316,13 @@ export const installMockAuthClient = async (
     let isInitialized = false;
     let isAuthenticated = mockOptions.startAuthenticated ?? false;
     const trackedWindow = window as typeof window & {
+      __CONSPECTUS_SESSION_RESUME_START_PAGES__?: string[];
       __CONSPECTUS_REAUTHENTICATE_START_PAGES__?: string[];
+      __CONSPECTUS_STARTUP_SESSION_RESUME_COUNT__?: number;
     };
+    trackedWindow.__CONSPECTUS_SESSION_RESUME_START_PAGES__ = [];
     trackedWindow.__CONSPECTUS_REAUTHENTICATE_START_PAGES__ = [];
+    trackedWindow.__CONSPECTUS_STARTUP_SESSION_RESUME_COUNT__ = 0;
 
     const toSession = () => ({
       isAuthenticated,
@@ -339,6 +347,11 @@ export const installMockAuthClient = async (
           }
         }
 
+        if (mockOptions.resumeSessionOnInitialize) {
+          isAuthenticated = true;
+          trackedWindow.__CONSPECTUS_STARTUP_SESSION_RESUME_COUNT__ = 1;
+        }
+
         isInitialized = true;
       },
       getSession() {
@@ -360,6 +373,18 @@ export const installMockAuthClient = async (
           };
         }
         isAuthenticated = true;
+      },
+      async attemptSessionResume(redirectStartPage: string) {
+        trackedWindow.__CONSPECTUS_SESSION_RESUME_START_PAGES__?.push(redirectStartPage);
+        await resolveDelay(mockOptions.attemptSessionResumeDelayMs);
+        if (mockOptions.failAttemptSessionResume) {
+          throw {
+            code: 'network_error',
+            message: 'Mock automatic session restoration failure.',
+          };
+        }
+
+        return mockOptions.attemptSessionResumeResult ?? false;
       },
       async reauthenticate(redirectStartPage: string) {
         trackedWindow.__CONSPECTUS_REAUTHENTICATE_START_PAGES__?.push(redirectStartPage);


### PR DESCRIPTION
## Summary

- retain a versioned, token-free Microsoft account hint for a 30-day session-restoration window
- automatically use guarded `prompt: none` redirects on cold start and expired Graph sessions
- keep the current explicit sign-in/reauthentication controls as fallback and clear restoration state on sign-out
- preserve the auth restoration hint during local app-data reset, consistent with the existing auth-session contract

## Scope

This is a manual bug fix and is not linked to a GitHub issue or backlog item. It does not add account-choice UI, change Graph scopes, alter redirect registrations, or persist Microsoft tokens.

Microsoft or browser policy may still require interactive sign-in before 30 days; the window controls when Conspectus attempts promptless restoration.

## Verification

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run test:e2e` — 133 passed, 1 skipped
- focused iPhone 13 Safari/WebKit session-resume scenarios — 3 passed
- local reviewer subagent — `APPROVED`
