### PR TITLE
feat: [M9-04] stage receipt transfer preparation

### DIFF
--- a/bundle-size-budgets.json
+++ b/bundle-size-budgets.json
@@ -2,11 +2,11 @@
   "description": "Defines the maximum raw and gzip bytes allowed for emitted JavaScript and CSS.",
   "budgets": {
     "javascript": {
-      "rawBytes": 696320,
+      "rawBytes": 706560,
       "gzipBytes": 215040
     },
     "css": {
-      "rawBytes": 30720,
+      "rawBytes": 32768,
       "gzipBytes": 5888
     }
   }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,7 +179,14 @@ Receipt analysis is an abortable, two-stage feature workflow behind typed OpenRo
    category arrays, per-group arithmetic, and an exact receipt-total match. Machine-readable mapping
    declarations in the active editable prompt bind every accepted transfer name to its exact ordered
    category list; prompts without unambiguous declarations are not ready for capture. The validated
-   result remains transient for the later account/category-resolution and save workflow.
+   result and only its item-index coverage proof remain transient for local preparation.
+5. While both remote stages run, show the current valid source accounts without preselecting one.
+   Stage 2 never waits for or receives that selection. Once both the validated derivation and a
+   deliberate current-run source selection exist, resolve every category name by one exact current
+   local match, target the sole primary spendings account, revalidate coverage and exact cent totals,
+   and reuse the existing Add Transfer validation and transfer-type rules. The resulting immutable
+   command batch is held only in memory for M9-05; this preparation step performs no SQLite, cache,
+   Graph, or OneDrive mutation and exposes no review or editing surface.
 
 Both calls use the explicitly selected model without model or provider fallback. They add no app
 owned ZDR or data-collection routing restriction, so stricter OpenRouter account preferences and

--- a/docs/CI-CD-Pipelines.md
+++ b/docs/CI-CD-Pipelines.md
@@ -114,8 +114,8 @@ limits per asset class:
 
 | Asset class |               Raw limit |              Gzip limit |
 | ----------- | ----------------------: | ----------------------: |
-| JavaScript  | 680 KiB (696,320 bytes) | 210 KiB (215,040 bytes) |
-| CSS         |   30 KiB (30,720 bytes) |  5.75 KiB (5,888 bytes) |
+| JavaScript  | 690 KiB (706,560 bytes) | 210 KiB (215,040 bytes) |
+| CSS         |   32 KiB (32,768 bytes) |  5.75 KiB (5,888 bytes) |
 
 Raw totals guard parse, storage, and uncompressed delivery cost. Gzip totals are calculated by
 compressing each emitted file independently and summing the results, matching separate network

--- a/docs/GitHub-Issues-Backlog.md
+++ b/docs/GitHub-Issues-Backlog.md
@@ -166,7 +166,7 @@ Exit criteria:
 - Depends on: `M9-01, M9-02`
 - GitHub: [#253](https://github.com/Jon2050/Conspectus-Mobile/issues/253)
 
-### :green_circle: M9-04 Select the source account and show staged automatic processing
+### :white_check_mark: M9-04 Select the source account and show staged automatic processing
 
 - Label: `feature`
 - Milestone: `M9 - Receipt Capture + OpenRouter`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.9.03",
+  "version": "0.9.04",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.9.03",
+      "version": "0.9.04",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.9.03",
+  "version": "0.9.04",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -29,6 +29,11 @@ Receipt AI settings:
   `receipt/receiptAnalysisController.ts` orchestrates the two OpenRouter stages. The analysis
   controller revalidates each selected model immediately before use, releases image bytes after
   stage 1, parses the active prompt's canonical transfer/category declarations, and retains only a
-  structurally, arithmetically, and mapping-validated transient derivation for the later
-  local-transfer workflow. Cancellation and supersession clear every transient result and never
-  expose raw or normalized bytes through public UI state.
+  structurally, arithmetically, and mapping-validated transient derivation plus its item-index
+  coverage proof for the later local-transfer workflow.
+- `receipt/receiptTransferPreparationController.ts` owns the deliberate per-run source selection,
+  accessible three-step progress state, and immutable in-memory command handoff. Its pure command
+  builder resolves exact current category names, targets the sole primary spendings account, and
+  reuses Add Transfer validation and type derivation without writing SQLite or OneDrive.
+- Cancellation, account/file context changes, and supersession clear selection, coverage proof,
+  derivation, and prepared commands; public UI state never exposes raw or normalized image bytes.

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -61,10 +61,12 @@
     createReceiptAnalysisController,
     createReceiptCaptureController,
     createReceiptImageNormalizer,
+    createReceiptTransferPreparationController,
     openRouterSettingsStore,
     toStoredReadyOpenRouterReceiptConfiguration,
     type ReceiptAnalysisController,
     type ReceiptCaptureController,
+    type ReceiptTransferPreparationController,
   } from '../receipt';
   import {
     createAddTransferSaveController,
@@ -81,6 +83,8 @@
     createAddTransferSaveController();
   export let receiptCaptureController: ReceiptCaptureController | null = null;
   export let receiptAnalysisController: ReceiptAnalysisController | null = null;
+  export let receiptPreparationController: ReceiptTransferPreparationController =
+    createReceiptTransferPreparationController();
   export let loadingDelayMs = 160;
   export let showLoadingPlaceholder = true;
 
@@ -135,6 +139,7 @@
   const unsubscribe = routeStore.subscribe((route) => {
     if (currentRoute === 'add' && route !== 'add') {
       effectiveReceiptCaptureController?.cancel();
+      receiptPreparationController.reset();
     }
     currentRoute = route;
   });
@@ -243,6 +248,7 @@
     selectedBinding !== null && addTransferHasLoadedDatabase && $syncStateStore.state !== 'idle';
   $: if (!addTransferDatabaseIsReady) {
     effectiveReceiptCaptureController?.cancel();
+    receiptPreparationController.reset();
   }
 
   const resolveNavIconUrl = (iconPath: string): string => `${navIconBaseUrl}${iconPath}`;
@@ -358,6 +364,7 @@
     }
 
     effectiveReceiptCaptureController?.cancel();
+    receiptPreparationController.reset();
 
     if (bindingRepairPersistenceIsRunning) {
       return;
@@ -581,6 +588,7 @@
     } else {
       ownedReceiptAnalysisController.dispose();
     }
+    receiptPreparationController.reset();
     resolveAppDbRuntime().close();
     disconnectFooterVisibilityTracking();
   });
@@ -718,6 +726,7 @@
           saveController={addTransferSaveController}
           receiptCaptureController={effectiveReceiptCaptureController}
           receiptAnalysisController={effectiveReceiptAnalysisController}
+          {receiptPreparationController}
           {networkStateStore}
           canOpenPanel={addTransferDatabaseIsReady}
         />

--- a/src/features/app-shell/routes/AddRoute.svelte
+++ b/src/features/app-shell/routes/AddRoute.svelte
@@ -1,4 +1,4 @@
-<!-- Renders the Add Transfer bottom-sheet form with all MVP fields for mobile data entry. -->
+<!-- Renders manual Add Transfer entry and the transient staged receipt-preparation workflow. -->
 <script lang="ts">
   import { onDestroy, onMount, tick } from 'svelte';
   import { _ } from 'svelte-i18n';
@@ -15,11 +15,18 @@
     type SyncStateStore,
     type NetworkStateStore,
   } from '@shared';
+  import {
+    createReceiptTransferPreparationController,
+    listReceiptSourceAccountOptions,
+  } from '../../receipt';
   import type {
     ReceiptAnalysisController,
     ReceiptAnalysisState,
     ReceiptCaptureController,
     ReceiptCaptureState,
+    ReceiptTransferPreparationController,
+    ReceiptTransferPreparationError,
+    ReceiptTransferPreparationState,
   } from '../../receipt';
   import BottomSheet from '../components/BottomSheet.svelte';
   import ProgressIndicator from '../components/ProgressIndicator.svelte';
@@ -58,6 +65,8 @@
   export let canOpenPanel = true;
   export let receiptCaptureController: ReceiptCaptureController | null = null;
   export let receiptAnalysisController: ReceiptAnalysisController | null = null;
+  export let receiptPreparationController: ReceiptTransferPreparationController =
+    createReceiptTransferPreparationController();
 
   let isOpen = true;
   let componentHasMounted = false;
@@ -77,7 +86,10 @@
     errorCode: null,
     errorReason: null,
     derivation: null,
+    extractedItemIndexes: null,
   };
+  let receiptPreparationState: ReceiptTransferPreparationState =
+    receiptPreparationController.getState();
   let lastObservedSyncState: SyncState = 'idle';
   $: isOffline = !$networkStateStore;
   $: isOptionsLoading = optionsState.operation === 'loading';
@@ -99,6 +111,21 @@
     receiptCaptureState.phase === 'handed_off' ||
     receiptAnalysisState.phase === 'extracting' ||
     receiptAnalysisState.phase === 'deriving';
+  $: receiptWorkflowIsActive = receiptPreparationState.phase !== 'idle';
+  $: receiptSourceAccountOptions = listReceiptSourceAccountOptions(optionsState);
+  const translateReceiptPreparationError = (
+    error: ReceiptTransferPreparationError | null,
+  ): string | null => {
+    if (error === null) return null;
+    const detail =
+      error.code === 'invalid_transfer' && error.detail?.startsWith('addTransfer.')
+        ? $_(error.detail)
+        : error.detail;
+    return $_(`addTransfer.receipt.preparationErrors.${error.code}`, {
+      values: { detail: detail ?? '' },
+    });
+  };
+  $: receiptPreparationError = translateReceiptPreparationError(receiptPreparationState.error);
   $: receiptAnalysisError =
     receiptAnalysisState.phase !== 'error' || receiptAnalysisState.errorCode === null
       ? null
@@ -106,6 +133,7 @@
         ? $_(`addTransfer.receipt.analysisErrors.${receiptAnalysisState.errorCode}`)
         : `${$_(`addTransfer.receipt.analysisErrors.${receiptAnalysisState.errorCode}`)} ${receiptAnalysisState.errorReason}`;
   $: receiptCaptureError =
+    receiptPreparationError ??
     receiptAnalysisError ??
     (receiptCaptureState.errorCode === null
       ? null
@@ -233,7 +261,14 @@
     }
 
     clearValidation();
+    receiptPreparationController.beginRun();
     void receiptCaptureController.capture(file);
