### PR TITLE
feat: [M9-02] Add ephemeral receipt capture foundation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,6 +146,21 @@ diagnostics. Browser storage is not equivalent to a server-held secret; code run
 controlling the same browser profile may be able to access it. Confirmed local reset removes the
 record, and explicit OpenRouter deletion removes the complete record for the active account.
 
+Receipt capture uses one native file input with `accept="image/*"` and `capture="environment"` so
+supported mobile operating systems own the camera/picker UI. The app does not create a camera stream,
+preview, shutter, or separate gallery flow. Selected images are decoded with their browser-applied
+orientation, limited to a 20 MiB source, resized without upscaling to a maximum 2560-pixel long edge,
+and canvas-encoded once as JPEG at quality `0.85`; encoded output above 4 MiB is rejected. Canvas
+re-encoding transfers raster pixels instead of original EXIF, GPS, camera, or device metadata.
+
+Raw files, decoded surfaces, normalized bytes, and temporary object URLs remain ephemeral. The
+normalization owner releases decoder/canvas resources on every outcome, and the receipt-run owner
+zeroes its normalized byte buffer after the stage-1 consumer finishes or when navigation, database
+binding, account, reset, sign-out, cancellation, or supersession abandons the run. No receipt image is
+written to IndexedDB, SQLite, OneDrive, service-worker caches, logs, diagnostics, or application
+backups. Browser and operating-system internals may still use implementation-defined temporary file
+storage for native `File` and canvas APIs; the application neither requests nor retains such storage.
+
 M9-01 performs only catalog requests and sends no receipt, extracted result, database content,
 account/category data, balance, or transfer history. The receipt workflow privacy boundary disclosed
 before later use is that stage 1 sends the image to OpenRouter and a routed vision provider, while

--- a/docs/GitHub-Issues-Backlog.md
+++ b/docs/GitHub-Issues-Backlog.md
@@ -144,7 +144,7 @@ Exit criteria:
 - Depends on: `none`
 - GitHub: [#251](https://github.com/Jon2050/Conspectus-Mobile/issues/251)
 
-### :green_circle: M9-02 Capture receipts from New Transfer and start ephemeral extraction
+### :white_check_mark: M9-02 Capture receipts from New Transfer and start ephemeral extraction
 
 - Label: `feature`
 - Milestone: `M9 - Receipt Capture + OpenRouter`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.9.01",
+  "version": "0.9.02",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.9.01",
+      "version": "0.9.02",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.9.01",
+  "version": "0.9.02",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -20,3 +20,11 @@ Receipt AI settings:
   transfer-prompt override.
 - `app-shell/routes/settingsOpenRouterController.ts` validates that record against a fresh
   authenticated catalog on every Settings entry and never exposes the key in public UI state.
+- `receipt/receiptImageNormalization.ts` owns the testable capture limits and normalized JPEG
+  contract: at most 20 MiB input, a 2560-pixel long edge without upscaling, JPEG quality `0.85`, and
+  at most 4 MiB output.
+- `receipt/browserReceiptImageCodec.ts` decodes browser-supported camera formats with their applied
+  orientation and canvas-re-encodes pixels so source EXIF/GPS/device metadata is not copied.
+- `receipt/receiptCaptureController.ts` owns a single in-memory capture until its typed M9-03
+  stage-one consumer settles, then zeroes the normalized byte buffer. Cancellation and supersession
+  never expose raw or normalized bytes through public UI state.

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -57,6 +57,15 @@
     type AddTransferFormFields,
   } from './routes/addTransferFormState';
   import {
+    browserReceiptImageCodec,
+    createReceiptCaptureController,
+    createReceiptImageNormalizer,
+    openRouterSettingsStore,
+    toStoredReadyOpenRouterReceiptConfiguration,
+    type ReceiptCaptureController,
+    type ReceiptStageOneStarter,
+  } from '../receipt';
+  import {
     createAddTransferSaveController,
     type AddTransferSaveController,
     type AddTransferSaveState,
@@ -69,6 +78,8 @@
     appServiceWorkerUpdateController;
   export let addTransferSaveController: AddTransferSaveController =
     createAddTransferSaveController();
+  export let receiptCaptureController: ReceiptCaptureController | null = null;
+  export let receiptStageOneStarter: ReceiptStageOneStarter | null = null;
   export let loadingDelayMs = 160;
   export let showLoadingPlaceholder = true;
 
@@ -96,8 +107,28 @@
   let authRecoveryError: string | null = null;
   let bindingRepairPersistenceIsRunning = false;
   let stopFooterVisibilityTracking = (): void => {};
+  const ownedReceiptCaptureController =
+    receiptCaptureController === null && receiptStageOneStarter !== null
+      ? createReceiptCaptureController({
+          normalizer: createReceiptImageNormalizer(browserReceiptImageCodec),
+          resolveConfiguration: () => {
+            const accountId = resolveAppAuthClient().getSession().account?.homeAccountId ?? null;
+            if (accountId === null) {
+              return null;
+            }
+            const settings = openRouterSettingsStore.read(accountId);
+            return settings === null ? null : toStoredReadyOpenRouterReceiptConfiguration(settings);
+          },
+          stageOneStarter: receiptStageOneStarter,
+        })
+      : null;
+  const effectiveReceiptCaptureController =
+    receiptCaptureController ?? ownedReceiptCaptureController;
   const navIconBaseUrl = import.meta.env.BASE_URL;
   const unsubscribe = routeStore.subscribe((route) => {
+    if (currentRoute === 'add' && route !== 'add') {
+      effectiveReceiptCaptureController?.cancel();
+    }
     currentRoute = route;
   });
   const unsubscribeAddTransferSaveController = addTransferSaveController.subscribe((state) => {
@@ -203,6 +234,9 @@
 
   $: addTransferDatabaseIsReady =
     selectedBinding !== null && addTransferHasLoadedDatabase && $syncStateStore.state !== 'idle';
+  $: if (!addTransferDatabaseIsReady) {
+    effectiveReceiptCaptureController?.cancel();
+  }
 
   const resolveNavIconUrl = (iconPath: string): string => `${navIconBaseUrl}${iconPath}`;
 
@@ -315,6 +349,8 @@
       selectedBindingHasEmitted = true;
       return;
     }
+
+    effectiveReceiptCaptureController?.cancel();
 
     if (bindingRepairPersistenceIsRunning) {
       return;
@@ -528,6 +564,11 @@
     unsubscribeAddTransferSaveController();
     unsubscribeSelectedBinding();
     unsubscribeQueuedForegroundSync();
+    if (ownedReceiptCaptureController === null) {
+      effectiveReceiptCaptureController?.cancel();
+    } else {
+      ownedReceiptCaptureController.dispose();
+    }
     resolveAppDbRuntime().close();
     disconnectFooterVisibilityTracking();
   });
@@ -663,6 +704,7 @@
         <AddRoute
           bind:fields={addTransferFields}
           saveController={addTransferSaveController}
+          receiptCaptureController={effectiveReceiptCaptureController}
           {networkStateStore}
           canOpenPanel={addTransferDatabaseIsReady}
         />

--- a/src/features/app-shell/routes/AddRoute.svelte
+++ b/src/features/app-shell/routes/AddRoute.svelte
@@ -15,6 +15,7 @@
     type SyncStateStore,
     type NetworkStateStore,
   } from '@shared';
+  import type { ReceiptCaptureController, ReceiptCaptureState } from '../../receipt';
   import BottomSheet from '../components/BottomSheet.svelte';
   import ProgressIndicator from '../components/ProgressIndicator.svelte';
   import {
@@ -50,14 +51,20 @@
   export let syncStateStore: SyncStateStore = appSyncStateStore;
   export let networkStateStore: NetworkStateStore = appNetworkStateStore;
   export let canOpenPanel = true;
+  export let receiptCaptureController: ReceiptCaptureController | null = null;
 
   let isOpen = true;
   let componentHasMounted = false;
   let hasRequestedOptionsLoad = false;
   let formElement: HTMLFormElement | null = null;
   let amountInputElement: HTMLInputElement | null = null;
+  let receiptFileInputElement: HTMLInputElement | null = null;
   let optionsState: AddTransferOptionsState = controller.getState();
   let saveState: AddTransferSaveState = saveController.getState();
+  let receiptCaptureState: ReceiptCaptureState = receiptCaptureController?.getState() ?? {
+    phase: 'idle',
+    errorCode: null,
+  };
   let lastObservedSyncState: SyncState = 'idle';
   $: isOffline = !$networkStateStore;
   $: isOptionsLoading = optionsState.operation === 'loading';
@@ -74,13 +81,26 @@
     saveState.phase === 'remote_commit_recovery_failed';
   $: saveBlocksEditing =
     saveState.canRetry || conflictRecoveryIsRequired || remoteCommitRecoveryIsRequired;
+  $: receiptCaptureIsBusy =
+    receiptCaptureState.phase === 'normalizing' || receiptCaptureState.phase === 'handed_off';
+  $: receiptCaptureError =
+    receiptCaptureState.errorCode === null
+      ? null
+      : $_(`addTransfer.receipt.errors.${receiptCaptureState.errorCode}`);
   $: effectiveFormError =
     formError ??
+    receiptCaptureError ??
     (conflictRecoveryIsRequired ? null : saveState.errorMessage) ??
     optionsState.error?.message ??
     null;
-  $: controlsAreDisabled = isSubmitting || isOptionsLoading || saveIsBusy || saveBlocksEditing;
+  $: controlsAreDisabled =
+    isSubmitting || isOptionsLoading || saveIsBusy || saveBlocksEditing || receiptCaptureIsBusy;
   $: submitIsDisabled = controlsAreDisabled || isOffline || optionsState.operation !== 'ready';
+  $: receiptCaptureIsDisabled =
+    receiptCaptureController === null ||
+    controlsAreDisabled ||
+    isOffline ||
+    optionsState.operation !== 'ready';
 
   let validationErrors: string[] = [];
   const allowedAmountNavigationKeys = new Set(['Tab', 'ArrowLeft', 'ArrowRight', 'Home', 'End']);
@@ -174,6 +194,28 @@
     await saveController.resolveConflict($_, isOffline);
   };
 