+  };
+
+  const handleReceiptSourceAccountChange = (event: Event): void => {
+    const value = (event.currentTarget as HTMLSelectElement).value;
+    const sourceAccountId = value.length === 0 ? null : Number(value);
+    receiptPreparationController.selectSourceAccount(sourceAccountId, optionsState);
   };
 
   const handleReceiptFileCancel = (event: Event): void => {
@@ -254,6 +289,7 @@
   const categoryIconUrl = `${navIconBaseUrl}icons/category_55.png`;
   const unsubscribeController = controller.subscribe((nextState) => {
     optionsState = nextState;
+    receiptPreparationController.refreshOptions(nextState);
   });
   const unsubscribeSaveController = saveController.subscribe((nextState) => {
     saveState = nextState;
@@ -261,11 +297,28 @@
   const unsubscribeReceiptCaptureController =
     receiptCaptureController?.subscribe((nextState) => {
       receiptCaptureState = nextState;
+      if (nextState.phase === 'error') {
+        receiptPreparationController.handleCaptureFailure();
+      }
     }) ?? (() => {});
   const unsubscribeReceiptAnalysisController =
     receiptAnalysisController?.subscribe((nextState) => {
       receiptAnalysisState = nextState;
+      receiptPreparationController.handleAnalysisState(nextState, optionsState);
     }) ?? (() => {});
+  const unsubscribeReceiptPreparationController = receiptPreparationController.subscribe(
+    (nextState) => {
+      const isNewLocalFailure =
+        nextState.phase === 'error' &&
+        nextState.error !== null &&
+        receiptPreparationState.phase !== 'error';
+      receiptPreparationState = nextState;
+      if (isNewLocalFailure) {
+        receiptCaptureController?.reset();
+        receiptAnalysisController?.reset();
+      }
+    },
+  );
   const unsubscribeSyncState = syncStateStore.subscribe((syncSnapshot) => {
     if (syncSnapshot.state === lastObservedSyncState) {
       return;
@@ -283,6 +336,7 @@
     }
 
     receiptCaptureController?.cancel();
+    receiptPreparationController.reset();
     isOpen = false;
     if (typeof window !== 'undefined') {
       window.location.hash = '#/transfers';
@@ -304,6 +358,17 @@
 
   $: if (!canOpenPanel) {
     receiptCaptureController?.cancel();
+    receiptPreparationController.reset();
+  }
+
+  $: if (
+    componentHasMounted &&
+    receiptWorkflowIsActive &&
+    isOffline &&
+    receiptPreparationState.phase !== 'error'
+  ) {
+    receiptPreparationController.failForOffline();
+    receiptCaptureController?.cancel();
   }
 
   onMount(() => {
@@ -318,8 +383,10 @@
     unsubscribeSaveController();
     unsubscribeReceiptCaptureController();
     unsubscribeReceiptAnalysisController();
+    unsubscribeReceiptPreparationController();
     unsubscribeSyncState();
     receiptCaptureController?.cancel();
+    receiptPreparationController.reset();
   });
 </script>
 
@@ -507,268 +574,335 @@
             accept="image/*"
             capture="environment"
             hidden
-            disabled={receiptCaptureIsDisabled}
+            disabled={receiptCaptureIsDisabled ||
+              (receiptWorkflowIsActive && receiptPreparationState.phase !== 'error')}
             on:change={handleReceiptFileChange}
             on:cancel={handleReceiptFileCancel}
           />
-          <button
-            type="button"
-            class="app-button app-button--secondary add-transfer-form__action"
-            data-testid="receipt-photo-button"
-            aria-controls="receipt-image-capture"
-            disabled={receiptCaptureIsDisabled}
-            on:click={openReceiptCapture}
-          >
-            <span aria-hidden="true">📷</span>
-            {$_('addTransfer.receipt.action')}
-          </button>
           {#if receiptCaptureController === null}
+            <button
+              type="button"
+              class="app-button app-button--secondary add-transfer-form__action"
+              data-testid="receipt-photo-button"
+              aria-controls="receipt-image-capture"
+              disabled
+            >
+              <span aria-hidden="true">📷</span>
+              {$_('addTransfer.receipt.action')}
+            </button>
             <p class="add-transfer-form__receipt-hint" data-testid="receipt-capture-unavailable">
               {$_('addTransfer.receipt.integrationPending')}
             </p>
-          {:else if receiptCaptureState.phase === 'normalizing'}
-            <p
-              class="add-transfer-form__status"
-              role="status"
-              data-testid="receipt-normalizing-status"
+          {:else if !receiptWorkflowIsActive}
+            <button
+              type="button"
+              class="app-button app-button--secondary add-transfer-form__action"
+              data-testid="receipt-photo-button"
+              aria-controls="receipt-image-capture"
+              disabled={receiptCaptureIsDisabled}
+              on:click={openReceiptCapture}
             >
-              {$_('addTransfer.receipt.normalizing')}
-            </p>
-          {:else if receiptAnalysisState.phase === 'extracting' || (receiptAnalysisController === null && receiptCaptureState.phase === 'handed_off')}
-            <p
-              class="add-transfer-form__status"
-              role="status"
-              data-testid="receipt-stage-one-status"
+              <span aria-hidden="true">📷</span>
+              {$_('addTransfer.receipt.action')}
+            </button>
+          {:else}
+            <ol
+              class="receipt-progress"
+              aria-label={$_('addTransfer.receipt.progressLabel')}
+              aria-live="polite"
+              data-testid="receipt-progress"
             >
-              {$_('addTransfer.receipt.stageOne')}
-            </p>
-          {:else if receiptAnalysisState.phase === 'deriving'}
-            <p
-              class="add-transfer-form__status"
-              role="status"
-              data-testid="receipt-stage-two-status"
-            >
-              {$_('addTransfer.receipt.stageTwo')}
-            </p>
-          {:else if receiptAnalysisState.phase === 'succeeded' && receiptAnalysisState.derivation !== null}
-            <p
-              class="add-transfer-form__status"
-              role="status"
-              data-testid="receipt-analysis-success"
-            >
-              {$_(
-                receiptAnalysisState.derivation.transfers.length === 1
-                  ? 'addTransfer.receipt.analysisSuccessOne'
-                  : 'addTransfer.receipt.analysisSuccessMany',
-                {
-                  values: { count: receiptAnalysisState.derivation.transfers.length },
-                },
-              )}
-            </p>
+              {#each receiptPreparationState.steps as step (step.id)}
+                <li
+                  class={`receipt-progress__step receipt-progress__step--${step.status}`}
+                  data-testid={`receipt-step-${step.id}`}
+                  data-state={step.status}
+                  aria-current={step.status === 'active' ? 'step' : undefined}
+                >
+                  <span class="receipt-progress__marker" aria-hidden="true"></span>
+                  <span>{$_(`addTransfer.receipt.steps.${step.id}`)}</span>
+                  <span class="app-visually-hidden"
+                    >{$_(`addTransfer.receipt.stepStates.${step.status}`)}</span
+                  >
+                </li>
+              {/each}
+            </ol>
+
+            {#if receiptPreparationState.phase === 'error'}
+              <button
+                type="button"
+                class="app-button app-button--secondary add-transfer-form__action"
+                data-testid="receipt-photo-button"
+                aria-controls="receipt-image-capture"
+                disabled={receiptCaptureIsDisabled}
+                on:click={openReceiptCapture}
+              >
+                <span aria-hidden="true">📷</span>
+                {$_('addTransfer.receipt.freshAction')}
+              </button>
+            {:else}
+              <div class="add-transfer-form__field receipt-source-account">
+                <label class="add-transfer-form__label" for="receipt-source-account">
+                  {$_('addTransfer.receipt.sourceAccount')}
+                </label>
+                <select
+                  id="receipt-source-account"
+                  class="app-input"
+                  data-testid="add-transfer-from-account"
+                  value={receiptPreparationState.sourceAccountId ?? ''}
+                  disabled={receiptPreparationState.phase === 'ready_for_commit'}
+                  on:change={handleReceiptSourceAccountChange}
+                >
+                  <option value="">{$_('addTransfer.fromAccountPlaceholder')}</option>
+                  {#each receiptSourceAccountOptions as account (account.accountId)}
+                    <option value={account.accountId}>{getAccountName(account)}</option>
+                  {/each}
+                </select>
+              </div>
+              {#if receiptPreparationState.phase === 'waiting_for_source'}
+                <p
+                  class="add-transfer-form__status"
+                  role="status"
+                  data-testid="receipt-account-required"
+                >
+                  {$_('addTransfer.receipt.accountRequired')}
+                </p>
+              {:else if receiptPreparationState.phase === 'ready_for_commit' && receiptPreparationState.readyForCommit !== null}
+                <p
+                  class="add-transfer-form__status"
+                  role="status"
+                  data-testid="receipt-analysis-success"
+                >
+                  {$_(
+                    receiptPreparationState.readyForCommit.length === 1
+                      ? 'addTransfer.receipt.analysisSuccessOne'
+                      : 'addTransfer.receipt.analysisSuccessMany',
+                    { values: { count: receiptPreparationState.readyForCommit.length } },
+                  )}
+                </p>
+              {/if}
+            {/if}
           {/if}
         </section>
 
-        <div class="add-transfer-form__field">
-          <label class="add-transfer-form__label" for="add-transfer-date"
-            >{$_('addTransfer.date')}</label
-          >
-          <input
-            id="add-transfer-date"
-            type="date"
-            class="app-input"
-            data-testid="add-transfer-date"
-            bind:value={fields.date}
-            disabled={controlsAreDisabled}
-            required
-          />
-        </div>
-
-        <div class="add-transfer-form__field">
-          <label class="add-transfer-form__label" for="add-transfer-name"
-            >{$_('addTransfer.name')}</label
-          >
-          <input
-            id="add-transfer-name"
-            type="text"
-            class="app-input"
-            data-testid="add-transfer-name"
-            placeholder={$_('addTransfer.namePlaceholder')}
-            bind:value={fields.name}
-            disabled={controlsAreDisabled}
-            autocomplete="off"
-          />
-        </div>
-
-        <div class="add-transfer-form__field">
-          <label class="add-transfer-form__label" for="add-transfer-buyplace"
-            >{$_('addTransfer.buyplace')}</label
-          >
-          <input
-            id="add-transfer-buyplace"
-            type="text"
-            class="app-input"
-            data-testid="add-transfer-buyplace"
-            placeholder={$_('addTransfer.buyplacePlaceholder')}
-            bind:value={fields.buyplace}
-            disabled={controlsAreDisabled}
-            autocomplete="off"
-          />
-        </div>
-
-        <div class="add-transfer-form__field">
-          <label class="add-transfer-form__label" for="add-transfer-amount"
-            >{$_('addTransfer.amount')}</label
-          >
-          <input
-            bind:this={amountInputElement}
-            id="add-transfer-amount"
-            type="text"
-            inputmode="numeric"
-            class="app-input"
-            data-testid="add-transfer-amount"
-            placeholder={$_('addTransfer.amountPlaceholder')}
-            bind:value={fields.amount}
-            disabled={controlsAreDisabled}
-            autocomplete="off"
-            on:keydown={handleAmountKeydown}
-            on:input={handleAmountInput}
-            on:paste={handleAmountPaste}
-          />
-        </div>
-
-        <div class="add-transfer-form__field">
-          <label class="add-transfer-form__label" for="add-transfer-from-account"
-            >{$_('addTransfer.fromAccount')}</label
-          >
-          <select
-            id="add-transfer-from-account"
-            class="app-input"
-            data-testid="add-transfer-from-account"
-            bind:value={fields.fromAccountId}
-            disabled={sourceAccountIsDisabled}
-          >
-            <option value={null}>{$_('addTransfer.fromAccountPlaceholder')}</option>
-            {#each optionsState.fromAccountOptions as account (account.accountId)}
-              <option value={account.accountId}>{getAccountName(account)}</option>
-            {/each}
-          </select>
-        </div>
-
-        <div class="add-transfer-form__field">
-          <label class="add-transfer-form__label" for="add-transfer-to-account"
-            >{$_('addTransfer.toAccount')}</label
-          >
-          <select
-            id="add-transfer-to-account"
-            class="app-input"
-            data-testid="add-transfer-to-account"
-            bind:value={fields.toAccountId}
-            disabled={controlsAreDisabled}
-          >
-            <option value={null}>{$_('addTransfer.toAccountPlaceholder')}</option>
-            {#each optionsState.toAccountOptions as account (account.accountId)}
-              <option value={account.accountId}>{getAccountName(account)}</option>
-            {/each}
-          </select>
-        </div>
-
-        <div class="add-transfer-form__field">
-          <div class="add-transfer-form__label-row">
-            <img
-              class="add-transfer-form__category-icon"
-              src={categoryIconUrl}
-              alt=""
-              aria-hidden="true"
-              width="20"
-              height="20"
+        {#if !receiptWorkflowIsActive}
+          <div class="add-transfer-form__field">
+            <label class="add-transfer-form__label" for="add-transfer-date"
+              >{$_('addTransfer.date')}</label
+            >
+            <input
+              id="add-transfer-date"
+              type="date"
+              class="app-input"
+              data-testid="add-transfer-date"
+              bind:value={fields.date}
+              disabled={controlsAreDisabled}
+              required
             />
-            <label class="add-transfer-form__label" for="add-transfer-category-1"
-              >{$_('addTransfer.categories')}</label
-            >
           </div>
-          <div class="add-transfer-form__category-selects">
-            <select
-              id="add-transfer-category-1"
-              class="app-input"
-              data-testid="add-transfer-category-1"
-              bind:value={fields.category1Id}
-              disabled={controlsAreDisabled}
-            >
-              <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option>
-              {#each optionsState.categoryOptions as cat (cat.categoryId)}
-                <option value={cat.categoryId}>{cat.name}</option>
-              {/each}
-            </select>
-            <select
-              id="add-transfer-category-2"
-              class="app-input"
-              data-testid="add-transfer-category-2"
-              bind:value={fields.category2Id}
-              disabled={controlsAreDisabled}
-            >
-              <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option>
-              {#each optionsState.categoryOptions as cat (cat.categoryId)}
-                <option value={cat.categoryId}>{cat.name}</option>
-              {/each}
-            </select>
-            <select
-              id="add-transfer-category-3"
-              class="app-input"
-              data-testid="add-transfer-category-3"
-              bind:value={fields.category3Id}
-              disabled={controlsAreDisabled}
-            >
-              <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option>
-              {#each optionsState.categoryOptions as cat (cat.categoryId)}
-                <option value={cat.categoryId}>{cat.name}</option>
-              {/each}
-            </select>
-          </div>
-        </div>
 
-        <div class="add-transfer-form__actions">
-          <button
-            type="button"
-            class="app-button app-button--secondary add-transfer-form__action"
-            data-testid="add-transfer-close"
-            disabled={isSubmitting || saveIsBusy}
-            on:click={handleClose}
-          >
-            {$_('addTransfer.close')}
-          </button>
-          {#if saveState.canRetry}
+          <div class="add-transfer-form__field">
+            <label class="add-transfer-form__label" for="add-transfer-name"
+              >{$_('addTransfer.name')}</label
+            >
+            <input
+              id="add-transfer-name"
+              type="text"
+              class="app-input"
+              data-testid="add-transfer-name"
+              placeholder={$_('addTransfer.namePlaceholder')}
+              bind:value={fields.name}
+              disabled={controlsAreDisabled}
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="add-transfer-form__field">
+            <label class="add-transfer-form__label" for="add-transfer-buyplace"
+              >{$_('addTransfer.buyplace')}</label
+            >
+            <input
+              id="add-transfer-buyplace"
+              type="text"
+              class="app-input"
+              data-testid="add-transfer-buyplace"
+              placeholder={$_('addTransfer.buyplacePlaceholder')}
+              bind:value={fields.buyplace}
+              disabled={controlsAreDisabled}
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="add-transfer-form__field">
+            <label class="add-transfer-form__label" for="add-transfer-amount"
+              >{$_('addTransfer.amount')}</label
+            >
+            <input
+              bind:this={amountInputElement}
+              id="add-transfer-amount"
+              type="text"
+              inputmode="numeric"
+              class="app-input"
+              data-testid="add-transfer-amount"
+              placeholder={$_('addTransfer.amountPlaceholder')}
+              bind:value={fields.amount}
+              disabled={controlsAreDisabled}
+              autocomplete="off"
+              on:keydown={handleAmountKeydown}
+              on:input={handleAmountInput}
+              on:paste={handleAmountPaste}
+            />
+          </div>
+
+          <div class="add-transfer-form__field">
+            <label class="add-transfer-form__label" for="add-transfer-from-account"
+              >{$_('addTransfer.fromAccount')}</label
+            >
+            <select
+              id="add-transfer-from-account"
+              class="app-input"
+              data-testid="add-transfer-from-account"
+              bind:value={fields.fromAccountId}
+              disabled={sourceAccountIsDisabled}
+            >
+              <option value={null}>{$_('addTransfer.fromAccountPlaceholder')}</option>
+              {#each optionsState.fromAccountOptions as account (account.accountId)}
+                <option value={account.accountId}>{getAccountName(account)}</option>
+              {/each}
+            </select>
+          </div>
+
+          <div class="add-transfer-form__field">
+            <label class="add-transfer-form__label" for="add-transfer-to-account"
+              >{$_('addTransfer.toAccount')}</label
+            >
+            <select
+              id="add-transfer-to-account"
+              class="app-input"
+              data-testid="add-transfer-to-account"
+              bind:value={fields.toAccountId}
+              disabled={controlsAreDisabled}
+            >
+              <option value={null}>{$_('addTransfer.toAccountPlaceholder')}</option>
+              {#each optionsState.toAccountOptions as account (account.accountId)}
+                <option value={account.accountId}>{getAccountName(account)}</option>
+              {/each}
+            </select>
+          </div>
+
+          <div class="add-transfer-form__field">
+            <div class="add-transfer-form__label-row">
+              <img
+                class="add-transfer-form__category-icon"
+                src={categoryIconUrl}
+                alt=""
+                aria-hidden="true"
+                width="20"
+                height="20"
+              />
+              <label class="add-transfer-form__label" for="add-transfer-category-1"
+                >{$_('addTransfer.categories')}</label
+              >
+            </div>
+            <div class="add-transfer-form__category-selects">
+              <select
+                id="add-transfer-category-1"
+                class="app-input"
+                data-testid="add-transfer-category-1"
+                bind:value={fields.category1Id}
+                disabled={controlsAreDisabled}
+              >
+                <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option
+                >
+                {#each optionsState.categoryOptions as cat (cat.categoryId)}
+                  <option value={cat.categoryId}>{cat.name}</option>
+                {/each}
+              </select>
+              <select
+                id="add-transfer-category-2"
+                class="app-input"
+                data-testid="add-transfer-category-2"
+                bind:value={fields.category2Id}
+                disabled={controlsAreDisabled}
+              >
+                <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option
+                >
+                {#each optionsState.categoryOptions as cat (cat.categoryId)}
+                  <option value={cat.categoryId}>{cat.name}</option>
+                {/each}
+              </select>
+              <select
+                id="add-transfer-category-3"
+                class="app-input"
+                data-testid="add-transfer-category-3"
+                bind:value={fields.category3Id}
+                disabled={controlsAreDisabled}
+              >
+                <option value={NO_CATEGORY_SELECTED}>{$_('addTransfer.categoryPlaceholder')}</option
+                >
+                {#each optionsState.categoryOptions as cat (cat.categoryId)}
+                  <option value={cat.categoryId}>{cat.name}</option>
+                {/each}
+              </select>
+            </div>
+          </div>
+
+          <div class="add-transfer-form__actions">
             <button
               type="button"
-              class="app-button app-button--primary add-transfer-form__action"
-              data-testid="add-transfer-retry"
-              disabled={saveIsBusy || isOffline}
-              on:click={handleRetry}
+              class="app-button app-button--secondary add-transfer-form__action"
+              data-testid="add-transfer-close"
+              disabled={isSubmitting || saveIsBusy}
+              on:click={handleClose}
             >
-              {$_('addTransfer.save.retry')}
+              {$_('addTransfer.close')}
             </button>
-          {:else if saveState.phase === 'conflict' || saveState.phase === 'conflict_syncing'}
+            {#if saveState.canRetry}
+              <button
+                type="button"
+                class="app-button app-button--primary add-transfer-form__action"
+                data-testid="add-transfer-retry"
+                disabled={saveIsBusy || isOffline}
+                on:click={handleRetry}
+              >
+                {$_('addTransfer.save.retry')}
+              </button>
+            {:else if saveState.phase === 'conflict' || saveState.phase === 'conflict_syncing'}
+              <button
+                type="button"
+                class="app-button app-button--primary add-transfer-form__action"
+                data-testid="add-transfer-resolve-conflict"
+                disabled={saveState.phase === 'conflict_syncing' || isOffline}
+                on:click={handleResolveConflict}
+              >
+                {saveState.phase === 'conflict_syncing'
+                  ? $_('addTransfer.save.conflictSyncingButton')
+                  : $_('addTransfer.save.conflictAction')}
+              </button>
+            {:else}
+              <button
+                type="submit"
+                class="app-button app-button--primary add-transfer-form__action"
+                data-testid="add-transfer-submit"
+                disabled={submitIsDisabled}
+              >
+                {saveIsBusy || isSubmitting ? $_('addTransfer.saving') : $_('addTransfer.submit')}
+              </button>
+            {/if}
+          </div>
+        {:else}
+          <div class="add-transfer-form__actions">
             <button
               type="button"
-              class="app-button app-button--primary add-transfer-form__action"
-              data-testid="add-transfer-resolve-conflict"
-              disabled={saveState.phase === 'conflict_syncing' || isOffline}
-              on:click={handleResolveConflict}
+              class="app-button app-button--secondary add-transfer-form__action"
+              data-testid="add-transfer-close"
+              disabled={isSubmitting || saveIsBusy}
+              on:click={handleClose}
             >
-              {saveState.phase === 'conflict_syncing'
-                ? $_('addTransfer.save.conflictSyncingButton')
-                : $_('addTransfer.save.conflictAction')}
+              {$_('addTransfer.close')}
             </button>
-          {:else}
-            <button
-              type="submit"
-              class="app-button app-button--primary add-transfer-form__action"
-              data-testid="add-transfer-submit"
-              disabled={submitIsDisabled}
-            >
-              {saveIsBusy || isSubmitting ? $_('addTransfer.saving') : $_('addTransfer.submit')}
-            </button>
-          {/if}
-        </div>
+          </div>
+        {/if}
       </form>
     </BottomSheet>
   {/if}
@@ -849,6 +983,75 @@
   .add-transfer-form__receipt-hint {
     color: var(--text-secondary);
     font-size: 0.84rem;
+  }
+
+  .receipt-progress {
+    display: grid;
+    gap: 0.55rem;
+    margin: 0.35rem 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .receipt-progress__step {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    min-height: 2.75rem;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--text-secondary) 22%, transparent);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    background: var(--surface-strong);
+    font-weight: 650;
+  }
+
+  .receipt-progress__marker {
+    width: 0.8rem;
+    height: 0.8rem;
+    flex: 0 0 auto;
+    border: 2px solid currentColor;
+    border-radius: 999px;
+  }
+
+  .receipt-progress__step--active {
+    border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 8%, var(--surface-strong));
+  }
+
+  .receipt-progress__step--active .receipt-progress__marker {
+    background: currentColor;
+  }
+
+  .receipt-progress__step--complete {
+    color: var(--positive);
+  }
+
+  .receipt-progress__step--complete .receipt-progress__marker {
+    background: currentColor;
+  }
+
+  .receipt-progress__step--error {
+    border-color: color-mix(in srgb, var(--error) 50%, transparent);
+    color: var(--error);
+    background: color-mix(in srgb, var(--error) 8%, var(--surface-strong));
+  }
+
+  .receipt-source-account {
+    margin-top: 0.2rem;
+  }
+
+  .app-visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .add-transfer-form__conflict {

--- a/src/features/app-shell/routes/AddRoute.test.ts
+++ b/src/features/app-shell/routes/AddRoute.test.ts
@@ -16,6 +16,10 @@ import type {
   ReceiptAnalysisController,
   ReceiptAnalysisState,
 } from '../../receipt/receiptAnalysisController';
+import type {
+  ReceiptTransferPreparationController,
+  ReceiptTransferPreparationState,
+} from '../../receipt/receiptTransferPreparationController';
 
 const READY_OPTIONS_STATE: AddTransferOptionsState = {
   operation: 'ready',
@@ -85,6 +89,30 @@ const createMockReceiptAnalysisController = (
   dispose: () => {},
 });
 
+const createMockReceiptPreparationController = (
+  state: ReceiptTransferPreparationState,
+): ReceiptTransferPreparationController => ({
+  getState: () => state,
+  subscribe: (listener) => {
+    listener(state);
+    return () => {};
+  },
+  beginRun: () => {},
+  handleCaptureFailure: () => {},
+  handleAnalysisState: () => {},
+  selectSourceAccount: () => {},
+  refreshOptions: () => {},
+  failForOffline: () => {},
+  reset: () => {},
+  dispose: () => {},
+});
+
+const PROCESSING_STEPS = [
+  { id: 'extraction' as const, status: 'active' as const },
+  { id: 'derivation' as const, status: 'pending' as const },
+  { id: 'creation' as const, status: 'pending' as const },
+];
+
 const renderAddRoute = (props: Record<string, unknown> = {}) =>
   render(AddRoute, {
     props: {
@@ -148,21 +176,36 @@ describe('AddRoute component', () => {
         phase: 'normalizing',
         errorCode: null,
       }),
+      receiptPreparationController: createMockReceiptPreparationController({
+        phase: 'processing',
+        steps: PROCESSING_STEPS,
+        sourceAccountId: null,
+        readyForCommit: null,
+        error: null,
+      }),
     }).body;
-    expect(normalizing).toContain('data-testid="receipt-normalizing-status"');
-    expect(normalizing).toContain('role="status"');
-    expect(normalizing).toMatch(/data-testid="receipt-photo-button"[^>]*disabled/);
-    expect(normalizing).toMatch(/data-testid="add-transfer-submit"[^>]*disabled/);
+    expect(normalizing).toContain('data-testid="receipt-progress"');
+    expect(normalizing).toContain('aria-live="polite"');
+    expect(normalizing).toMatch(/data-testid="receipt-step-extraction"[^>]*data-state="active"/);
+    expect(normalizing).not.toContain('data-testid="receipt-photo-button"');
+    expect(normalizing).not.toContain('data-testid="add-transfer-submit"');
 
     const handedOff = renderAddRoute({
       receiptCaptureController: createMockReceiptCaptureController({
         phase: 'handed_off',
         errorCode: null,
       }),
+      receiptPreparationController: createMockReceiptPreparationController({
+        phase: 'processing',
+        steps: PROCESSING_STEPS,
+        sourceAccountId: null,
+        readyForCommit: null,
+        error: null,
+      }),
     }).body;
-    expect(handedOff).toContain('data-testid="receipt-stage-one-status"');
+    expect(handedOff).toContain('data-testid="receipt-step-extraction"');
     expect(handedOff).toContain('Foto auslesen');
-    expect(handedOff).toMatch(/data-testid="receipt-photo-button"[^>]*disabled/);
+    expect(handedOff).not.toContain('data-testid="receipt-photo-button"');
   });
 
   it('shows stage-two progress and a validated analysis result without a review or retry action', () => {
@@ -177,13 +220,24 @@ describe('AddRoute component', () => {
         errorCode: null,
         errorReason: null,
         derivation: null,
+        extractedItemIndexes: null,
+      }),
+      receiptPreparationController: createMockReceiptPreparationController({
+        phase: 'processing',
+        steps: [
+          { id: 'extraction', status: 'complete' },
+          { id: 'derivation', status: 'active' },
+          { id: 'creation', status: 'pending' },
+        ],
+        sourceAccountId: null,
+        readyForCommit: null,
+        error: null,
       }),
     }).body;
-    expect(deriving).toContain('data-testid="receipt-stage-two-status"');
+    expect(deriving).toMatch(/data-testid="receipt-step-derivation"[^>]*data-state="active"/);
     expect(deriving).toContain('Transferdaten erstellen');
-    expect(deriving).toMatch(/data-testid="receipt-photo-button"[^>]*disabled/);
     expect(deriving).not.toMatch(/data-testid="add-transfer-from-account"[^>]*disabled/);
-    expect(deriving).toMatch(/data-testid="add-transfer-date"[^>]*disabled/);
+    expect(deriving).not.toContain('data-testid="add-transfer-date"');
 
     const succeeded = renderAddRoute({
       receiptCaptureController: createMockReceiptCaptureController(),
@@ -207,6 +261,29 @@ describe('AddRoute component', () => {
             },
           ],
         },
+        extractedItemIndexes: [0],
+      }),
+      receiptPreparationController: createMockReceiptPreparationController({
+        phase: 'ready_for_commit',
+        steps: [
+          { id: 'extraction', status: 'complete' },
+          { id: 'derivation', status: 'complete' },
+          { id: 'creation', status: 'active' },
+        ],
+        sourceAccountId: 11,
+        readyForCommit: [
+          {
+            bookingDateEpochDay: 20665,
+            name: 'Lebensmittel',
+            amountCents: 500,
+            transferTypeId: 1,
+            fromAccountId: 11,
+            toAccountId: 2,
+            categoryIds: [20],
+            buyplace: 'Markt',
+          },
+        ],
+        error: null,
       }),
     }).body;
     expect(succeeded).toContain('data-testid="receipt-analysis-success"');
@@ -218,34 +295,37 @@ describe('AddRoute component', () => {
   it('uses the plural success copy for multiple validated transfers', () => {
     const { body } = renderAddRoute({
       receiptCaptureController: createMockReceiptCaptureController(),
-      receiptAnalysisController: createMockReceiptAnalysisController({
-        phase: 'succeeded',
-        stage: null,
-        errorCode: null,
-        errorReason: null,
-        derivation: {
-          status: 'ok',
-          errorReason: null,
-          receiptTotalCents: 500,
-          transfers: [
-            {
-              name: 'Lebensmittel',
-              amountCents: 300,
-              categoryNames: ['Einkauf'],
-              buyplace: 'Markt',
-              receiptDate: '2026-07-31',
-              sourceItemIndexes: [0],
-            },
-            {
-              name: 'Haushalt',
-              amountCents: 200,
-              categoryNames: ['Haushalt'],
-              buyplace: 'Markt',
-              receiptDate: '2026-07-31',
-              sourceItemIndexes: [1],
-            },
-          ],
-        },
+      receiptPreparationController: createMockReceiptPreparationController({
+        phase: 'ready_for_commit',
+        steps: [
+          { id: 'extraction', status: 'complete' },
+          { id: 'derivation', status: 'complete' },
+          { id: 'creation', status: 'active' },
+        ],
+        sourceAccountId: 11,
+        readyForCommit: [
+          {
+            bookingDateEpochDay: 20665,
+            name: 'Lebensmittel',
+            amountCents: 300,
+            transferTypeId: 1,
+            fromAccountId: 11,
+            toAccountId: 2,
+            categoryIds: [20],
+            buyplace: 'Markt',
+          },
+          {
+            bookingDateEpochDay: 20665,
+            name: 'Haushalt',
+            amountCents: 200,
+            transferTypeId: 1,
+            fromAccountId: 11,
+            toAccountId: 2,
+            categoryIds: [22],
+            buyplace: 'Markt',
+          },
+        ],
+        error: null,
       }),
     });
 
@@ -256,6 +336,7 @@ describe('AddRoute component', () => {
     const controller = createMockOptionsController({
       ...READY_OPTIONS_STATE,
       fromAccountOptions: [{ accountId: 11, name: 'Checking', accountTypeId: 3 }],
+      toAccountOptions: [{ accountId: 2, name: 'Spendings', accountTypeId: 2 }],
     });
     for (const phase of ['extracting', 'deriving'] as const) {
       const { body } = renderAddRoute({
@@ -270,12 +351,27 @@ describe('AddRoute component', () => {
           errorCode: null,
           errorReason: null,
           derivation: null,
+          extractedItemIndexes: null,
+        }),
+        receiptPreparationController: createMockReceiptPreparationController({
+          phase: 'processing',
+          steps:
+            phase === 'extracting'
+              ? PROCESSING_STEPS
+              : [
+                  { id: 'extraction', status: 'complete' },
+                  { id: 'derivation', status: 'active' },
+                  { id: 'creation', status: 'pending' },
+                ],
+          sourceAccountId: null,
+          readyForCommit: null,
+          error: null,
         }),
       });
 
       expect(body).not.toMatch(/data-testid="add-transfer-from-account"[^>]*disabled/);
-      expect(body).toMatch(/data-testid="add-transfer-name"[^>]*disabled/);
-      expect(body).toMatch(/data-testid="receipt-photo-button"[^>]*disabled/);
+      expect(body).not.toContain('data-testid="add-transfer-name"');
+      expect(body).not.toContain('data-testid="receipt-photo-button"');
     }
   });
 
@@ -291,6 +387,18 @@ describe('AddRoute component', () => {
         errorCode: 'model_error',
         errorReason: 'Der Gesamtbetrag ist unlesbar.',
         derivation: null,
+        extractedItemIndexes: null,
+      }),
+      receiptPreparationController: createMockReceiptPreparationController({
+        phase: 'error',
+        steps: [
+          { id: 'extraction', status: 'error' },
+          { id: 'derivation', status: 'pending' },
+          { id: 'creation', status: 'pending' },
+        ],
+        sourceAccountId: null,
+        readyForCommit: null,
+        error: null,
       }),
     });
 
@@ -298,6 +406,7 @@ describe('AddRoute component', () => {
     expect(body).toContain('Der Gesamtbetrag ist unlesbar.');
     expect(body).not.toContain('receipt-analysis-retry');
     expect(body).not.toMatch(/data-testid="receipt-photo-button"[^>]*disabled/);
+    expect(body).toContain('Neuen Kassenbon fotografieren');
   });
 
   it('renders actionable localized capture errors without source details', () => {
@@ -312,6 +421,58 @@ describe('AddRoute component', () => {
     expect(body).toContain('Das Foto konnte nicht gelesen werden');
     expect(body).not.toContain('.heic');
     expect(body).not.toContain('EXIF');
+  });
+
+  it('renders a specific local preparation failure and clears the source selector', () => {
+    const { body } = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController(),
+      receiptPreparationController: createMockReceiptPreparationController({
+        phase: 'error',
+        steps: [
+          { id: 'extraction', status: 'complete' },
+          { id: 'derivation', status: 'complete' },
+          { id: 'creation', status: 'error' },
+        ],
+        sourceAccountId: null,
+        readyForCommit: null,
+        error: { code: 'category_not_found', detail: 'Einkauf' },
+      }),
+    });
+
+    expect(body).toContain('Die Kategorie "Einkauf"');
+    expect(body).toMatch(/data-testid="receipt-step-creation"[^>]*data-state="error"/);
+    expect(body).not.toContain('data-testid="add-transfer-from-account"');
+    expect(body).toContain('Neuen Kassenbon fotografieren');
+  });
+
+  it.each([
+    {
+      code: 'source_account_unavailable' as const,
+      message: 'Das gewählte Quellkonto ist nicht mehr gültig.',
+    },
+    {
+      code: 'primary_spendings_unavailable' as const,
+      message: 'Das primäre Ausgabenkonto ist nicht eindeutig verfügbar.',
+    },
+  ])('renders the account-topology failure $code as a fresh-photo restart', ({ code, message }) => {
+    const { body } = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController(),
+      receiptPreparationController: createMockReceiptPreparationController({
+        phase: 'error',
+        steps: [
+          { id: 'extraction', status: 'complete' },
+          { id: 'derivation', status: 'complete' },
+          { id: 'creation', status: 'error' },
+        ],
+        sourceAccountId: null,
+        readyForCommit: null,
+        error: { code, detail: null },
+      }),
+    });
+
+    expect(body).toContain(message);
+    expect(body).not.toContain('data-testid="add-transfer-from-account"');
+    expect(body).toContain('Neuen Kassenbon fotografieren');
   });
 
   it('renders the date field with app-input class', () => {

--- a/src/features/receipt/index.ts
+++ b/src/features/receipt/index.ts
@@ -1,4 +1,4 @@
-// Exposes receipt AI settings contracts to feature-level Settings and future receipt workflows.
+// Exposes receipt AI settings, capture, analysis, and transfer-preparation feature contracts.
 export { DEFAULT_TRANSFER_DERIVATION_PROMPT } from './receiptPrompts';
 export type { VersionedReceiptPrompt } from './receiptPrompts';
 export { createReceiptAnalysisController } from './receiptAnalysisController';
@@ -9,6 +9,21 @@ export type {
   ReceiptAnalysisStage,
   ReceiptAnalysisState,
 } from './receiptAnalysisController';
+export { listReceiptSourceAccountOptions } from './receiptTransferCommandBuilder';
+export type {
+  ReceiptTransferCommandBuildResult,
+  ReceiptTransferPreparationError,
+  ReceiptTransferPreparationErrorCode,
+} from './receiptTransferCommandBuilder';
+export { createReceiptTransferPreparationController } from './receiptTransferPreparationController';
+export type {
+  ReceiptProcessingStep,
+  ReceiptProcessingStepId,
+  ReceiptProcessingStepStatus,
+  ReceiptTransferPreparationController,
+  ReceiptTransferPreparationPhase,
+  ReceiptTransferPreparationState,
+} from './receiptTransferPreparationController';
 export {
   createEmptyOpenRouterReceiptSettings,
   reconcileOpenRouterModelSelections,

--- a/src/features/receipt/receiptAnalysisController.test.ts
+++ b/src/features/receipt/receiptAnalysisController.test.ts
@@ -130,6 +130,7 @@ describe('receipt analysis controller', () => {
       phase: 'succeeded',
       errorCode: null,
       derivation: { status: 'ok', receiptTotalCents: 350 },
+      extractedItemIndexes: [0, 1, 2],
     });
   });
 
@@ -161,6 +162,7 @@ describe('receipt analysis controller', () => {
       stage: 'derivation',
       errorCode: 'invalid_prompt',
       derivation: null,
+      extractedItemIndexes: null,
     });
   });
 
@@ -332,6 +334,7 @@ describe('receipt analysis controller', () => {
       errorCode: null,
       errorReason: null,
       derivation: null,
+      extractedItemIndexes: null,
     });
   });
 });

--- a/src/features/receipt/receiptAnalysisController.ts
+++ b/src/features/receipt/receiptAnalysisController.ts
@@ -43,6 +43,7 @@ export interface ReceiptAnalysisState {
   readonly errorCode: ReceiptAnalysisErrorCode | null;
   readonly errorReason: string | null;
   readonly derivation: ReceiptTransferDerivation | null;
+  readonly extractedItemIndexes: readonly number[] | null;
 }
 
 class ReceiptAnalysisError extends Error {
@@ -74,6 +75,7 @@ const INITIAL_STATE: ReceiptAnalysisState = {
   errorCode: null,
   errorReason: null,
   derivation: null,
+  extractedItemIndexes: null,
 };
 
 const createAbortError = (): DOMException =>
@@ -190,6 +192,7 @@ export const createReceiptAnalysisController = (
       errorCode: error.code,
       errorReason: error.reason,
       derivation: null,
+      extractedItemIndexes: null,
     });
   };
 
@@ -350,6 +353,7 @@ export const createReceiptAnalysisController = (
           errorCode: null,
           errorReason: null,
           derivation: parsedDerivation.value,
+          extractedItemIndexes: Object.freeze(extraction.items.map((item) => item.index)),
         });
       } catch (error) {
         if (

--- a/src/features/receipt/receiptTransferCommandBuilder.test.ts
+++ b/src/features/receipt/receiptTransferCommandBuilder.test.ts
@@ -1,0 +1,161 @@
+// Verifies exact local receipt mapping, desktop-rule reuse, and fail-closed batch preparation.
+import { describe, expect, it } from 'vitest';
+import {
+  PRIMARY_INCOME_ACCOUNT_TYPE_ID,
+  PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID,
+  TRANSFER_TYPE_STD_EXPENSE,
+} from '@db';
+
+import type { AddTransferOptionsState } from '../app-shell/routes/addTransferOptionsController';
+import type { ReceiptTransferDerivation } from './receiptAnalysisContracts';
+import {
+  buildReceiptTransferCommands,
+  listReceiptSourceAccountOptions,
+} from './receiptTransferCommandBuilder';
+
+const OPTIONS: AddTransferOptionsState = {
+  operation: 'ready',
+  fromAccountOptions: [
+    { accountId: 1, name: 'Primary Income', accountTypeId: PRIMARY_INCOME_ACCOUNT_TYPE_ID },
+    { accountId: 11, name: 'Checking', accountTypeId: 3 },
+    { accountId: 12, name: 'Cash', accountTypeId: 4 },
+  ],
+  toAccountOptions: [
+    { accountId: 2, name: 'Primary Spendings', accountTypeId: PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID },
+    { accountId: 11, name: 'Checking', accountTypeId: 3 },
+  ],
+  categoryOptions: [
+    { categoryId: 20, name: 'Einkauf' },
+    { categoryId: 21, name: 'Lebensmittel' },
+    { categoryId: 22, name: 'Haushalt' },
+  ],
+  error: null,
+};
+
+const DERIVATION: ReceiptTransferDerivation = {
+  status: 'ok',
+  errorReason: null,
+  receiptTotalCents: 500,
+  transfers: [
+    {
+      name: 'Lebensmittel',
+      amountCents: 350,
+      categoryNames: ['Einkauf', 'Lebensmittel'],
+      buyplace: 'Markt',
+      receiptDate: '2026-07-31',
+      sourceItemIndexes: [0, 1],
+    },
+    {
+      name: 'Haushaltsartikel',
+      amountCents: 150,
+      categoryNames: ['Einkauf', 'Haushalt'],
+      buyplace: 'Markt',
+      receiptDate: '2026-07-31',
+      sourceItemIndexes: [2],
+    },
+  ],
+};
+
+describe('receipt transfer command builder', () => {
+  it('offers only sources valid for the primary spendings destination', () => {
+    expect(listReceiptSourceAccountOptions(OPTIONS)).toEqual([
+      { accountId: 11, name: 'Checking', accountTypeId: 3 },
+      { accountId: 12, name: 'Cash', accountTypeId: 4 },
+    ]);
+  });
+
+  it('applies one source to every immutable command and preserves exact category order', () => {
+    const result = buildReceiptTransferCommands(DERIVATION, [0, 1, 2], 11, OPTIONS);
+
+    expect(result).toMatchObject({ ok: true });
+    if (!result.ok) return;
+    expect(result.commands).toEqual([
+      {
+        bookingDateEpochDay: 20665,
+        name: 'Lebensmittel',
+        amountCents: 350,
+        transferTypeId: TRANSFER_TYPE_STD_EXPENSE,
+        fromAccountId: 11,
+        toAccountId: 2,
+        categoryIds: [20, 21],
+        buyplace: 'Markt',
+      },
+      {
+        bookingDateEpochDay: 20665,
+        name: 'Haushaltsartikel',
+        amountCents: 150,
+        transferTypeId: TRANSFER_TYPE_STD_EXPENSE,
+        fromAccountId: 11,
+        toAccountId: 2,
+        categoryIds: [20, 22],
+        buyplace: 'Markt',
+      },
+    ]);
+    expect(Object.isFrozen(result.commands)).toBe(true);
+    expect(Object.isFrozen(result.commands[0]?.categoryIds)).toBe(true);
+  });
+
+  it('rejects missing and ambiguous exact category names without trusting an ID', () => {
+    const missing = buildReceiptTransferCommands(
+      { ...DERIVATION, transfers: [{ ...DERIVATION.transfers[0]!, categoryNames: ['Food'] }] },
+      [0, 1],
+      11,
+      OPTIONS,
+    );
+    expect(missing).toEqual({
+      ok: false,
+      error: { code: 'category_not_found', detail: 'Food' },
+    });
+
+    const ambiguous = buildReceiptTransferCommands(DERIVATION, [0, 1, 2], 11, {
+      ...OPTIONS,
+      categoryOptions: [...OPTIONS.categoryOptions, { categoryId: 23, name: 'Einkauf' }],
+    });
+    expect(ambiguous).toEqual({
+      ok: false,
+      error: { code: 'category_ambiguous', detail: 'Einkauf' },
+    });
+  });
+
+  it('rejects stale source and non-unique primary spendings accounts', () => {
+    expect(buildReceiptTransferCommands(DERIVATION, [0, 1, 2], 99, OPTIONS)).toMatchObject({
+      ok: false,
+      error: { code: 'source_account_unavailable' },
+    });
+    expect(
+      buildReceiptTransferCommands(DERIVATION, [0, 1, 2], 11, {
+        ...OPTIONS,
+        toAccountOptions: [
+          ...OPTIONS.toAccountOptions,
+          { accountId: 3, name: 'Duplicate', accountTypeId: PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID },
+        ],
+      }),
+    ).toMatchObject({ ok: false, error: { code: 'primary_spendings_unavailable' } });
+  });
+
+  it('revalidates exact item coverage, positive cents, and the receipt total', () => {
+    expect(buildReceiptTransferCommands(DERIVATION, [0, 1, 2, 3], 11, OPTIONS)).toMatchObject({
+      ok: false,
+      error: { code: 'invalid_item_coverage' },
+    });
+    expect(
+      buildReceiptTransferCommands(
+        {
+          ...DERIVATION,
+          transfers: [{ ...DERIVATION.transfers[0]!, amountCents: 0 }],
+        },
+        [0, 1],
+        11,
+        OPTIONS,
+      ),
+    ).toMatchObject({ ok: false, error: { code: 'non_positive_amount' } });
+    expect(
+      buildReceiptTransferCommands(
+        { ...DERIVATION, receiptTotalCents: 501 },
+        [0, 1, 2],
+        11,
+        OPTIONS,
+      ),
+    ).toMatchObject({ ok: false, error: { code: 'total_mismatch' } });
+  });
+});

--- a/src/features/receipt/receiptTransferCommandBuilder.ts
+++ b/src/features/receipt/receiptTransferCommandBuilder.ts
@@ -1,0 +1,270 @@
+// Converts validated receipt derivations into immutable desktop-compatible transfer commands.
+import { PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID, type CreateTransferInput } from '@db';
+
+import {
+  isoDateToEpochDay,
+  type AddTransferAccountOption,
+  type AddTransferFormFields,
+} from '../app-shell/routes/addTransferFormState';
+import { formatAmountInputDigits } from '../app-shell/routes/addTransferAmountInput';
+import type { AddTransferOptionsState } from '../app-shell/routes/addTransferOptionsController';
+import { validateAddTransfer } from '../app-shell/routes/addTransferValidation';
+import { deriveTransferType } from '../app-shell/routes/transferTypeDerivation';
+import type { ReceiptTransferDerivation } from './receiptAnalysisContracts';
+
+export type ReceiptTransferPreparationErrorCode =
+  | 'options_unavailable'
+  | 'offline'
+  | 'source_account_unavailable'
+  | 'primary_spendings_unavailable'
+  | 'category_not_found'
+  | 'category_ambiguous'
+  | 'invalid_transfer'
+  | 'invalid_item_coverage'
+  | 'non_positive_amount'
+  | 'total_mismatch';
+
+export interface ReceiptTransferPreparationError {
+  readonly code: ReceiptTransferPreparationErrorCode;
+  readonly detail: string | null;
+}
+
+export type ReceiptTransferCommandBuildResult =
+  | { readonly ok: true; readonly commands: readonly CreateTransferInput[] }
+  | { readonly ok: false; readonly error: ReceiptTransferPreparationError };
+
+const failure = (
+  code: ReceiptTransferPreparationErrorCode,
+  detail: string | null = null,
+): ReceiptTransferCommandBuildResult => ({ ok: false, error: { code, detail } });
+
+const findPrimarySpendingsAccount = (
+  optionsState: AddTransferOptionsState,
+): AddTransferAccountOption | null => {
+  const matches = optionsState.toAccountOptions.filter(
+    (account) => account.accountTypeId === PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID,
+  );
+  return matches.length === 1 ? (matches[0] ?? null) : null;
+};
+
+const createValidationFields = (
+  source: AddTransferAccountOption,
+  destination: AddTransferAccountOption,
+  transfer: ReceiptTransferDerivation['transfers'][number],
+): AddTransferFormFields => ({
+  date: transfer.receiptDate,
+  name: transfer.name,
+  amount: formatAmountInputDigits(String(transfer.amountCents)),
+  fromAccountId: source.accountId,
+  toAccountId: destination.accountId,
+  category1Id: -1,
+  category2Id: -1,
+  category3Id: -1,
+  buyplace: transfer.buyplace,
+});
+
+const hasSafeExactCoverage = (
+  derivation: ReceiptTransferDerivation,
+  expectedItemIndexes: readonly number[],
+): boolean => {
+  if (expectedItemIndexes.length === 0) {
+    return false;
+  }
+
+  const expected = new Set<number>();
+  for (const index of expectedItemIndexes) {
+    if (!Number.isSafeInteger(index) || index < 0 || expected.has(index)) {
+      return false;
+    }
+    expected.add(index);
+  }
+
+  const covered = new Set<number>();
+  for (const transfer of derivation.transfers) {
+    if (!Array.isArray(transfer.sourceItemIndexes) || transfer.sourceItemIndexes.length === 0) {
+      return false;
+    }
+    for (const index of transfer.sourceItemIndexes) {
+      if (!Number.isSafeInteger(index) || !expected.has(index) || covered.has(index)) {
+        return false;
+      }
+      covered.add(index);
+    }
+  }
+
+  return covered.size === expected.size;
+};
+
+export const listReceiptSourceAccountOptions = (
+  optionsState: AddTransferOptionsState,
+): readonly AddTransferAccountOption[] => {
+  if (optionsState.operation !== 'ready') {
+    return [];
+  }
+  const destination = findPrimarySpendingsAccount(optionsState);
+  if (destination === null) {
+    return [];
+  }
+
+  return optionsState.fromAccountOptions.filter((source) => {
+    const fields: AddTransferFormFields = {
+      date: '2026-01-01',
+      name: 'Receipt',
+      amount: '0,01€',
+      fromAccountId: source.accountId,
+      toAccountId: destination.accountId,
+      category1Id: -1,
+      category2Id: -1,
+      category3Id: -1,
+      buyplace: '',
+    };
+    return (
+      validateAddTransfer(
+        fields,
+        optionsState.fromAccountOptions,
+        optionsState.toAccountOptions,
+        (key) => key,
+      ).length === 0
+    );
+  });
+};
+
+export const validateReceiptSourceAccountTopology = (
+  optionsState: AddTransferOptionsState,
+): ReceiptTransferPreparationError | null => {
+  if (optionsState.operation !== 'ready') {
+    return { code: 'options_unavailable', detail: null };
+  }
+  if (findPrimarySpendingsAccount(optionsState) === null) {
+    return { code: 'primary_spendings_unavailable', detail: null };
+  }
+  if (listReceiptSourceAccountOptions(optionsState).length === 0) {
+    return { code: 'source_account_unavailable', detail: null };
+  }
+  return null;
+};
+
+export const buildReceiptTransferCommands = (
+  derivation: ReceiptTransferDerivation,
+  expectedItemIndexes: readonly number[],
+  sourceAccountId: number,
+  optionsState: AddTransferOptionsState,
+): ReceiptTransferCommandBuildResult => {
+  if (optionsState.operation !== 'ready') {
+    return failure('options_unavailable');
+  }
+
+  const destination = findPrimarySpendingsAccount(optionsState);
+  if (destination === null) {
+    return failure('primary_spendings_unavailable');
+  }
+
+  const validSources = listReceiptSourceAccountOptions(optionsState);
+  const sourceMatches = validSources.filter((account) => account.accountId === sourceAccountId);
+  if (sourceMatches.length !== 1) {
+    return failure('source_account_unavailable');
+  }
+  const source = sourceMatches[0];
+  if (source === undefined) {
+    return failure('source_account_unavailable');
+  }
+
+  if (
+    !Number.isSafeInteger(derivation.receiptTotalCents) ||
+    derivation.receiptTotalCents <= 0 ||
+    !Array.isArray(derivation.transfers) ||
+    derivation.transfers.length === 0
+  ) {
+    return failure('total_mismatch');
+  }
+  if (!hasSafeExactCoverage(derivation, expectedItemIndexes)) {
+    return failure('invalid_item_coverage');
+  }
+
+  const categoriesByName = new Map<string, number[]>();
+  for (const category of optionsState.categoryOptions) {
+    const matches = categoriesByName.get(category.name) ?? [];
+    matches.push(category.categoryId);
+    categoriesByName.set(category.name, matches);
+  }
+
+  let totalCents = 0;
+  const commands: CreateTransferInput[] = [];
+  for (const transfer of derivation.transfers) {
+    if (
+      typeof transfer.name !== 'string' ||
+      typeof transfer.buyplace !== 'string' ||
+      typeof transfer.receiptDate !== 'string'
+    ) {
+      return failure('invalid_transfer');
+    }
+    if (!Number.isSafeInteger(transfer.amountCents) || transfer.amountCents <= 0) {
+      return failure('non_positive_amount');
+    }
+    const nextTotal = totalCents + transfer.amountCents;
+    if (!Number.isSafeInteger(nextTotal)) {
+      return failure('total_mismatch');
+    }
+    totalCents = nextTotal;
+
+    if (
+      !Array.isArray(transfer.categoryNames) ||
+      transfer.categoryNames.length > 3 ||
+      transfer.categoryNames.some((categoryName: unknown) => typeof categoryName !== 'string')
+    ) {
+      return failure('invalid_transfer');
+    }
+    const categoryIds: number[] = [];
+    for (const categoryName of transfer.categoryNames) {
+      const matches = categoriesByName.get(categoryName) ?? [];
+      if (matches.length === 0) {
+        return failure('category_not_found', categoryName);
+      }
+      if (matches.length !== 1) {
+        return failure('category_ambiguous', categoryName);
+      }
+      const categoryId = matches[0];
+      if (categoryId === undefined) {
+        return failure('category_not_found', categoryName);
+      }
+      categoryIds.push(categoryId);
+    }
+
+    const fields = createValidationFields(source, destination, transfer);
+    const validationErrors = validateAddTransfer(
+      fields,
+      optionsState.fromAccountOptions,
+      optionsState.toAccountOptions,
+      (key) => key,
+    );
+    if (validationErrors.length > 0) {
+      return failure('invalid_transfer', validationErrors[0] ?? null);
+    }
+
+    let bookingDateEpochDay: number;
+    try {
+      bookingDateEpochDay = isoDateToEpochDay(transfer.receiptDate);
+    } catch {
+      return failure('invalid_transfer', 'addTransfer.validation.dateInvalid');
+    }
+
+    commands.push(
+      Object.freeze({
+        bookingDateEpochDay,
+        name: transfer.name.trim(),
+        amountCents: transfer.amountCents,
+        transferTypeId: deriveTransferType(source.accountTypeId, destination.accountTypeId),
+        fromAccountId: source.accountId,
+        toAccountId: destination.accountId,
+        categoryIds: Object.freeze([...categoryIds]),
+        buyplace: transfer.buyplace.trim().length > 0 ? transfer.buyplace.trim() : null,
+      }),
+    );
+  }
+
+  if (totalCents !== derivation.receiptTotalCents) {
+    return failure('total_mismatch');
+  }
+
+  return { ok: true, commands: Object.freeze(commands) };
+};

--- a/src/features/receipt/receiptTransferPreparationController.test.ts
+++ b/src/features/receipt/receiptTransferPreparationController.test.ts
@@ -1,0 +1,216 @@
+// Verifies account-independent analysis progress, automatic handoff, and complete transient cleanup.
+import { describe, expect, it } from 'vitest';
+import { PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID } from '@db';
+
+import type { AddTransferOptionsState } from '../app-shell/routes/addTransferOptionsController';
+import type { ReceiptAnalysisState } from './receiptAnalysisController';
+import { createReceiptTransferPreparationController } from './receiptTransferPreparationController';
+
+const OPTIONS: AddTransferOptionsState = {
+  operation: 'ready',
+  fromAccountOptions: [{ accountId: 11, name: 'Checking', accountTypeId: 3 }],
+  toAccountOptions: [
+    { accountId: 2, name: 'Primary Spendings', accountTypeId: PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID },
+  ],
+  categoryOptions: [{ categoryId: 20, name: 'Einkauf' }],
+  error: null,
+};
+
+const SUCCEEDED: ReceiptAnalysisState = {
+  phase: 'succeeded',
+  stage: null,
+  errorCode: null,
+  errorReason: null,
+  derivation: {
+    status: 'ok',
+    errorReason: null,
+    receiptTotalCents: 350,
+    transfers: [
+      {
+        name: 'Lebensmittel',
+        amountCents: 350,
+        categoryNames: ['Einkauf'],
+        buyplace: 'Markt',
+        receiptDate: '2026-07-31',
+        sourceItemIndexes: [0],
+      },
+    ],
+  },
+  extractedItemIndexes: [0],
+};
+
+const DERIVING: ReceiptAnalysisState = {
+  phase: 'deriving',
+  stage: 'derivation',
+  errorCode: null,
+  errorReason: null,
+  derivation: null,
+  extractedItemIndexes: null,
+};
+
+describe('receipt transfer preparation controller', () => {
+  it('starts with no source and lets analysis reach stage two independently', () => {
+    const controller = createReceiptTransferPreparationController();
+
+    controller.beginRun();
+    controller.handleAnalysisState(DERIVING, OPTIONS);
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'processing',
+      sourceAccountId: null,
+      steps: [
+        { id: 'extraction', status: 'complete' },
+        { id: 'derivation', status: 'active' },
+        { id: 'creation', status: 'pending' },
+      ],
+    });
+  });
+
+  it('waits after analysis and hands off automatically when the source is selected', () => {
+    const controller = createReceiptTransferPreparationController();
+    controller.beginRun();
+    controller.handleAnalysisState(SUCCEEDED, OPTIONS);
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'waiting_for_source',
+      sourceAccountId: null,
+      readyForCommit: null,
+    });
+
+    controller.selectSourceAccount(11, OPTIONS);
+
+    const state = controller.getState();
+    expect(state).toMatchObject({
+      phase: 'ready_for_commit',
+      sourceAccountId: 11,
+      steps: [
+        { id: 'extraction', status: 'complete' },
+        { id: 'derivation', status: 'complete' },
+        { id: 'creation', status: 'active' },
+      ],
+    });
+    expect(state.readyForCommit).toHaveLength(1);
+    expect(state.readyForCommit?.[0]).toMatchObject({ fromAccountId: 11, toAccountId: 2 });
+  });
+
+  it('prepares the same batch when the source is selected before analysis completes', () => {
+    const controller = createReceiptTransferPreparationController();
+    controller.beginRun();
+    controller.selectSourceAccount(11, OPTIONS);
+    controller.handleAnalysisState(DERIVING, OPTIONS);
+    controller.handleAnalysisState(SUCCEEDED, OPTIONS);
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'ready_for_commit',
+      sourceAccountId: 11,
+      readyForCommit: [{ fromAccountId: 11, amountCents: 350 }],
+    });
+  });
+
+  it('fails closed on local category resolution and clears all run data', () => {
+    const controller = createReceiptTransferPreparationController();
+    controller.beginRun();
+    controller.selectSourceAccount(11, OPTIONS);
+    controller.handleAnalysisState(SUCCEEDED, { ...OPTIONS, categoryOptions: [] });
+
+    expect(controller.getState()).toEqual({
+      phase: 'error',
+      steps: [
+        { id: 'extraction', status: 'complete' },
+        { id: 'derivation', status: 'complete' },
+        { id: 'creation', status: 'error' },
+      ],
+      sourceAccountId: null,
+      readyForCommit: null,
+      error: { code: 'category_not_found', detail: 'Einkauf' },
+    });
+  });
+
+  it.each([
+    {
+      name: 'no valid source account',
+      options: { ...OPTIONS, fromAccountOptions: [] },
+      code: 'source_account_unavailable',
+    },
+    {
+      name: 'a missing primary spendings account',
+      options: { ...OPTIONS, toAccountOptions: [] },
+      code: 'primary_spendings_unavailable',
+    },
+    {
+      name: 'ambiguous primary spendings accounts',
+      options: {
+        ...OPTIONS,
+        toAccountOptions: [
+          ...OPTIONS.toAccountOptions,
+          {
+            accountId: 3,
+            name: 'Duplicate Primary Spendings',
+            accountTypeId: PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID,
+          },
+        ],
+      },
+      code: 'primary_spendings_unavailable',
+    },
+  ])('fails closed after analysis when account topology has $name', ({ options, code }) => {
+    const controller = createReceiptTransferPreparationController();
+    controller.beginRun();
+
+    controller.handleAnalysisState(SUCCEEDED, options);
+
+    expect(controller.getState()).toEqual({
+      phase: 'error',
+      steps: [
+        { id: 'extraction', status: 'complete' },
+        { id: 'derivation', status: 'complete' },
+        { id: 'creation', status: 'error' },
+      ],
+      sourceAccountId: null,
+      readyForCommit: null,
+      error: { code, detail: null },
+    });
+  });
+
+  it('fails the active remote step when connectivity is lost and clears the selection', () => {
+    const controller = createReceiptTransferPreparationController();
+    controller.beginRun();
+    controller.selectSourceAccount(11, OPTIONS);
+    controller.handleAnalysisState(DERIVING, OPTIONS);
+
+    controller.failForOffline();
+
+    expect(controller.getState()).toEqual({
+      phase: 'error',
+      steps: [
+        { id: 'extraction', status: 'complete' },
+        { id: 'derivation', status: 'error' },
+        { id: 'creation', status: 'pending' },
+      ],
+      sourceAccountId: null,
+      readyForCommit: null,
+      error: { code: 'offline', detail: null },
+    });
+  });
+
+  it('clears selection, proof, commands, and progress on cancellation or a fresh run', () => {
+    const controller = createReceiptTransferPreparationController();
+    controller.beginRun();
+    controller.selectSourceAccount(11, OPTIONS);
+    controller.handleAnalysisState(SUCCEEDED, OPTIONS);
+    expect(controller.getState().phase).toBe('ready_for_commit');
+
+    controller.reset();
+    expect(controller.getState()).toMatchObject({
+      phase: 'idle',
+      sourceAccountId: null,
+      readyForCommit: null,
+    });
+
+    controller.beginRun();
+    expect(controller.getState()).toMatchObject({
+      phase: 'processing',
+      sourceAccountId: null,
+      readyForCommit: null,
+    });
+  });
+});

--- a/src/features/receipt/receiptTransferPreparationController.ts
+++ b/src/features/receipt/receiptTransferPreparationController.ts
@@ -1,0 +1,294 @@
+// Owns transient source selection, staged progress, validation, and the M9-05 command handoff.
+import type { CreateTransferInput } from '@db';
+
+import type { AddTransferOptionsState } from '../app-shell/routes/addTransferOptionsController';
+import type { ReceiptAnalysisState } from './receiptAnalysisController';
+import {
+  buildReceiptTransferCommands,
+  validateReceiptSourceAccountTopology,
+  type ReceiptTransferPreparationError,
+} from './receiptTransferCommandBuilder';
+import type { ReceiptTransferDerivation } from './receiptAnalysisContracts';
+
+export type ReceiptProcessingStepId = 'extraction' | 'derivation' | 'creation';
+export type ReceiptProcessingStepStatus = 'pending' | 'active' | 'complete' | 'error';
+export type ReceiptTransferPreparationPhase =
+  | 'idle'
+  | 'processing'
+  | 'waiting_for_source'
+  | 'ready_for_commit'
+  | 'error';
+
+export interface ReceiptProcessingStep {
+  readonly id: ReceiptProcessingStepId;
+  readonly status: ReceiptProcessingStepStatus;
+}
+
+export interface ReceiptTransferPreparationState {
+  readonly phase: ReceiptTransferPreparationPhase;
+  readonly steps: readonly ReceiptProcessingStep[];
+  readonly sourceAccountId: number | null;
+  readonly readyForCommit: readonly CreateTransferInput[] | null;
+  readonly error: ReceiptTransferPreparationError | null;
+}
+
+export interface ReceiptTransferPreparationController {
+  getState(): ReceiptTransferPreparationState;
+  subscribe(listener: (state: ReceiptTransferPreparationState) => void): () => void;
+  beginRun(): void;
+  handleCaptureFailure(): void;
+  handleAnalysisState(
+    analysisState: ReceiptAnalysisState,
+    optionsState: AddTransferOptionsState,
+  ): void;
+  selectSourceAccount(sourceAccountId: number | null, optionsState: AddTransferOptionsState): void;
+  refreshOptions(optionsState: AddTransferOptionsState): void;
+  failForOffline(): void;
+  reset(): void;
+  dispose(): void;
+}
+
+const steps = (
+  extraction: ReceiptProcessingStepStatus,
+  derivation: ReceiptProcessingStepStatus,
+  creation: ReceiptProcessingStepStatus,
+): readonly ReceiptProcessingStep[] =>
+  Object.freeze([
+    Object.freeze({ id: 'extraction' as const, status: extraction }),
+    Object.freeze({ id: 'derivation' as const, status: derivation }),
+    Object.freeze({ id: 'creation' as const, status: creation }),
+  ]);
+
+const INITIAL_STATE: ReceiptTransferPreparationState = Object.freeze({
+  phase: 'idle',
+  steps: steps('pending', 'pending', 'pending'),
+  sourceAccountId: null,
+  readyForCommit: null,
+  error: null,
+});
+
+export const createReceiptTransferPreparationController =
+  (): ReceiptTransferPreparationController => {
+    const listeners = new Set<(state: ReceiptTransferPreparationState) => void>();
+    let state = INITIAL_STATE;
+    let derivation: ReceiptTransferDerivation | null = null;
+    let expectedItemIndexes: readonly number[] | null = null;
+    let isDisposed = false;
+
+    const publish = (nextState: ReceiptTransferPreparationState): void => {
+      state = Object.freeze(nextState);
+      listeners.forEach((listener) => listener(state));
+    };
+
+    const clearTransientResult = (): void => {
+      derivation = null;
+      expectedItemIndexes = null;
+    };
+
+    const fail = (
+      step: ReceiptProcessingStepId,
+      error: ReceiptTransferPreparationError | null,
+    ): void => {
+      clearTransientResult();
+      const failedSteps =
+        step === 'extraction'
+          ? steps('error', 'pending', 'pending')
+          : step === 'derivation'
+            ? steps('complete', 'error', 'pending')
+            : steps('complete', 'complete', 'error');
+      publish({
+        phase: 'error',
+        steps: failedSteps,
+        sourceAccountId: null,
+        readyForCommit: null,
+        error,
+      });
+    };
+
+    const tryPrepare = (optionsState: AddTransferOptionsState): void => {
+      if (
+        isDisposed ||
+        derivation === null ||
+        expectedItemIndexes === null ||
+        state.sourceAccountId === null ||
+        state.phase === 'ready_for_commit' ||
+        state.phase === 'error'
+      ) {
+        return;
+      }
+
+      const result = buildReceiptTransferCommands(
+        derivation,
+        expectedItemIndexes,
+        state.sourceAccountId,
+        optionsState,
+      );
+      if (!result.ok) {
+        fail('creation', result.error);
+        return;
+      }
+
+      clearTransientResult();
+      publish({
+        phase: 'ready_for_commit',
+        steps: steps('complete', 'complete', 'active'),
+        sourceAccountId: state.sourceAccountId,
+        readyForCommit: result.commands,
+        error: null,
+      });
+    };
+
+    const reset = (): void => {
+      clearTransientResult();
+      if (!isDisposed) {
+        publish(INITIAL_STATE);
+      }
+    };
+
+    const activeStep = (): ReceiptProcessingStepId =>
+      state.steps.find((step) => step.status === 'active')?.id ?? 'creation';
+
+    return {
+      getState: () => state,
+
+      subscribe(listener): () => void {
+        if (isDisposed) {
+          listener(INITIAL_STATE);
+          return () => {};
+        }
+        listeners.add(listener);
+        listener(state);
+        return () => listeners.delete(listener);
+      },
+
+      beginRun(): void {
+        if (isDisposed) return;
+        clearTransientResult();
+        publish({
+          phase: 'processing',
+          steps: steps('active', 'pending', 'pending'),
+          sourceAccountId: null,
+          readyForCommit: null,
+          error: null,
+        });
+      },
+
+      handleCaptureFailure(): void {
+        if (!isDisposed && state.phase !== 'idle' && state.phase !== 'error') {
+          fail('extraction', null);
+        }
+      },
+
+      handleAnalysisState(analysisState, optionsState): void {
+        if (isDisposed || state.phase === 'idle' || state.phase === 'error') {
+          return;
+        }
+
+        if (analysisState.phase === 'extracting') {
+          publish({ ...state, phase: 'processing', steps: steps('active', 'pending', 'pending') });
+          return;
+        }
+        if (analysisState.phase === 'deriving') {
+          publish({ ...state, phase: 'processing', steps: steps('complete', 'active', 'pending') });
+          return;
+        }
+        if (analysisState.phase === 'error') {
+          fail(analysisState.stage === 'derivation' ? 'derivation' : 'extraction', null);
+          return;
+        }
+        if (
+          analysisState.phase === 'succeeded' &&
+          analysisState.derivation !== null &&
+          analysisState.extractedItemIndexes !== null
+        ) {
+          derivation = analysisState.derivation;
+          expectedItemIndexes = Object.freeze([...analysisState.extractedItemIndexes]);
+          if (state.sourceAccountId === null) {
+            const topologyError = validateReceiptSourceAccountTopology(optionsState);
+            if (topologyError !== null) {
+              fail('creation', topologyError);
+              return;
+            }
+            publish({
+              ...state,
+              phase: 'waiting_for_source',
+              steps: steps('complete', 'complete', 'pending'),
+            });
+            return;
+          }
+          publish({
+            ...state,
+            phase: 'processing',
+            steps: steps('complete', 'complete', 'active'),
+          });
+          tryPrepare(optionsState);
+        }
+      },
+
+      selectSourceAccount(sourceAccountId, optionsState): void {
+        if (
+          isDisposed ||
+          state.phase === 'idle' ||
+          state.phase === 'error' ||
+          state.phase === 'ready_for_commit'
+        ) {
+          return;
+        }
+        publish({ ...state, sourceAccountId });
+        if (derivation !== null && expectedItemIndexes !== null) {
+          if (sourceAccountId === null) {
+            publish({ ...state, sourceAccountId: null, phase: 'waiting_for_source' });
+            return;
+          }
+          publish({
+            ...state,
+            sourceAccountId,
+            phase: 'processing',
+            steps: steps('complete', 'complete', 'active'),
+          });
+          tryPrepare(optionsState);
+        }
+      },
+
+      refreshOptions(optionsState): void {
+        if (
+          isDisposed ||
+          state.phase === 'idle' ||
+          state.phase === 'error' ||
+          state.phase === 'ready_for_commit'
+        ) {
+          return;
+        }
+        if (optionsState.operation !== 'ready') {
+          fail(activeStep(), { code: 'options_unavailable', detail: null });
+          return;
+        }
+        if (derivation !== null && state.sourceAccountId === null) {
+          const topologyError = validateReceiptSourceAccountTopology(optionsState);
+          if (topologyError !== null) {
+            fail('creation', topologyError);
+          }
+          return;
+        }
+        if (state.sourceAccountId !== null && derivation !== null) {
+          tryPrepare(optionsState);
+        }
+      },
+
+      failForOffline(): void {
+        if (!isDisposed && state.phase !== 'idle' && state.phase !== 'error') {
+          fail(activeStep(), { code: 'offline', detail: null });
+        }
+      },
+
+      reset,
+
+      dispose(): void {
+        if (isDisposed) return;
+        clearTransientResult();
+        isDisposed = true;
+        state = INITIAL_STATE;
+        listeners.clear();
+      },
+    };
+  };

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -79,8 +79,35 @@
       "normalizing": "Foto wird sicher vorbereitet...",
       "stageOne": "Foto auslesen",
       "stageTwo": "Transferdaten erstellen",
+      "freshAction": "Neuen Kassenbon fotografieren",
+      "sourceAccount": "Quellkonto für alle Transfers",
+      "accountRequired": "Wähle ein Quellkonto, damit die Transfers automatisch erstellt werden können.",
+      "progressLabel": "Fortschritt der Kassenbonverarbeitung",
+      "steps": {
+        "extraction": "Foto auslesen",
+        "derivation": "Transferdaten erstellen",
+        "creation": "Transfers erstellen"
+      },
+      "stepStates": {
+        "pending": "Ausstehend",
+        "active": "In Bearbeitung",
+        "complete": "Abgeschlossen",
+        "error": "Fehlgeschlagen"
+      },
       "analysisSuccessOne": "Transferdaten für 1 Transfer wurden erstellt.",
       "analysisSuccessMany": "Transferdaten für {count} Transfers wurden erstellt.",
+      "preparationErrors": {
+        "options_unavailable": "Konten und Kategorien sind nicht mehr aktuell verfügbar. Starte mit einem neuen Foto.",
+        "offline": "Die Internetverbindung wurde unterbrochen. Starte online mit einem neuen Foto.",
+        "source_account_unavailable": "Das gewählte Quellkonto ist nicht mehr gültig. Starte mit einem neuen Foto.",
+        "primary_spendings_unavailable": "Das primäre Ausgabenkonto ist nicht eindeutig verfügbar. Starte mit einem neuen Foto.",
+        "category_not_found": "Die Kategorie \"{detail}\" ist in der aktuellen Datenbank nicht vorhanden. Starte nach der Korrektur mit einem neuen Foto.",
+        "category_ambiguous": "Die Kategorie \"{detail}\" ist in der aktuellen Datenbank nicht eindeutig. Starte nach der Korrektur mit einem neuen Foto.",
+        "invalid_transfer": "Mindestens ein Transfer verletzt die lokalen Conspectus-Regeln: {detail} Starte mit einem neuen Foto.",
+        "invalid_item_coverage": "Die Bonpositionen sind nicht genau einmal auf die Transfers verteilt. Starte mit einem neuen Foto.",
+        "non_positive_amount": "Mindestens ein Transferbetrag ist nicht positiv oder kein sicherer Centwert. Starte mit einem neuen Foto.",
+        "total_mismatch": "Die Transfersumme stimmt nicht exakt mit dem Bonbetrag überein. Starte mit einem neuen Foto."
+      },
       "errors": {
         "empty_file": "Das ausgewählte Bild ist leer. Nimm ein neues Foto auf.",
         "source_too_large": "Das Foto ist zu groß. Nimm ein neues Foto mit höchstens 20 MB auf.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -79,8 +79,35 @@
       "normalizing": "Preparing the photo securely...",
       "stageOne": "Read photo",
       "stageTwo": "Create transfer data",
+      "freshAction": "Photograph a new receipt",
+      "sourceAccount": "Source account for all transfers",
+      "accountRequired": "Select a source account so the transfers can be created automatically.",
+      "progressLabel": "Receipt processing progress",
+      "steps": {
+        "extraction": "Read photo",
+        "derivation": "Create transfer data",
+        "creation": "Create transfers"
+      },
+      "stepStates": {
+        "pending": "Pending",
+        "active": "In progress",
+        "complete": "Complete",
+        "error": "Failed"
+      },
       "analysisSuccessOne": "Transfer data for 1 transfer is ready.",
       "analysisSuccessMany": "Transfer data for {count} transfers is ready.",
+      "preparationErrors": {
+        "options_unavailable": "Accounts and categories are no longer currently available. Start again with a new photo.",
+        "offline": "The internet connection was interrupted. Start online with a new photo.",
+        "source_account_unavailable": "The selected source account is no longer valid. Start again with a new photo.",
+        "primary_spendings_unavailable": "The primary spendings account is not uniquely available. Start again with a new photo.",
+        "category_not_found": "The category \"{detail}\" does not exist in the current database. Correct it, then start with a new photo.",
+        "category_ambiguous": "The category \"{detail}\" is ambiguous in the current database. Correct it, then start with a new photo.",
+        "invalid_transfer": "At least one transfer violates the local Conspectus rules: {detail} Start again with a new photo.",
+        "invalid_item_coverage": "Receipt items are not assigned to the transfers exactly once. Start again with a new photo.",
+        "non_positive_amount": "At least one transfer amount is not a positive safe cent value. Start again with a new photo.",
+        "total_mismatch": "The transfer total does not exactly match the receipt total. Start again with a new photo."
+      },
       "errors": {
         "empty_file": "The selected image is empty. Take a new photo.",
         "source_too_large": "The photo is too large. Take a new photo no larger than 20 MB.",

--- a/tests/e2e/receipt-capture.spec.ts
+++ b/tests/e2e/receipt-capture.spec.ts
@@ -60,6 +60,38 @@ const DERIVATION = {
   ],
 };
 
+const MULTI_EXTRACTION = {
+  ...EXTRACTION,
+  receiptTotalCents: 500,
+  items: [
+    { index: 0, name: 'Brot', quantityText: null, lineTotalCents: 300, kind: 'item' },
+    { index: 1, name: 'Reiniger', quantityText: null, lineTotalCents: 200, kind: 'item' },
+  ],
+};
+
+const MULTI_DERIVATION = {
+  ...DERIVATION,
+  receiptTotalCents: 500,
+  transfers: [
+    {
+      name: 'Lebensmittel',
+      amountCents: 300,
+      categoryNames: ['Einkauf', 'Lebensmittel'],
+      buyplace: 'Markt',
+      receiptDate: '2026-07-31',
+      sourceItemIndexes: [0],
+    },
+    {
+      name: 'Haushaltsartikel',
+      amountCents: 200,
+      categoryNames: ['Einkauf', 'Haushalt'],
+      buyplace: 'Markt',
+      receiptDate: '2026-07-31',
+      sourceItemIndexes: [1],
+    },
+  ],
+};
+
 const installReadyReceiptConfiguration = async (page: Page): Promise<void> => {
   await page.addInitScript(() => {
     window.localStorage.setItem(
@@ -155,6 +187,10 @@ test('exposes one native outward-camera image input without custom capture or ga
       { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
       { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
     ],
+    categoryRows: [
+      { categoryId: 20, name: 'Einkauf' },
+      { categoryId: 21, name: 'Lebensmittel' },
+    ],
   });
 
   await page.goto(appPath('#/add'));
@@ -198,6 +234,10 @@ test('runs the two isolated OpenRouter stages while account selection remains op
       { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
       { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
     ],
+    categoryRows: [
+      { categoryId: 20, name: 'Einkauf' },
+      { categoryId: 21, name: 'Lebensmittel' },
+    ],
   });
   await page.goto(appPath('#/add'));
 
@@ -206,15 +246,23 @@ test('runs the two isolated OpenRouter stages while account selection remains op
     mimeType: 'image/png',
     buffer: RECEIPT_IMAGE,
   });
-  await expect(page.getByTestId('receipt-stage-one-status')).toBeVisible();
+  await expect(page.getByTestId('receipt-progress')).toBeVisible();
+  await expect(page.getByTestId('receipt-progress')).toHaveAccessibleName(
+    'Receipt processing progress',
+  );
+  await expect(page.getByTestId('receipt-step-extraction')).toHaveAttribute('data-state', 'active');
   await expect(page.getByTestId('add-transfer-from-account')).toBeEnabled();
+  await expect(page.getByTestId('add-transfer-date')).toHaveCount(0);
+  await expect(page.getByTestId('add-transfer-submit')).toHaveCount(0);
+  await expect(page.getByTestId('receipt-progress')).not.toContainText('%');
   await page.getByTestId('add-transfer-from-account').selectOption('11');
-  await expect(page.getByTestId('receipt-stage-two-status')).toBeVisible();
+  await expect(page.getByTestId('receipt-step-derivation')).toHaveAttribute('data-state', 'active');
   await expect(page.getByTestId('add-transfer-from-account')).toBeEnabled();
   await expect(page.getByTestId('add-transfer-from-account')).toHaveValue('11');
   await expect(page.getByTestId('receipt-analysis-success')).toContainText(
     'Transfer data for 1 transfer is ready.',
   );
+  await expect(page.getByTestId('receipt-step-creation')).toHaveAttribute('data-state', 'active');
 
   expect(requests.catalogRequests).toHaveLength(2);
   expect(requests.completionRequests).toHaveLength(2);
@@ -227,6 +275,7 @@ test('runs the two isolated OpenRouter stages while account selection remains op
   expect(JSON.stringify(stageOneBody)).toContain('data:image/jpeg;base64,');
   expect(JSON.stringify(stageTwoBody)).not.toContain('data:image/jpeg;base64,');
   expect(JSON.stringify(stageTwoBody)).not.toContain('accountId');
+  expect(JSON.stringify(stageOneBody)).not.toContain('accountId');
   expect(stageOneBody.provider).toEqual({ allow_fallbacks: false });
   expect(stageTwoBody.provider).toEqual({
     allow_fallbacks: false,
@@ -236,6 +285,100 @@ test('runs the two isolated OpenRouter stages while account selection remains op
     type: 'json_schema',
     json_schema: { strict: true },
   });
+  expect(await getLocalTransferWriteCallCount(page)).toBe(0);
+  expect(await getGraphUploadCallCount(page)).toBe(0);
+});
+
+test('waits for a deliberate late source selection and prepares a multi-transfer batch automatically', async ({
+  page,
+}) => {
+  await installReadyReceiptConfiguration(page);
+  await installReceiptAnalysisRoutes(page, [MULTI_EXTRACTION, MULTI_DERIVATION]);
+  await installReadyAddTransferTestDb(page, {
+    fromAccountOptionRows: [
+      { accountId: 1, name: 'Primary Income', amountCents: 0, accountTypeId: 1 },
+      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+    ],
+    toAccountOptionRows: [
+      { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+    ],
+    categoryRows: [
+      { categoryId: 20, name: 'Einkauf' },
+      { categoryId: 21, name: 'Lebensmittel' },
+      { categoryId: 22, name: 'Haushalt' },
+    ],
+  });
+  await page.goto(appPath('#/add'));
+
+  await page.getByTestId('receipt-image-input').setInputFiles({
+    name: 'multi-receipt.png',
+    mimeType: 'image/png',
+    buffer: RECEIPT_IMAGE,
+  });
+
+  await expect(page.getByTestId('receipt-account-required')).toBeVisible();
+  await expect(page.getByTestId('receipt-step-extraction')).toHaveAttribute(
+    'data-state',
+    'complete',
+  );
+  await expect(page.getByTestId('receipt-step-derivation')).toHaveAttribute(
+    'data-state',
+    'complete',
+  );
+  await expect(page.getByTestId('receipt-step-creation')).toHaveAttribute('data-state', 'pending');
+  await expect(page.getByTestId('add-transfer-from-account')).toHaveValue('');
+  await expect(page.getByTestId('add-transfer-from-account').locator('option')).toHaveCount(2);
+
+  await page.getByTestId('add-transfer-from-account').selectOption('11');
+
+  await expect(page.getByTestId('receipt-analysis-success')).toContainText(
+    'Transfer data for 2 transfers is ready.',
+  );
+  await expect(page.getByTestId('receipt-step-creation')).toHaveAttribute('data-state', 'active');
+  await expect(page.getByTestId('add-transfer-from-account')).toBeDisabled();
+  await expect(page.locator('[data-testid*="receipt-review"]')).toHaveCount(0);
+  expect(await getLocalTransferWriteCallCount(page)).toBe(0);
+  expect(await getGraphUploadCallCount(page)).toBe(0);
+});
+
+test('cancels an active run on route abandonment and never restores its source or results', async ({
+  page,
+}) => {
+  await installReadyReceiptConfiguration(page);
+  await installReceiptAnalysisRoutes(page, [EXTRACTION, DERIVATION]);
+  await installReadyAddTransferTestDb(page, {
+    fromAccountOptionRows: [
+      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+    ],
+    toAccountOptionRows: [
+      { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+    ],
+    categoryRows: [
+      { categoryId: 20, name: 'Einkauf' },
+      { categoryId: 21, name: 'Lebensmittel' },
+    ],
+  });
+  await page.goto(appPath('#/add'));
+
+  await page.getByTestId('receipt-image-input').setInputFiles({
+    name: 'cancelled-receipt.png',
+    mimeType: 'image/png',
+    buffer: RECEIPT_IMAGE,
+  });
+  await expect(page.getByTestId('receipt-progress')).toBeVisible();
+  await page.getByTestId('add-transfer-from-account').selectOption('11');
+  await page.getByTestId('add-transfer-close').click();
+  await expect(page.getByTestId('route-transfers')).toBeVisible();
+
+  await page.evaluate(() => {
+    window.location.hash = '#/add';
+  });
+  await expect(page).toHaveURL(/#\/add$/);
+  await expect(page.getByTestId('receipt-photo-button')).toBeVisible();
+  await expect(page.getByTestId('receipt-progress')).toHaveCount(0);
+  await expect(page.getByTestId('add-transfer-from-account')).toHaveValue('');
+  await page.waitForTimeout(700);
+  await expect(page.getByTestId('receipt-progress')).toHaveCount(0);
   expect(await getLocalTransferWriteCallCount(page)).toBe(0);
   expect(await getGraphUploadCallCount(page)).toBe(0);
 });
@@ -257,7 +400,18 @@ test('ends a model-declared failure and starts again only after a fresh file sel
     EXTRACTION,
     DERIVATION,
   ]);
-  await installReadyAddTransferTestDb(page);
+  await installReadyAddTransferTestDb(page, {
+    fromAccountOptionRows: [
+      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+    ],
+    toAccountOptionRows: [
+      { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+    ],
+    categoryRows: [
+      { categoryId: 20, name: 'Einkauf' },
+      { categoryId: 21, name: 'Lebensmittel' },
+    ],
+  });
   await page.goto(appPath('#/add'));
 
   const input = page.getByTestId('receipt-image-input');
@@ -269,9 +423,16 @@ test('ends a model-declared failure and starts again only after a fresh file sel
   await page.waitForTimeout(300);
   expect(requests.completionRequests).toHaveLength(1);
   await expect(page.getByTestId('receipt-photo-button')).toBeEnabled();
+  await expect(page.getByTestId('receipt-photo-button')).toHaveAccessibleName(
+    'Photograph a new receipt',
+  );
+  await expect(page.getByTestId('add-transfer-from-account')).toHaveCount(0);
+  await expect(page.getByTestId('receipt-step-extraction')).toHaveAttribute('data-state', 'error');
   await expect(page.getByTestId('receipt-analysis-retry')).toHaveCount(0);
 
   await input.setInputFiles({ name: 'second.png', mimeType: 'image/png', buffer: RECEIPT_IMAGE });
+  await expect(page.getByTestId('add-transfer-from-account')).toBeEnabled();
+  await page.getByTestId('add-transfer-from-account').selectOption('11');
   await expect(page.getByTestId('receipt-analysis-success')).toBeVisible();
   expect(requests.completionRequests).toHaveLength(3);
   expect(await getLocalTransferWriteCallCount(page)).toBe(0);


### PR DESCRIPTION
# Pull Request

## Linked Issue or Task

- Closes #254
- Milestone: M9 - Receipt Capture + OpenRouter

## Context

- Problem: M9-03 produced validated receipt-derived transfer data, but the mobile flow did not deliberately select a source account per run or prepare a validated immutable batch for the later atomic commit.
- Goal: Complete M9-04 with accessible staged progress and automatic local preparation while preserving the privacy and no-write boundary owned by M9-05.

## Changes

- Show valid source accounts immediately after a fresh capture and keep selection independent of both OpenRouter stages.
- Add one accessible ordered progress surface for photo extraction, transfer-data derivation, and transfer creation without fake percentages or an intermediate editor/confirmation step.
- Resolve exact category names, validate item coverage and safe cent totals, reuse Add Transfer validation/type derivation, and expose an immutable command handoff for M9-05.
- Fail closed and clear all transient state for remote, local-validation, stale-account, and impossible account-topology failures; cancellation, route changes, reset, sign-out, and file rebinding also clear the run.
- Keep images, model payloads/responses, account IDs, derived data, and prepared commands transient; M9-04 performs no SQLite, cache, Graph, or OneDrive write.
- Bump the app version to `0.9.04`, synchronize architecture/backlog docs, and raise only the reviewed raw JS/CSS bundle ceilings for intentional product growth while leaving gzip ceilings unchanged.

## Test Plan

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 759 tests passed (632 app + 127 scripts)
- [x] `npm run build`
- [x] `npm run check:dead-code`
- [x] `npm run check:bundle-size`
- [x] `git diff --check`
- [x] `npm run test:e2e` — 153 passed, 1 expected skip across Chromium and Pixel 5
- Notes: Build emitted the existing large-chunk advisory. Final bundle totals remain within the documented limits: JS 704,622/706,560 bytes raw and 212,650/215,040 gzip; CSS 31,978/32,768 raw and 5,796/5,888 gzip.

## Screenshots

- [ ] UI change: screenshots attached
- [ ] No UI change
- Automated Chromium and Pixel 5 coverage verifies the workflow; no manual screenshot was captured.

## Manual Device QA (Release PRs Only)

- [x] Not a release PR; physical-device QA is not required here.
- [ ] Release PR: all required rows in [`docs/Manual-Device-QA.md`](https://github.com/Jon2050/Conspectus-Mobile/blob/main/docs/Manual-Device-QA.md) pass.
- Tested candidate URL / commit: N/A
- Completed results and evidence location in this PR: Local and CI checks listed above.

## Release Process (Release PRs Only)

- [x] Not a release PR; the release-cut process is not required here.
- [ ] Release PR: the single checklist from [`docs/Release-Process.md`](https://github.com/Jon2050/Conspectus-Mobile/blob/main/docs/Release-Process.md) is copied into this PR or a dedicated PR comment and completed there.
- Planned version / tag: `0.9.04` application version; no release tag in this issue PR.
- Candidate commit / `Quality` / `Deploy Preview` evidence: Commit `2c47d00590111b8c445b12096641196ea1cefd67`; GitHub checks pending.
- Reviewer-agent approval evidence: Codex reviewer subagent `/root/m9_04_review` returned `APPROVED` with no actionable findings after one P2 correction and full re-verification.
- Human release-owner `APPROVED FOR RELEASE` evidence: N/A
- Approved release-notes location: N/A
- Production commit / `Deploy Production` / post-deploy evidence: N/A

## Risk Notes

- User impact: Receipt capture now transitions directly into a deliberate source-account choice and locally validated staged preparation. Semantic grouping still depends on model quality; any contract or local validation failure requires a fresh capture.
- Assumptions: The sole primary spendings account remains authoritative, category matching is exact and case-sensitive, and M9-05 will consume the immutable handoff and own the atomic DB/write/upload step.
- Rollback plan: Revert this issue commit; no persisted data migration or remote-state change is introduced by M9-04.

## QS Checklist

- [x] The linked issue or manual-task context is included in this PR.
- [x] Lint, typecheck, tests, and build were run and pass.
- [ ] Screenshots are included for UI changes.
- [x] Risk and rollback notes are documented.
- [x] No secrets, tokens, or credentials were added to the repository.
- [x] No unintended path/base URL changes were introduced (production remains rooted at `https://jon2050.de/conspectus/`).

## Merge And Cleanup (PR Path)

- [ ] Required GitHub checks are green.
- [x] PR will be merged into `main` with `Rebase and merge`.
- [x] PR will be merged into `main` once checks/review requirements are satisfied.
- [x] Head branch will be deleted after merge.
- [x] Linked issue/backlog marker becomes done on `main` only through the merged issue commit.