+  const openReceiptCapture = (): void => {
+    if (!receiptCaptureIsDisabled) {
+      receiptFileInputElement?.click();
+    }
+  };
+
+  const handleReceiptFileChange = (event: Event): void => {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.item(0) ?? null;
+    input.value = '';
+    if (file === null || receiptCaptureController === null) {
+      return;
+    }
+
+    clearValidation();
+    void receiptCaptureController.capture(file);
+  };
+
+  const handleReceiptFileCancel = (event: Event): void => {
+    (event.currentTarget as HTMLInputElement).value = '';
+  };
+
   const getAccountName = (account: { name: string; accountTypeId: number | null }) => {
     if (account.accountTypeId === PRIMARY_INCOME_ACCOUNT_TYPE_ID) {
       return $_('transfers.primaryIncome');
@@ -192,6 +234,10 @@
   const unsubscribeSaveController = saveController.subscribe((nextState) => {
     saveState = nextState;
   });
+  const unsubscribeReceiptCaptureController =
+    receiptCaptureController?.subscribe((nextState) => {
+      receiptCaptureState = nextState;
+    }) ?? (() => {});
   const unsubscribeSyncState = syncStateStore.subscribe((syncSnapshot) => {
     if (syncSnapshot.state === lastObservedSyncState) {
       return;
@@ -208,6 +254,7 @@
       return;
     }
 
+    receiptCaptureController?.cancel();
     isOpen = false;
     if (typeof window !== 'undefined') {
       window.location.hash = '#/transfers';
@@ -227,6 +274,10 @@
     isOpen = true;
   }
 
+  $: if (!canOpenPanel) {
+    receiptCaptureController?.cancel();
+  }
+
   onMount(() => {
     componentHasMounted = true;
     if (canOpenPanel) {
@@ -237,7 +288,9 @@
   onDestroy(() => {
     unsubscribeController();
     unsubscribeSaveController();
+    unsubscribeReceiptCaptureController();
     unsubscribeSyncState();
+    receiptCaptureController?.cancel();
   });
 </script>
 
@@ -273,7 +326,7 @@
         bind:this={formElement}
         class="add-transfer-form"
         data-testid="add-transfer-form"
-        aria-busy={isSubmitting || isOptionsLoading || saveIsBusy}
+        aria-busy={isSubmitting || isOptionsLoading || saveIsBusy || receiptCaptureIsBusy}
         on:submit|preventDefault={handleSubmit}
         on:input={clearValidation}
         on:change={clearValidation}
@@ -403,6 +456,62 @@
             </p>
           {/each}
         {/if}
+
+        <section
+          class="add-transfer-form__receipt add-transfer-form__upload"
+          aria-labelledby="receipt-capture-heading"
+        >
+          <div class="add-transfer-form__upload">
+            <h4 id="receipt-capture-heading">{$_('addTransfer.receipt.heading')}</h4>
+            <p class="add-transfer-form__receipt-hint">
+              {$_('addTransfer.receipt.description')}
+            </p>
+          </div>
+          <input
+            bind:this={receiptFileInputElement}
+            id="receipt-image-capture"
+            data-testid="receipt-image-input"
+            type="file"
+            accept="image/*"
+            capture="environment"
+            hidden
+            disabled={receiptCaptureIsDisabled}
+            on:change={handleReceiptFileChange}
+            on:cancel={handleReceiptFileCancel}
+          />
+          <button
+            type="button"
+            class="app-button app-button--secondary add-transfer-form__action"
+            data-testid="receipt-photo-button"
+            aria-controls="receipt-image-capture"
+            disabled={receiptCaptureIsDisabled}
+            on:click={openReceiptCapture}
+          >
+            <span aria-hidden="true">📷</span>
+            {$_('addTransfer.receipt.action')}
+          </button>
+          {#if receiptCaptureController === null}
+            <p class="add-transfer-form__receipt-hint" data-testid="receipt-capture-unavailable">
+              {$_('addTransfer.receipt.integrationPending')}
+            </p>
+          {:else if receiptCaptureState.phase === 'normalizing'}
+            <p
+              class="add-transfer-form__status"
+              role="status"
+              data-testid="receipt-normalizing-status"
+            >
+              {$_('addTransfer.receipt.normalizing')}
+            </p>
+          {:else if receiptCaptureState.phase === 'handed_off'}
+            <p
+              class="add-transfer-form__status"
+              role="status"
+              data-testid="receipt-stage-one-status"
+            >
+              {$_('addTransfer.receipt.stageOne')}
+            </p>
+          {/if}
+        </section>
 
         <div class="add-transfer-form__field">
           <label class="add-transfer-form__label" for="add-transfer-date"
@@ -675,6 +784,16 @@
     display: flex;
     flex-direction: column;
     gap: 0.3rem;
+  }
+
+  .add-transfer-form__receipt h4,
+  .add-transfer-form__receipt p {
+    margin: 0;
+  }
+
+  .add-transfer-form__receipt-hint {
+    color: var(--text-secondary);
+    font-size: 0.84rem;
   }
 
   .add-transfer-form__conflict {

--- a/src/features/app-shell/routes/AddRoute.test.ts
+++ b/src/features/app-shell/routes/AddRoute.test.ts
@@ -8,6 +8,10 @@ import type {
   AddTransferOptionsState,
 } from './addTransferOptionsController';
 import type { AddTransferSaveController, AddTransferSaveState } from './addTransferSaveController';
+import type {
+  ReceiptCaptureController,
+  ReceiptCaptureState,
+} from '../../receipt/receiptCaptureController';
 
 const READY_OPTIONS_STATE: AddTransferOptionsState = {
   operation: 'ready',
@@ -50,6 +54,20 @@ const createMockSaveController = (
   reset: () => {},
 });
 
+const createMockReceiptCaptureController = (
+  state: ReceiptCaptureState = { phase: 'idle', errorCode: null },
+): ReceiptCaptureController => ({
+  getState: () => state,
+  subscribe: (listener) => {
+    listener(state);
+    return () => {};
+  },
+  capture: async () => true,
+  cancel: () => {},
+  reset: () => {},
+  dispose: () => {},
+});
+
 const renderAddRoute = (props: Record<string, unknown> = {}) =>
   render(AddRoute, {
     props: {
@@ -78,6 +96,68 @@ describe('AddRoute component', () => {
 
     expect(body).toContain('data-testid="add-transfer-form"');
     expect(body).toContain('<form');
+  });
+
+  it('renders one accessible native environment-camera input without a custom camera flow', () => {
+    const { body } = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController(),
+    });
+
+    expect(body).toContain('data-testid="receipt-photo-button"');
+    expect(body).toContain('Kassenbon fotografieren');
+    expect(body).toMatch(
+      /data-testid="receipt-image-input"[^>]*type="file"[^>]*accept="image\/\*"[^>]*capture="environment"/,
+    );
+    expect(body).not.toContain('multiple');
+    expect(body).not.toContain('getUserMedia');
+    expect(body).not.toContain('receipt-preview');
+    expect(body).not.toContain('gallery');
+    expect(body).not.toMatch(/data-testid="receipt-photo-button"[^>]*disabled/);
+  });
+
+  it('disables capture when no stage-one consumer is composed', () => {
+    const { body } = renderAddRoute();
+
+    expect(body).toMatch(/data-testid="receipt-image-input"[^>]*disabled/);
+    expect(body).toMatch(/data-testid="receipt-photo-button"[^>]*disabled/);
+    expect(body).toContain('data-testid="receipt-capture-unavailable"');
+  });
+
+  it('shows accessible preparation and stage-one states while preventing duplicate actions', () => {
+    const normalizing = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController({
+        phase: 'normalizing',
+        errorCode: null,
+      }),
+    }).body;
+    expect(normalizing).toContain('data-testid="receipt-normalizing-status"');
+    expect(normalizing).toContain('role="status"');
+    expect(normalizing).toMatch(/data-testid="receipt-photo-button"[^>]*disabled/);
+    expect(normalizing).toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
+
+    const handedOff = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController({
+        phase: 'handed_off',
+        errorCode: null,
+      }),
+    }).body;
+    expect(handedOff).toContain('data-testid="receipt-stage-one-status"');
+    expect(handedOff).toContain('Foto auslesen');
+    expect(handedOff).toMatch(/data-testid="receipt-photo-button"[^>]*disabled/);
+  });
+
+  it('renders actionable localized capture errors without source details', () => {
+    const { body } = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController({
+        phase: 'error',
+        errorCode: 'decode_failed',
+      }),
+    });
+
+    expect(body).toContain('data-testid="add-transfer-form-error"');
+    expect(body).toContain('Das Foto konnte nicht gelesen werden');
+    expect(body).not.toContain('.heic');
+    expect(body).not.toContain('EXIF');
   });
 
   it('renders the date field with app-input class', () => {

--- a/src/features/receipt/browserReceiptImageCodec.test.ts
+++ b/src/features/receipt/browserReceiptImageCodec.test.ts
@@ -1,0 +1,211 @@
+// Verifies browser receipt decoding, orientation hints, fallback URL cleanup, and canvas release.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { browserReceiptImageCodec } from './browserReceiptImageCodec';
+import { createReceiptImageNormalizer } from './receiptImageNormalization';
+
+const createFile = (): File => ({ size: 128, type: 'image/heic' }) as File;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('browser receipt image codec', () => {
+  it('requests browser-applied source orientation and closes the decoded bitmap', async () => {
+    const close = vi.fn();
+    const bitmap = { width: 3024, height: 4032, close } as unknown as ImageBitmap;
+    const createBitmap = vi.fn().mockResolvedValue(bitmap);
+    vi.stubGlobal('createImageBitmap', createBitmap);
+
+    const decoded = await browserReceiptImageCodec.decode(
+      createFile(),
+      new AbortController().signal,
+    );
+
+    expect(createBitmap).toHaveBeenCalledWith(createFile(), {
+      imageOrientation: 'from-image',
+    });
+    expect(decoded).toMatchObject({ width: 3024, height: 4032, source: bitmap });
+    decoded.dispose();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to an image element and revokes its temporary object URL', async () => {
+    const revokeObjectUrl = vi.fn();
+    vi.stubGlobal('createImageBitmap', vi.fn().mockRejectedValue(new Error('unsupported')));
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn().mockReturnValue('blob:receipt-photo'),
+      revokeObjectURL: revokeObjectUrl,
+    });
+
+    class MockImage {
+      naturalWidth = 1200;
+      naturalHeight = 1600;
+      decoding = '';
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      private value = '';
+
+      set src(nextValue: string) {
+        this.value = nextValue;
+        if (nextValue) {
+          queueMicrotask(() => this.onload?.());
+        }
+      }
+
+      get src(): string {
+        return this.value;
+      }
+    }
+    vi.stubGlobal('Image', MockImage);
+
+    const decoded = await browserReceiptImageCodec.decode(
+      createFile(),
+      new AbortController().signal,
+    );
+    expect(decoded).toMatchObject({ width: 1200, height: 1600 });
+    expect(revokeObjectUrl).not.toHaveBeenCalled();
+
+    decoded.dispose();
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:receipt-photo');
+  });
+
+  it('revokes the fallback object URL when image loading cannot start', async () => {
+    const revokeObjectUrl = vi.fn();
+    vi.stubGlobal('createImageBitmap', vi.fn().mockRejectedValue(new Error('unsupported')));
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn().mockReturnValue('blob:receipt-photo'),
+      revokeObjectURL: revokeObjectUrl,
+    });
+
+    class ThrowingImage {
+      naturalWidth = 0;
+      naturalHeight = 0;
+      decoding = '';
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      set src(_nextValue: string) {
+        throw new Error('image loading failed');
+      }
+    }
+    vi.stubGlobal('Image', ThrowingImage);
+
+    await expect(
+      browserReceiptImageCodec.decode(createFile(), new AbortController().signal),
+    ).rejects.toThrow('image loading failed');
+    expect(revokeObjectUrl).toHaveBeenCalledWith('blob:receipt-photo');
+  });
+
+  it('draws only oriented pixels into an opaque JPEG canvas and releases the canvas', async () => {
+    const fillRect = vi.fn();
+    const drawImage = vi.fn();
+    const context = { fillStyle: '', fillRect, drawImage };
+    const encoded = new Blob(['encoded-pixels-only'], { type: 'image/jpeg' });
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue(context),
+      toBlob: vi.fn((callback: BlobCallback, type: string, quality: number) => {
+        expect(type).toBe('image/jpeg');
+        expect(quality).toBe(0.85);
+        callback(encoded);
+      }),
+    };
+    vi.stubGlobal('document', {
+      createElement: vi.fn().mockReturnValue(canvas),
+    });
+    const source = {} as CanvasImageSource;
+
+    await expect(
+      browserReceiptImageCodec.encodeJpeg(
+        { source, width: 1600, height: 1200, dispose: vi.fn() },
+        1600,
+        1200,
+        0.85,
+        new AbortController().signal,
+      ),
+    ).resolves.toBe(encoded);
+
+    expect(canvas.getContext).toHaveBeenCalledWith('2d', { alpha: false });
+    expect(fillRect).toHaveBeenCalledWith(0, 0, 1600, 1200);
+    expect(drawImage).toHaveBeenCalledWith(source, 0, 0, 1600, 1200);
+    expect(canvas.width).toBe(0);
+    expect(canvas.height).toBe(0);
+  });
+
+  it('releases canvas and decoded resources immediately when pending encoding is cancelled', async () => {
+    let finishEncoding: BlobCallback = () => {};
+    const context = {
+      fillStyle: '',
+      fillRect: vi.fn(),
+      drawImage: vi.fn(),
+    };
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue(context),
+      toBlob: vi.fn((callback: BlobCallback) => {
+        finishEncoding = callback;
+      }),
+    };
+    vi.stubGlobal('document', {
+      createElement: vi.fn().mockReturnValue(canvas),
+    });
+    const dispose = vi.fn();
+    const normalizer = createReceiptImageNormalizer({
+      decode: vi.fn().mockResolvedValue({
+        source: {} as CanvasImageSource,
+        width: 1600,
+        height: 1200,
+        dispose,
+      }),
+      encodeJpeg: browserReceiptImageCodec.encodeJpeg,
+    });
+    const abortController = new AbortController();
+    const normalization = normalizer.normalize(createFile(), abortController.signal);
+    await vi.waitFor(() => expect(canvas.toBlob).toHaveBeenCalledOnce());
+
+    abortController.abort();
+
+    await expect(normalization).rejects.toMatchObject({ name: 'AbortError' });
+    expect(canvas.width).toBe(0);
+    expect(canvas.height).toBe(0);
+    expect(dispose).toHaveBeenCalledOnce();
+
+    finishEncoding(new Blob(['late-result'], { type: 'image/jpeg' }));
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it('releases the canvas when drawing fails before encoding', async () => {
+    const context = {
+      fillStyle: '',
+      fillRect: vi.fn(),
+      drawImage: vi.fn(() => {
+        throw new Error('draw failed');
+      }),
+    };
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue(context),
+      toBlob: vi.fn(),
+    };
+    vi.stubGlobal('document', {
+      createElement: vi.fn().mockReturnValue(canvas),
+    });
+
+    await expect(
+      browserReceiptImageCodec.encodeJpeg(
+        { source: {} as CanvasImageSource, width: 10, height: 10, dispose: vi.fn() },
+        10,
+        10,
+        0.85,
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow('draw failed');
+    expect(canvas.toBlob).not.toHaveBeenCalled();
+    expect(canvas.width).toBe(0);
+    expect(canvas.height).toBe(0);
+  });
+});

--- a/src/features/receipt/browserReceiptImageCodec.ts
+++ b/src/features/receipt/browserReceiptImageCodec.ts
@@ -1,0 +1,173 @@
+// Implements orientation-aware browser decoding and metadata-free canvas JPEG re-encoding.
+import type { DecodedReceiptImage, ReceiptImageCodec } from './receiptImageNormalization';
+
+const throwIfAborted = (signal: AbortSignal): void => {
+  if (signal.aborted) {
+    throw new DOMException('Receipt image processing was cancelled.', 'AbortError');
+  }
+};
+
+const decodeWithImageBitmap = async (
+  file: File,
+  signal: AbortSignal,
+): Promise<DecodedReceiptImage> => {
+  throwIfAborted(signal);
+  const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+  if (signal.aborted) {
+    bitmap.close();
+    throw new DOMException('Receipt image processing was cancelled.', 'AbortError');
+  }
+
+  return {
+    source: bitmap,
+    width: bitmap.width,
+    height: bitmap.height,
+    dispose: () => bitmap.close(),
+  };
+};
+
+const decodeWithImageElement = (file: File, signal: AbortSignal): Promise<DecodedReceiptImage> =>
+  new Promise((resolve, reject) => {
+    throwIfAborted(signal);
+    const objectUrl = URL.createObjectURL(file);
+    const image = new Image();
+    let hasSettled = false;
+
+    const cleanupListeners = (): void => {
+      image.onload = null;
+      image.onerror = null;
+      signal.removeEventListener('abort', handleAbort);
+    };
+    const release = (): void => {
+      cleanupListeners();
+      try {
+        image.src = '';
+      } catch {
+        // The URL still has to be revoked when a browser rejects clearing a failed image source.
+      } finally {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+    const handleAbort = (): void => {
+      if (hasSettled) {
+        return;
+      }
+      hasSettled = true;
+      release();
+      reject(new DOMException('Receipt image processing was cancelled.', 'AbortError'));
+    };
+
+    image.decoding = 'async';
+    image.onload = () => {
+      if (hasSettled) {
+        return;
+      }
+      hasSettled = true;
+      cleanupListeners();
+      resolve({
+        source: image,
+        width: image.naturalWidth,
+        height: image.naturalHeight,
+        dispose: release,
+      });
+    };
+    image.onerror = () => {
+      if (hasSettled) {
+        return;
+      }
+      hasSettled = true;
+      release();
+      reject(new Error('The browser could not decode the receipt image.'));
+    };
+    signal.addEventListener('abort', handleAbort, { once: true });
+    try {
+      image.src = objectUrl;
+    } catch (error) {
+      hasSettled = true;
+      release();
+      reject(error);
+    }
+  });
+
+const decodeReceiptImage = async (
+  file: File,
+  signal: AbortSignal,
+): Promise<DecodedReceiptImage> => {
+  try {
+    return await decodeWithImageBitmap(file, signal);
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error;
+    }
+    return decodeWithImageElement(file, signal);
+  }
+};
+
+const encodeReceiptImageAsJpeg = (
+  image: DecodedReceiptImage,
+  width: number,
+  height: number,
+  quality: number,
+  signal: AbortSignal,
+): Promise<Blob> =>
+  new Promise((resolve, reject) => {
+    throwIfAborted(signal);
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const releaseCanvas = (): void => {
+      canvas.width = 0;
+      canvas.height = 0;
+    };
+    const context = canvas.getContext('2d', { alpha: false });
+    if (context === null) {
+      releaseCanvas();
+      reject(new Error('A browser canvas is unavailable.'));
+      return;
+    }
+
+    let hasSettled = false;
+    const settle = (complete: () => void): void => {
+      if (hasSettled) {
+        return;
+      }
+      hasSettled = true;
+      signal.removeEventListener('abort', handleAbort);
+      releaseCanvas();
+      complete();
+    };
+    const handleAbort = (): void => {
+      settle(() =>
+        reject(new DOMException('Receipt image processing was cancelled.', 'AbortError')),
+      );
+    };
+    signal.addEventListener('abort', handleAbort, { once: true });
+
+    try {
+      context.fillStyle = '#ffffff';
+      context.fillRect(0, 0, width, height);
+      context.drawImage(image.source, 0, 0, width, height);
+      canvas.toBlob(
+        (blob) => {
+          if (signal.aborted) {
+            handleAbort();
+            return;
+          }
+          if (blob === null) {
+            settle(() => reject(new Error('The browser could not encode the receipt image.')));
+            return;
+          }
+          settle(() => resolve(blob));
+        },
+        'image/jpeg',
+        quality,
+      );
+    } catch (error) {
+      settle(() => reject(error));
+    }
+  });
+
+export const browserReceiptImageCodec: ReceiptImageCodec = {
+  decode: decodeReceiptImage,
+  encodeJpeg: encodeReceiptImageAsJpeg,
+};

--- a/src/features/receipt/index.ts
+++ b/src/features/receipt/index.ts
@@ -6,6 +6,7 @@ export {
   reconcileOpenRouterModelSelections,
   resolveTransferDerivationPrompt,
   toReadyOpenRouterReceiptConfiguration,
+  toStoredReadyOpenRouterReceiptConfiguration,
 } from './openRouterReceiptConfiguration';
 export type {
   ReadyOpenRouterReceiptConfiguration,
@@ -16,3 +17,14 @@ export type {
   OpenRouterSettingsStorageAdapter,
   OpenRouterSettingsStore,
 } from './openRouterSettingsStore';
+export { browserReceiptImageCodec } from './browserReceiptImageCodec';
+export { createReceiptImageNormalizer } from './receiptImageNormalization';
+export { createReceiptCaptureController } from './receiptCaptureController';
+export type {
+  ReceiptCaptureController,
+  ReceiptCaptureErrorCode,
+  ReceiptCapturePhase,
+  ReceiptCaptureState,
+  ReceiptStageOneStarter,
+  ReceiptStageOneStartInput,
+} from './receiptCaptureController';

--- a/src/features/receipt/openRouterReceiptConfiguration.test.ts
+++ b/src/features/receipt/openRouterReceiptConfiguration.test.ts
@@ -6,6 +6,7 @@ import {
   reconcileOpenRouterModelSelections,
   resolveTransferDerivationPrompt,
   toReadyOpenRouterReceiptConfiguration,
+  toStoredReadyOpenRouterReceiptConfiguration,
   type StoredOpenRouterReceiptSettings,
 } from './openRouterReceiptConfiguration';
 import { DEFAULT_TRANSFER_DERIVATION_PROMPT } from './receiptPrompts';
@@ -51,6 +52,18 @@ describe('OpenRouter receipt configuration', () => {
       transferPrompt: DEFAULT_TRANSFER_DERIVATION_PROMPT.text,
       extractionPrompt: { version: 1 },
     });
+  });
+
+  it('resolves previously validated stored settings for the capture handoff', () => {
+    expect(toStoredReadyOpenRouterReceiptConfiguration(settings())).toMatchObject({
+      apiKey: 'secret-key',
+      visionModelId: 'shared-model',
+      transferModelId: 'shared-model',
+      extractionPrompt: { version: 1 },
+    });
+    expect(
+      toStoredReadyOpenRouterReceiptConfiguration(settings({ visionModelId: null })),
+    ).toBeNull();
   });
 
   it.each([

--- a/src/features/receipt/openRouterReceiptConfiguration.ts
+++ b/src/features/receipt/openRouterReceiptConfiguration.ts
@@ -52,15 +52,14 @@ export const reconcileOpenRouterModelSelections = (
     : null,
 });
 
-export const toReadyOpenRouterReceiptConfiguration = (
+export const toStoredReadyOpenRouterReceiptConfiguration = (
   settings: StoredOpenRouterReceiptSettings,
-  catalog: OpenRouterCompatibleModelCatalog,
 ): ReadyOpenRouterReceiptConfiguration | null => {
   const transferPrompt = resolveTransferDerivationPrompt(settings);
   if (
     !settings.apiKey.trim() ||
-    !includesModel(catalog.visionModels, settings.visionModelId) ||
-    !includesModel(catalog.transferModels, settings.transferModelId) ||
+    settings.visionModelId === null ||
+    settings.transferModelId === null ||
     !RECEIPT_EXTRACTION_SYSTEM_PROMPT.text.trim() ||
     !transferPrompt.trim()
   ) {
@@ -74,4 +73,18 @@ export const toReadyOpenRouterReceiptConfiguration = (
     extractionPrompt: RECEIPT_EXTRACTION_SYSTEM_PROMPT,
     transferPrompt,
   };
+};
+
+export const toReadyOpenRouterReceiptConfiguration = (
+  settings: StoredOpenRouterReceiptSettings,
+  catalog: OpenRouterCompatibleModelCatalog,
+): ReadyOpenRouterReceiptConfiguration | null => {
+  if (
+    !includesModel(catalog.visionModels, settings.visionModelId) ||
+    !includesModel(catalog.transferModels, settings.transferModelId)
+  ) {
+    return null;
+  }
+
+  return toStoredReadyOpenRouterReceiptConfiguration(settings);
 };

--- a/src/features/receipt/receiptCaptureController.test.ts
+++ b/src/features/receipt/receiptCaptureController.test.ts
@@ -1,0 +1,167 @@
+// Verifies single-flight receipt capture, typed handoff, cancellation, and ephemeral cleanup.
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ReadyOpenRouterReceiptConfiguration } from './openRouterReceiptConfiguration';
+import {
+  createReceiptCaptureController,
+  type ReceiptCaptureState,
+  type ReceiptStageOneStarter,
+} from './receiptCaptureController';
+import {
+  ReceiptImageNormalizationError,
+  type NormalizedReceiptImage,
+  type ReceiptImageNormalizer,
+} from './receiptImageNormalization';
+import { RECEIPT_EXTRACTION_SYSTEM_PROMPT } from './receiptPrompts';
+
+const CONFIGURATION: ReadyOpenRouterReceiptConfiguration = {
+  apiKey: 'secret-key',
+  visionModelId: 'vision-model',
+  transferModelId: 'transfer-model',
+  extractionPrompt: RECEIPT_EXTRACTION_SYSTEM_PROMPT,
+  transferPrompt: 'Transfer prompt',
+};
+
+const createFile = (): File => ({ size: 12, type: 'image/jpeg' }) as File;
+
+const createImage = (): NormalizedReceiptImage => ({
+  mimeType: 'image/jpeg',
+  bytes: new Uint8Array([1, 2, 3, 4]),
+  width: 1200,
+  height: 1600,
+});
+
+const deferred = () => {
+  let resolve = (): void => {};
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+};
+
+describe('receipt capture controller', () => {
+  it('normalizes once, hands only the normalized image to stage one, and clears bytes afterward', async () => {
+    const image = createImage();
+    const normalizer: ReceiptImageNormalizer = { normalize: vi.fn().mockResolvedValue(image) };
+    const stageOneStarter: ReceiptStageOneStarter = { start: vi.fn().mockResolvedValue(undefined) };
+    const controller = createReceiptCaptureController({
+      normalizer,
+      resolveConfiguration: () => CONFIGURATION,
+      stageOneStarter,
+    });
+    const states: ReceiptCaptureState[] = [];
+    controller.subscribe((state) => states.push(state));
+
+    await expect(controller.capture(createFile())).resolves.toBe(true);
+
+    expect(normalizer.normalize).toHaveBeenCalledOnce();
+    expect(stageOneStarter.start).toHaveBeenCalledOnce();
+    expect(stageOneStarter.start).toHaveBeenCalledWith(
+      { image, configuration: CONFIGURATION },
+      expect.any(AbortSignal),
+    );
+    expect(states.map((state) => state.phase)).toEqual([
+      'idle',
+      'normalizing',
+      'handed_off',
+      'idle',
+    ]);
+    expect(image.bytes.every((byte) => byte === 0)).toBe(true);
+  });
+
+  it('does not normalize or hand off cancellation without a file or missing configuration', async () => {
+    const normalizer: ReceiptImageNormalizer = { normalize: vi.fn() };
+    const stageOneStarter: ReceiptStageOneStarter = { start: vi.fn() };
+    const controller = createReceiptCaptureController({
+      normalizer,
+      resolveConfiguration: () => null,
+      stageOneStarter,
+    });
+
+    await expect(controller.capture(null)).resolves.toBe(false);
+    await expect(controller.capture(createFile())).resolves.toBe(false);
+
+    expect(normalizer.normalize).not.toHaveBeenCalled();
+    expect(stageOneStarter.start).not.toHaveBeenCalled();
+    expect(controller.getState()).toEqual({
+      phase: 'error',
+      errorCode: 'configuration_unavailable',
+    });
+  });
+
+  it('prevents duplicate capture and clears image memory when the run is cancelled', async () => {
+    const image = createImage();
+    const normalizer: ReceiptImageNormalizer = { normalize: vi.fn().mockResolvedValue(image) };
+    const stage = deferred();
+    const stageOneStarter: ReceiptStageOneStarter = {
+      start: vi.fn().mockReturnValue(stage.promise),
+    };
+    const controller = createReceiptCaptureController({
+      normalizer,
+      resolveConfiguration: () => CONFIGURATION,
+      stageOneStarter,
+    });
+
+    const firstCapture = controller.capture(createFile());
+    await vi.waitFor(() => expect(controller.getState().phase).toBe('handed_off'));
+    await expect(controller.capture(createFile())).resolves.toBe(false);
+    controller.cancel();
+
+    expect(normalizer.normalize).toHaveBeenCalledOnce();
+    expect(stageOneStarter.start).toHaveBeenCalledOnce();
+    expect(controller.getState()).toEqual({ phase: 'idle', errorCode: null });
+    expect(image.bytes.every((byte) => byte === 0)).toBe(true);
+
+    stage.resolve();
+    await expect(firstCapture).resolves.toBe(false);
+  });
+
+  it('surfaces safe normalization and stage-one failures and permits a fresh run', async () => {
+    const normalizer: ReceiptImageNormalizer = {
+      normalize: vi
+        .fn()
+        .mockRejectedValueOnce(new ReceiptImageNormalizationError('decode_failed'))
+        .mockResolvedValueOnce(createImage()),
+    };
+    const stageOneStarter: ReceiptStageOneStarter = {
+      start: vi.fn().mockRejectedValue(new Error('provider response with sensitive details')),
+    };
+    const controller = createReceiptCaptureController({
+      normalizer,
+      resolveConfiguration: () => CONFIGURATION,
+      stageOneStarter,
+    });
+
+    await expect(controller.capture(createFile())).resolves.toBe(false);
+    expect(controller.getState()).toEqual({ phase: 'error', errorCode: 'decode_failed' });
+
+    await expect(controller.capture(createFile())).resolves.toBe(false);
+    expect(controller.getState()).toEqual({ phase: 'error', errorCode: 'stage_one_failed' });
+    expect(stageOneStarter.start).toHaveBeenCalledOnce();
+  });
+
+  it('aborts and suppresses stale normalization completion after disposal', async () => {
+    const normalization = deferred();
+    const image = createImage();
+    const normalizer: ReceiptImageNormalizer = {
+      normalize: vi.fn().mockImplementation(async () => {
+        await normalization.promise;
+        return image;
+      }),
+    };
+    const stageOneStarter: ReceiptStageOneStarter = { start: vi.fn() };
+    const controller = createReceiptCaptureController({
+      normalizer,
+      resolveConfiguration: () => CONFIGURATION,
+      stageOneStarter,
+    });
+
+    const capture = controller.capture(createFile());
+    controller.dispose();
+    normalization.resolve();
+
+    await expect(capture).resolves.toBe(false);
+    expect(stageOneStarter.start).not.toHaveBeenCalled();
+    expect(image.bytes.every((byte) => byte === 0)).toBe(true);
+  });
+});

--- a/src/features/receipt/receiptCaptureController.ts
+++ b/src/features/receipt/receiptCaptureController.ts
@@ -1,0 +1,172 @@
+// Coordinates one ephemeral receipt capture, normalization, stage-one handoff, and cleanup.
+import type { ReadyOpenRouterReceiptConfiguration } from './openRouterReceiptConfiguration';
+import {
+  ReceiptImageNormalizationError,
+  disposeNormalizedReceiptImage,
+  type NormalizedReceiptImage,
+  type ReceiptImageNormalizationErrorCode,
+  type ReceiptImageNormalizer,
+} from './receiptImageNormalization';
+
+export type ReceiptCapturePhase = 'idle' | 'normalizing' | 'handed_off' | 'error';
+export type ReceiptCaptureErrorCode =
+  | ReceiptImageNormalizationErrorCode
+  | 'configuration_unavailable'
+  | 'stage_one_failed';
+
+export interface ReceiptCaptureState {
+  readonly phase: ReceiptCapturePhase;
+  readonly errorCode: ReceiptCaptureErrorCode | null;
+}
+
+export interface ReceiptStageOneStartInput {
+  readonly image: NormalizedReceiptImage;
+  readonly configuration: ReadyOpenRouterReceiptConfiguration;
+}
+
+export interface ReceiptStageOneStarter {
+  start(input: ReceiptStageOneStartInput, signal: AbortSignal): Promise<void>;
+}
+
+export interface ReceiptCaptureController {
+  getState(): ReceiptCaptureState;
+  subscribe(listener: (state: ReceiptCaptureState) => void): () => void;
+  capture(file: File | null): Promise<boolean>;
+  cancel(): void;
+  reset(): void;
+  dispose(): void;
+}
+
+interface CreateReceiptCaptureControllerOptions {
+  readonly normalizer: ReceiptImageNormalizer;
+  readonly resolveConfiguration: () => ReadyOpenRouterReceiptConfiguration | null;
+  readonly stageOneStarter: ReceiptStageOneStarter;
+}
+
+const INITIAL_STATE: ReceiptCaptureState = {
+  phase: 'idle',
+  errorCode: null,
+};
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof DOMException && error.name === 'AbortError';
+
+export const createReceiptCaptureController = (
+  options: CreateReceiptCaptureControllerOptions,
+): ReceiptCaptureController => {
+  const listeners = new Set<(state: ReceiptCaptureState) => void>();
+  let state = INITIAL_STATE;
+  let activeAbortController: AbortController | null = null;
+  let activeNormalizedImage: NormalizedReceiptImage | null = null;
+  let activeRunId = 0;
+  let isDisposed = false;
+
+  const publish = (nextState: ReceiptCaptureState): void => {
+    state = nextState;
+    listeners.forEach((listener) => listener(state));
+  };
+
+  const cancelActiveRun = (): void => {
+    activeRunId += 1;
+    activeAbortController?.abort();
+    activeAbortController = null;
+    disposeNormalizedReceiptImage(activeNormalizedImage);
+    activeNormalizedImage = null;
+  };
+
+  const reset = (): void => {
+    cancelActiveRun();
+    if (!isDisposed) {
+      publish(INITIAL_STATE);
+    }
+  };
+
+  return {
+    getState: () => state,
+
+    subscribe(listener): () => void {
+      if (isDisposed) {
+        listener(INITIAL_STATE);
+        return () => {};
+      }
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+
+    async capture(file): Promise<boolean> {
+      if (isDisposed || file === null || activeAbortController !== null) {
+        return false;
+      }
+
+      const configuration = (() => {
+        try {
+          return options.resolveConfiguration();
+        } catch {
+          return null;
+        }
+      })();
+      if (configuration === null) {
+        publish({ phase: 'error', errorCode: 'configuration_unavailable' });
+        return false;
+      }
+
+      const runId = ++activeRunId;
+      const abortController = new AbortController();
+      activeAbortController = abortController;
+      let normalizedImage: NormalizedReceiptImage | null = null;
+      publish({ phase: 'normalizing', errorCode: null });
+
+      try {
+        normalizedImage = await options.normalizer.normalize(file, abortController.signal);
+        if (runId !== activeRunId || abortController.signal.aborted) {
+          return false;
+        }
+
+        activeNormalizedImage = normalizedImage;
+        publish({ phase: 'handed_off', errorCode: null });
+        await options.stageOneStarter.start(
+          { image: normalizedImage, configuration },
+          abortController.signal,
+        );
+        if (runId !== activeRunId || abortController.signal.aborted) {
+          return false;
+        }
+
+        activeAbortController = null;
+        publish(INITIAL_STATE);
+        return true;
+      } catch (error) {
+        if (runId !== activeRunId || isAbortError(error)) {
+          return false;
+        }
+
+        activeAbortController = null;
+        publish({
+          phase: 'error',
+          errorCode:
+            error instanceof ReceiptImageNormalizationError ? error.code : 'stage_one_failed',
+        });
+        return false;
+      } finally {
+        if (activeNormalizedImage === normalizedImage) {
+          activeNormalizedImage = null;
+        }
+        disposeNormalizedReceiptImage(normalizedImage);
+      }
+    },
+
+    cancel: reset,
+    reset,
+
+    dispose(): void {
+      if (isDisposed) {
+        return;
+      }
+      cancelActiveRun();
+      isDisposed = true;
+      state = INITIAL_STATE;
+      listeners.clear();
+    },
+  };
+};

--- a/src/features/receipt/receiptImageNormalization.test.ts
+++ b/src/features/receipt/receiptImageNormalization.test.ts
@@ -1,0 +1,191 @@
+// Verifies bounded receipt resizing, re-encoding, validation failures, and byte cleanup.
+import { describe, expect, it, vi, type Mock } from 'vitest';
+
+import {
+  RECEIPT_IMAGE_JPEG_QUALITY,
+  RECEIPT_IMAGE_MAX_OUTPUT_BYTES,
+  RECEIPT_IMAGE_MAX_SOURCE_BYTES,
+  ReceiptImageNormalizationError,
+  calculateReceiptImageDimensions,
+  createReceiptImageNormalizer,
+  disposeNormalizedReceiptImage,
+  type DecodedReceiptImage,
+  type ReceiptImageCodec,
+} from './receiptImageNormalization';
+
+const createDecodedImage = (
+  width = 4032,
+  height = 3024,
+): DecodedReceiptImage & { dispose: Mock<() => void> } => ({
+  source: {} as CanvasImageSource,
+  width,
+  height,
+  dispose: vi.fn<() => void>(),
+});
+
+const createFile = (size = 128): File =>
+  ({ size, type: 'image/heic' }) as Pick<File, 'size' | 'type'> as File;
+
+const deferred = () => {
+  let resolve = (): void => {};
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+};
+
+describe('receipt image normalization', () => {
+  it('preserves aspect ratio, avoids upscaling, and bounds the longest edge', () => {
+    expect(calculateReceiptImageDimensions(1200, 800)).toEqual({ width: 1200, height: 800 });
+    expect(calculateReceiptImageDimensions(4032, 3024)).toEqual({ width: 2560, height: 1920 });
+    expect(calculateReceiptImageDimensions(3024, 4032)).toEqual({ width: 1920, height: 2560 });
+  });
+
+  it.each([
+    [0, 100],
+    [100, 0],
+    [Number.NaN, 100],
+    [100, Number.POSITIVE_INFINITY],
+  ])('rejects invalid decoded dimensions', (width, height) => {
+    expect(() => calculateReceiptImageDimensions(width, height)).toThrow(
+      new ReceiptImageNormalizationError('invalid_dimensions'),
+    );
+  });
+
+  it('rejects empty and oversized sources before decoding', async () => {
+    const codec: ReceiptImageCodec = {
+      decode: vi.fn(),
+      encodeJpeg: vi.fn(),
+    };
+    const normalizer = createReceiptImageNormalizer(codec);
+
+    await expect(
+      normalizer.normalize(createFile(0), new AbortController().signal),
+    ).rejects.toMatchObject({
+      code: 'empty_file',
+    });
+    await expect(
+      normalizer.normalize(
+        createFile(RECEIPT_IMAGE_MAX_SOURCE_BYTES + 1),
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({ code: 'source_too_large' });
+    expect(codec.decode).not.toHaveBeenCalled();
+  });
+
+  it('decodes orientation-aware dimensions and returns only new bounded JPEG bytes', async () => {
+    const decodedImage = createDecodedImage();
+    const sanitizedBytes = new TextEncoder().encode('fresh-jpeg-without-source-metadata');
+    const codec: ReceiptImageCodec = {
+      decode: vi.fn().mockResolvedValue(decodedImage),
+      encodeJpeg: vi.fn().mockResolvedValue(new Blob([sanitizedBytes], { type: 'image/jpeg' })),
+    };
+    const normalizer = createReceiptImageNormalizer(codec);
+
+    const image = await normalizer.normalize(createFile(), new AbortController().signal);
+
+    expect(codec.encodeJpeg).toHaveBeenCalledWith(
+      decodedImage,
+      2560,
+      1920,
+      RECEIPT_IMAGE_JPEG_QUALITY,
+      expect.any(AbortSignal),
+    );
+    expect(image).toMatchObject({ mimeType: 'image/jpeg', width: 2560, height: 1920 });
+    expect(image.bytes).toEqual(sanitizedBytes);
+    expect(decodedImage.dispose).toHaveBeenCalledOnce();
+
+    disposeNormalizedReceiptImage(image);
+    expect(image.bytes.every((byte) => byte === 0)).toBe(true);
+  });
+
+  it('maps decode and encode failures without leaking source details', async () => {
+    const decodeFailure = new Error('sensitive-camera-file-name.heic');
+    const decodeCodec: ReceiptImageCodec = {
+      decode: vi.fn().mockRejectedValue(decodeFailure),
+      encodeJpeg: vi.fn(),
+    };
+    await expect(
+      createReceiptImageNormalizer(decodeCodec).normalize(
+        createFile(),
+        new AbortController().signal,
+      ),
+    ).rejects.toEqual(new ReceiptImageNormalizationError('decode_failed'));
+
+    const decodedImage = createDecodedImage();
+    const encodeCodec: ReceiptImageCodec = {
+      decode: vi.fn().mockResolvedValue(decodedImage),
+      encodeJpeg: vi.fn().mockRejectedValue(new Error('canvas failed')),
+    };
+    await expect(
+      createReceiptImageNormalizer(encodeCodec).normalize(
+        createFile(),
+        new AbortController().signal,
+      ),
+    ).rejects.toEqual(new ReceiptImageNormalizationError('encode_failed'));
+    expect(decodedImage.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('rejects invalid and oversized encoded output and always disposes decoded resources', async () => {
+    const invalidDecodedImage = createDecodedImage();
+    const invalidCodec: ReceiptImageCodec = {
+      decode: vi.fn().mockResolvedValue(invalidDecodedImage),
+      encodeJpeg: vi.fn().mockResolvedValue(new Blob(['png'], { type: 'image/png' })),
+    };
+    await expect(
+      createReceiptImageNormalizer(invalidCodec).normalize(
+        createFile(),
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({ code: 'encode_failed' });
+    expect(invalidDecodedImage.dispose).toHaveBeenCalledOnce();
+
+    const oversizedDecodedImage = createDecodedImage();
+    const oversizedBlob = {
+      type: 'image/jpeg',
+      size: RECEIPT_IMAGE_MAX_OUTPUT_BYTES + 1,
+    } as Blob;
+    const oversizedCodec: ReceiptImageCodec = {
+      decode: vi.fn().mockResolvedValue(oversizedDecodedImage),
+      encodeJpeg: vi.fn().mockResolvedValue(oversizedBlob),
+    };
+    await expect(
+      createReceiptImageNormalizer(oversizedCodec).normalize(
+        createFile(),
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({ code: 'output_too_large' });
+    expect(oversizedDecodedImage.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('zeroes encoded bytes when cancellation wins after encoding', async () => {
+    const decodedImage = createDecodedImage();
+    const arrayBufferGate = deferred();
+    const encodedBytes = new Uint8Array([7, 8, 9]);
+    const encodedBlob = {
+      type: 'image/jpeg',
+      size: encodedBytes.byteLength,
+      arrayBuffer: async () => {
+        await arrayBufferGate.promise;
+        return encodedBytes.buffer;
+      },
+    } as Blob;
+    const codec: ReceiptImageCodec = {
+      decode: vi.fn().mockResolvedValue(decodedImage),
+      encodeJpeg: vi.fn().mockResolvedValue(encodedBlob),
+    };
+    const abortController = new AbortController();
+    const normalization = createReceiptImageNormalizer(codec).normalize(
+      createFile(),
+      abortController.signal,
+    );
+    await vi.waitFor(() => expect(codec.encodeJpeg).toHaveBeenCalledOnce());
+
+    abortController.abort();
+    arrayBufferGate.resolve();
+
+    await expect(normalization).rejects.toMatchObject({ name: 'AbortError' });
+    expect(encodedBytes.every((byte) => byte === 0)).toBe(true);
+    expect(decodedImage.dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/receipt/receiptImageNormalization.ts
+++ b/src/features/receipt/receiptImageNormalization.ts
@@ -1,0 +1,165 @@
+// Defines the testable receipt-image normalization contract and its bounded output format.
+
+export const RECEIPT_IMAGE_MAX_SOURCE_BYTES = 20 * 1024 * 1024;
+const RECEIPT_IMAGE_MAX_LONG_EDGE_PX = 2560;
+export const RECEIPT_IMAGE_JPEG_QUALITY = 0.85;
+export const RECEIPT_IMAGE_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
+export const RECEIPT_IMAGE_OUTPUT_MIME_TYPE = 'image/jpeg' as const;
+
+export type ReceiptImageNormalizationErrorCode =
+  | 'empty_file'
+  | 'source_too_large'
+  | 'decode_failed'
+  | 'invalid_dimensions'
+  | 'encode_failed'
+  | 'output_too_large';
+
+export class ReceiptImageNormalizationError extends Error {
+  constructor(readonly code: ReceiptImageNormalizationErrorCode) {
+    super(`Receipt image normalization failed: ${code}.`);
+    this.name = 'ReceiptImageNormalizationError';
+  }
+}
+
+export interface NormalizedReceiptImage {
+  readonly mimeType: typeof RECEIPT_IMAGE_OUTPUT_MIME_TYPE;
+  readonly bytes: Uint8Array;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface DecodedReceiptImage {
+  readonly source: CanvasImageSource;
+  readonly width: number;
+  readonly height: number;
+  dispose(): void;
+}
+
+export interface ReceiptImageCodec {
+  decode(file: File, signal: AbortSignal): Promise<DecodedReceiptImage>;
+  encodeJpeg(
+    image: DecodedReceiptImage,
+    width: number,
+    height: number,
+    quality: number,
+    signal: AbortSignal,
+  ): Promise<Blob>;
+}
+
+export interface ReceiptImageNormalizer {
+  normalize(file: File, signal: AbortSignal): Promise<NormalizedReceiptImage>;
+}
+
+export interface ReceiptImageDimensions {
+  readonly width: number;
+  readonly height: number;
+}
+
+const throwIfAborted = (signal: AbortSignal): void => {
+  if (signal.aborted) {
+    throw new DOMException('Receipt image normalization was cancelled.', 'AbortError');
+  }
+};
+
+export const calculateReceiptImageDimensions = (
+  width: number,
+  height: number,
+  maxLongEdgePx: number = RECEIPT_IMAGE_MAX_LONG_EDGE_PX,
+): ReceiptImageDimensions => {
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0 ||
+    !Number.isFinite(maxLongEdgePx) ||
+    maxLongEdgePx <= 0
+  ) {
+    throw new ReceiptImageNormalizationError('invalid_dimensions');
+  }
+
+  const longEdge = Math.max(width, height);
+  if (longEdge <= maxLongEdgePx) {
+    return { width: Math.round(width), height: Math.round(height) };
+  }
+
+  const scale = maxLongEdgePx / longEdge;
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+};
+
+export const disposeNormalizedReceiptImage = (image: NormalizedReceiptImage | null): void => {
+  image?.bytes.fill(0);
+};
+
+const toNormalizationError = (
+  error: unknown,
+  fallbackCode: ReceiptImageNormalizationErrorCode,
+): ReceiptImageNormalizationError | unknown =>
+  error instanceof ReceiptImageNormalizationError
+    ? error
+    : error instanceof DOMException && error.name === 'AbortError'
+      ? error
+      : new ReceiptImageNormalizationError(fallbackCode);
+
+export const createReceiptImageNormalizer = (codec: ReceiptImageCodec): ReceiptImageNormalizer => ({
+  async normalize(file, signal): Promise<NormalizedReceiptImage> {
+    throwIfAborted(signal);
+    if (file.size === 0) {
+      throw new ReceiptImageNormalizationError('empty_file');
+    }
+    if (file.size > RECEIPT_IMAGE_MAX_SOURCE_BYTES) {
+      throw new ReceiptImageNormalizationError('source_too_large');
+    }
+
+    let decodedImage: DecodedReceiptImage;
+    try {
+      decodedImage = await codec.decode(file, signal);
+    } catch (error) {
+      throw toNormalizationError(error, 'decode_failed');
+    }
+
+    try {
+      throwIfAborted(signal);
+      const dimensions = calculateReceiptImageDimensions(decodedImage.width, decodedImage.height);
+
+      let encodedImage: Blob;
+      try {
+        encodedImage = await codec.encodeJpeg(
+          decodedImage,
+          dimensions.width,
+          dimensions.height,
+          RECEIPT_IMAGE_JPEG_QUALITY,
+          signal,
+        );
+      } catch (error) {
+        throw toNormalizationError(error, 'encode_failed');
+      }
+
+      throwIfAborted(signal);
+      if (encodedImage.type !== RECEIPT_IMAGE_OUTPUT_MIME_TYPE || encodedImage.size === 0) {
+        throw new ReceiptImageNormalizationError('encode_failed');
+      }
+      if (encodedImage.size > RECEIPT_IMAGE_MAX_OUTPUT_BYTES) {
+        throw new ReceiptImageNormalizationError('output_too_large');
+      }
+
+      const bytes = new Uint8Array(await encodedImage.arrayBuffer());
+      try {
+        throwIfAborted(signal);
+        return {
+          mimeType: RECEIPT_IMAGE_OUTPUT_MIME_TYPE,
+          bytes,
+          width: dimensions.width,
+          height: dimensions.height,
+        };
+      } catch (error) {
+        bytes.fill(0);
+        throw error;
+      }
+    } finally {
+      decodedImage.dispose();
+    }
+  },
+});

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -70,6 +70,24 @@
     "submit": "Transfer speichern",
     "saving": "Transfer wird gespeichert...",
     "close": "Schließen",
+    "receipt": {
+      "heading": "Kassenbon erfassen",
+      "description": "Nimm ein Foto mit der Kameraauswahl deines Geräts auf.",
+      "action": "Kassenbon fotografieren",
+      "integrationPending": "Die Belegverarbeitung ist derzeit nicht verfügbar.",
+      "normalizing": "Foto wird sicher vorbereitet...",
+      "stageOne": "Foto auslesen",
+      "errors": {
+        "empty_file": "Das ausgewählte Bild ist leer. Nimm ein neues Foto auf.",
+        "source_too_large": "Das Foto ist zu groß. Nimm ein neues Foto mit höchstens 20 MB auf.",
+        "decode_failed": "Das Foto konnte nicht gelesen werden. Nimm ein neues, scharfes Foto auf.",
+        "invalid_dimensions": "Das Foto hat ungültige Abmessungen. Nimm ein neues Foto auf.",
+        "encode_failed": "Das Foto konnte nicht sicher vorbereitet werden. Nimm ein neues Foto auf.",
+        "output_too_large": "Das vorbereitete Foto ist weiterhin zu groß. Nimm ein neues Foto mit geringerer Auflösung auf.",
+        "configuration_unavailable": "Die Beleg-KI ist nicht vollständig eingerichtet. Prüfe API-Schlüssel und beide Modelle in den Einstellungen.",
+        "stage_one_failed": "Das Foto konnte nicht ausgelesen werden. Starte mit einem neuen Foto erneut."
+      }
+    },
     "save": {
       "localSave": "Transfer wird lokal gespeichert und der Datenbank-Upload vorbereitet...",
       "uploading": "Aktualisierte Datenbank wird auf OneDrive hochgeladen...",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -70,6 +70,24 @@
     "submit": "Save transfer",
     "saving": "Saving transfer...",
     "close": "Close",
+    "receipt": {
+      "heading": "Capture receipt",
+      "description": "Take a photo using your device's camera picker.",
+      "action": "Photograph receipt",
+      "integrationPending": "Receipt processing is currently unavailable.",
+      "normalizing": "Preparing the photo securely...",
+      "stageOne": "Read photo",
+      "errors": {
+        "empty_file": "The selected image is empty. Take a new photo.",
+        "source_too_large": "The photo is too large. Take a new photo no larger than 20 MB.",
+        "decode_failed": "The photo could not be read. Take a new, clear photo.",
+        "invalid_dimensions": "The photo has invalid dimensions. Take a new photo.",
+        "encode_failed": "The photo could not be prepared safely. Take a new photo.",
+        "output_too_large": "The prepared photo is still too large. Take a new photo at a lower resolution.",
+        "configuration_unavailable": "Receipt AI is not fully configured. Check the API key and both models in Settings.",
+        "stage_one_failed": "The photo could not be read. Start again with a new photo."
+      }
+    },
     "save": {
       "localSave": "Saving transfer locally and preparing the database upload...",
       "uploading": "Uploading updated database to OneDrive...",

--- a/tests/e2e/receipt-capture.spec.ts
+++ b/tests/e2e/receipt-capture.spec.ts
@@ -1,0 +1,44 @@
+// Verifies the browser-visible native receipt capture boundary without simulating OS camera UI.
+import { expect, test } from '@playwright/test';
+
+import { appPath, installReadyAddTransferTestDb } from './support/app-test-harness';
+
+test.use({ viewport: { width: 320, height: 720 } });
+
+test('exposes one native outward-camera image input without custom capture or gallery UI', async ({
+  page,
+}) => {
+  await installReadyAddTransferTestDb(page, {
+    fromAccountOptionRows: [
+      { accountId: 1, name: 'Primary Income', amountCents: 0, accountTypeId: 1 },
+      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+    ],
+    toAccountOptionRows: [
+      { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+    ],
+  });
+
+  await page.goto(appPath('#/add'));
+
+  const photoButton = page.getByTestId('receipt-photo-button');
+  const nativeInput = page.getByTestId('receipt-image-input');
+  await expect(photoButton).toBeVisible();
+  await expect(photoButton).toHaveAccessibleName('Photograph receipt');
+  await expect(nativeInput).toHaveAttribute('type', 'file');
+  await expect(nativeInput).toHaveAttribute('accept', 'image/*');
+  await expect(nativeInput).toHaveAttribute('capture', 'environment');
+  await expect(nativeInput).not.toHaveAttribute('multiple', '');
+  await expect(page.locator('video')).toHaveCount(0);
+  await expect(page.locator('[data-testid*="gallery"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid*="receipt-preview"]')).toHaveCount(0);
+  await expect(page.getByTestId('add-transfer-close')).toBeEnabled();
+  const captureSectionSize = await page
+    .locator('.add-transfer-form__receipt')
+    .evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    }));
+  expect(captureSectionSize.clientWidth).toBeGreaterThan(0);
+  expect(captureSectionSize.scrollWidth).toBeLessThanOrEqual(captureSectionSize.clientWidth);
+});


### PR DESCRIPTION
# Pull Request

## Linked Issue or Task

- Closes #252
- Milestone/task: M9-02 — Capture receipts from New Transfer and start ephemeral extraction

## Context

- Problem: Mobile receipt capture needs a native camera/picker boundary that normalizes images,
  strips source metadata, and hands bytes to later AI processing without persisting them.
- Goal: Deliver the safe M9-02 capture/normalization foundation and typed stage-one handoff. The
  production action remains intentionally disabled until #253 composes the real OpenRouter starter.

## Changes

- Add one accessible native `image/*` file input with `capture="environment"`; no custom stream,
  preview, shutter, or gallery workflow.
- Decode browser-supported camera output with applied orientation, resize without upscaling to a
  2560 px long edge, and canvas-encode once as JPEG quality 0.85.
- Enforce 20 MiB source and 4 MiB normalized-output limits with localized actionable errors.
- Add a single-flight capture controller that hands normalized bytes to `ReceiptStageOneStarter`,
  zeroes them after settlement, and promptly releases them on cancellation or supersession.
- Cancel receipt work on route, database-binding, database-readiness, reset/account/sign-out, and
  component-lifecycle abandonment paths.
- Document the durable privacy/cleanup contract and bump the app version to `0.9.02`.
- Record the production activation and physical-device QA handoff on #253:
  https://github.com/Jon2050/Conspectus-Mobile/issues/253#issuecomment-5145271211

## Test Plan

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run check:dead-code`
- [x] `npm run test` — 539 application tests and 127 script tests passed
- [x] `npm run build`
- [x] `npm run check:bundle-size`
- [x] `npm run test:e2e` — 145 passed, 1 intentional skip across Chromium and Pixel 5
- [x] Focused iPhone 13 WebKit receipt E2E — 1 passed
- Notes: Independent local reviewer returned `APPROVED` after the pending-canvas-encoding
  cancellation race was fixed and regression-tested.

## Screenshots

- [ ] UI change: screenshots attached
- [ ] No UI change
- Note: The capture control is intentionally disabled in production until #253 supplies the real
  stage-one starter; layout and native-input behavior are covered at 320 px, Pixel 5, and iPhone 13
  WebKit viewports.

## Manual Device QA (Release PRs Only)

- [x] Not a release PR; the release physical-device gate is not required here.
- [ ] Release PR: all required rows in `docs/Manual-Device-QA.md` pass.
- Tested candidate URL / commit: local production build at `1c168fbd37656e5b532359c2884f0f24db70d760`
- Completed results and evidence location in this PR: Physical camera/PWA/HEIC verification is
  explicitly deferred to #253 when the complete capture-to-extraction flow is operable.

## Release Process (Release PRs Only)

- [x] Not a release PR; the release-cut process is not required here.
- [ ] Release PR: the single checklist from `docs/Release-Process.md` is completed.
- Planned version / tag: n/a
- Candidate commit / `Quality` / `Deploy Preview` evidence: pending this PR's CI
- Reviewer-agent approval evidence: local review `APPROVED`; no actionable findings
- Human release-owner `APPROVED FOR RELEASE` evidence: n/a
- Approved release-notes location: n/a
- Production commit / `Deploy Production` / post-deploy evidence: n/a

## Risk Notes

- User impact: The disabled receipt action and explanatory state are visible, but receipt capture
  becomes operable only when #253 composes the real stage-one starter.
- Privacy/memory: Receipt files and normalized bytes are not persisted or logged. Browser/OS native
  file internals remain implementation-defined; app-owned buffers and decoding resources are
  released on all covered outcomes.
- Rollback plan: Revert this single scoped commit; it introduces no schema, Graph scope, deployment,
  or persistent-data migration.

## QS Checklist

- [x] The linked issue and clarified foundation scope are included in this PR.
- [x] Lint, typecheck, tests, build, bundle-size, and browser checks pass.
- [ ] Screenshots are included for UI changes.
- [x] Risk and rollback notes are documented.
- [x] No secrets, tokens, or credentials were added to the repository.
- [x] No unintended path/base URL changes were introduced.

## Merge And Cleanup (PR Path)

- [ ] Required GitHub checks are green.
- [x] PR will be merged into `main` with Rebase and merge.
- [x] PR will be merged into `main` once checks/review requirements are satisfied.
- [x] Head branch will be deleted after merge.
- [x] The M9-02 backlog marker update is included and will be verified on merged `main`.
