### PR TITLE
M9-05: Automatically commit validated receipt transfers

### DIFF
--- a/bundle-size-budgets.json
+++ b/bundle-size-budgets.json
@@ -2,8 +2,8 @@
   "description": "Defines the maximum raw and gzip bytes allowed for emitted JavaScript and CSS.",
   "budgets": {
     "javascript": {
-      "rawBytes": 706560,
-      "gzipBytes": 215040
+      "rawBytes": 729088,
+      "gzipBytes": 219136
     },
     "css": {
       "rawBytes": 32768,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -187,6 +187,24 @@ Receipt analysis is an abortable, two-stage feature workflow behind typed OpenRo
    and reuse the existing Add Transfer validation and transfer-type rules. The resulting immutable
    command batch is held only in memory for M9-05; this preparation step performs no SQLite, cache,
    Graph, or OneDrive mutation and exposes no review or editing surface.
+6. Claim a prepared command batch once, revalidate it against the authenticated verified-current
+   runtime, and apply all transfer inserts and balance changes in one SQLite transaction. Export one
+   full snapshot and send it through the existing eTag/`If-Match` upload boundary. The final progress
+   step remains active until OneDrive acceptance and required cache reconciliation; only then is the
+   exact singular/plural created count shown.
+
+After command handoff, image, extraction, raw response, and derivation state is released. A retryable
+pre-commit upload failure retains only the already exported database bytes and the eTag against
+which they were produced, so retry repeats neither the AI stages, local validation, transaction,
+nor export and cannot attach stale bytes to newer cached metadata. An eTag conflict instead discards those
+stale bytes, refreshes the authoritative runtime, retains only the immutable commands, revalidates
+them, and waits for an explicit save-again action without adding a review screen. When OneDrive
+accepts the upload but local cache persistence fails, the remote commit is final: all write retries
+are disabled and the app forces verified reconciliation. A remaining reconciliation failure says
+that OneDrive is already updated and cannot resume the batch. If the local transaction commits but
+the subsequent SQLite export fails or is empty, the app closes that runtime and restores the
+verified OneDrive snapshot before enabling another write, preventing an unreported local batch from
+entering a later upload.
 
 Both calls use the explicitly selected model without model or provider fallback. They add no app
 owned ZDR or data-collection routing restriction, so stricter OpenRouter account preferences and
@@ -234,14 +252,15 @@ Consequences:
 
 ## Transfer write flow
 
-Creating a transfer mirrors the desktop application's business and database behavior:
+Creating one manual transfer or an automatic validated receipt batch mirrors the desktop
+application's business and database behavior:
 
 1. Require online state and a ready, current database runtime.
 2. Validate the date, name, positive integer-cent amount, available account selections, category
    selections, and primary-account combination rules.
 3. Derive the desktop-compatible transfer type from the selected account types.
-4. In one SQLite transaction, insert the transfer, decrement the source balance, and increment the
-   destination balance.
+4. In one SQLite transaction, insert the transfer or every transfer in the batch and apply every
+   matching source/destination balance change. Any statement failure rolls back the entire action.
 5. Export a new full SQLite byte snapshot.
 6. Upload the full file to OneDrive with `If-Match` using the current eTag.
 7. After remote success, persist the uploaded bytes and returned eTag and refresh visible data.
@@ -251,11 +270,18 @@ Safety invariants:
 - A failed SQL statement rolls back the entire local transaction.
 - Success is not shown before OneDrive accepts the upload.
 - A retryable transport failure retries the already exported bytes; it does not repeat the local
-  SQL transaction.
+  SQL transaction. The retry remains bound to its original eTag and becomes a conflict if cached
+  authoritative metadata has advanced.
+- A post-transaction export failure closes the locally changed runtime and restores the verified
+  OneDrive snapshot before another write is allowed.
+- Missing or otherwise untrustworthy cached upload metadata after a local commit uses the same
+  authoritative restore path; the locally changed runtime is never left available for a later
+  unrelated export.
 - A cache failure after remote success is a reconciliation problem, not a retryable remote write.
 - An eTag conflict discards stale pending bytes, closes the current sql.js runtime, downloads and
-  validates the latest OneDrive snapshot, reopens the runtime, and only then allows the user to
-  review and submit the preserved draft again.
+  validates the latest OneDrive snapshot, and reopens the runtime. Manual entry then allows review
+  and resubmission of its draft; receipt creation revalidates immutable commands and requires an
+  explicit save-again action without exposing a review surface or rerunning either model.
 - The application never silently overwrites a remotely changed database.
 
 ## Data compatibility

--- a/docs/CI-CD-Pipelines.md
+++ b/docs/CI-CD-Pipelines.md
@@ -114,7 +114,7 @@ limits per asset class:
 
 | Asset class |               Raw limit |              Gzip limit |
 | ----------- | ----------------------: | ----------------------: |
-| JavaScript  | 690 KiB (706,560 bytes) | 210 KiB (215,040 bytes) |
+| JavaScript  | 712 KiB (729,088 bytes) | 214 KiB (219,136 bytes) |
 | CSS         |   32 KiB (32,768 bytes) |  5.75 KiB (5,888 bytes) |
 
 Raw totals guard parse, storage, and uncompressed delivery cost. Gzip totals are calculated by

--- a/docs/GitHub-Issues-Backlog.md
+++ b/docs/GitHub-Issues-Backlog.md
@@ -177,7 +177,7 @@ Exit criteria:
 - Depends on: `M9-03`
 - GitHub: [#254](https://github.com/Jon2050/Conspectus-Mobile/issues/254)
 
-### :green_circle: M9-05 Automatically commit validated receipt transfers through OneDrive
+### :white_check_mark: M9-05 Automatically commit validated receipt transfers through OneDrive
 
 - Label: `feature`
 - Milestone: `M9 - Receipt Capture + OpenRouter`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conspectus-mobile",
-  "version": "0.9.04",
+  "version": "0.9.05",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conspectus-mobile",
-      "version": "0.9.04",
+      "version": "0.9.05",
       "dependencies": {
         "@azure/msal-browser": "^5.4.0",
         "dexie": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "conspectus-mobile",
   "private": true,
-  "version": "0.9.04",
+  "version": "0.9.05",
   "type": "module",
   "scripts": {
     "dev": "vite --host localhost --port 5173 --strictPort",

--- a/src/db/README.md
+++ b/src/db/README.md
@@ -19,7 +19,8 @@ Expected public interfaces (`src/db/index.ts`):
 - `AccountRecord`: normalized account row shape for Accounts UI.
 - `createTransferMonthQueryService` + `getEpochDayMonthBounds`: inclusive epoch-day month filtering for transfer list reads.
 - `TransferRecord`: normalized transfer row shape for Transfers UI.
-- `CreateTransferInput` and `CreateTransferResult`: write-path contract.
+- `CreateTransferInput`, `CreateTransferResult`, and `CreateTransferBatchResult`: atomic write-path
+  contracts for manual and receipt-created transfers.
 
 Schema source of truth:
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -11,6 +11,7 @@ export {
   type BrowserDbRuntimeOpenOptions,
   type CategoryRecord,
   type CreateTransferInput,
+  type CreateTransferBatchResult,
   type CreateTransferResult,
   type TransferRecord,
 } from './types';

--- a/src/db/transferWriteService.test.ts
+++ b/src/db/transferWriteService.test.ts
@@ -126,6 +126,35 @@ describe('transfer write service', () => {
     runtime.close();
   });
 
+  it('creates a complete batch in one transaction with ordered IDs and exact balances', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    const service = createTransferWriteService(runtime);
+    const fromBefore = getAccountSnapshot(runtime, 3);
+    const toBefore = getAccountSnapshot(runtime, 4);
+
+    const result = service.createTransfers([
+      createBaseInput('Batch first'),
+      { ...createBaseInput('Batch second'), amountCents: 566 },
+    ]);
+
+    expect(result.createdCount).toBe(2);
+    expect(result.transferIds).toHaveLength(2);
+    expect(result.transferIds[1]).toBe((result.transferIds[0] ?? 0) + 1);
+    expect(countTransfersByName(runtime, 'Batch first')).toBe(1);
+    expect(countTransfersByName(runtime, 'Batch second')).toBe(1);
+    expect(getAccountSnapshot(runtime, 3).amountCents).toBe(fromBefore.amountCents - 1800);
+    expect(getAccountSnapshot(runtime, 4).amountCents).toBe(toBefore.amountCents + 1800);
+    runtime.close();
+  });
+
+  it('rejects an empty batch without opening a transaction', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    const service = createTransferWriteService(runtime);
+
+    expectDbQueryFailed(() => service.createTransfers([]));
+    runtime.close();
+  });
+
   it('persists nullable category and buyplace fields', async () => {
     const runtime = await createRuntimeFromTransferFixture();
     const service = createTransferWriteService(runtime);
@@ -223,6 +252,32 @@ describe('transfer write service', () => {
       toBefore,
       'Destination failure write',
     );
+    runtime.close();
+  });
+
+  it('rolls back every earlier transfer when a later batch statement fails', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    runtime.exec(`
+      CREATE TRIGGER fail_second_batch_insert
+      BEFORE INSERT ON transfer
+      WHEN NEW.name = 'Batch failure'
+      BEGIN
+        SELECT RAISE(ABORT, 'later insert failed');
+      END;
+    `);
+    const service = createTransferWriteService(runtime);
+    const fromBefore = getAccountSnapshot(runtime, 3);
+    const toBefore = getAccountSnapshot(runtime, 4);
+
+    expectDbQueryFailed(() =>
+      service.createTransfers([
+        createBaseInput('Batch rolled back'),
+        createBaseInput('Batch failure'),
+      ]),
+    );
+
+    expectBalancesAndTransferCountUnchanged(runtime, fromBefore, toBefore, 'Batch rolled back');
+    expect(countTransfersByName(runtime, 'Batch failure')).toBe(0);
     runtime.close();
   });
 

--- a/src/db/transferWriteService.ts
+++ b/src/db/transferWriteService.ts
@@ -3,7 +3,12 @@ import type { QueryExecResult, SqlValue } from 'sql.js';
 
 import { resolveAppBrowserDbRuntime } from './browserDbRuntime';
 import { DbRuntimeError, toDbRuntimeError } from './dbRuntimeErrors';
-import type { BrowserDbRuntime, CreateTransferInput, CreateTransferResult } from './types';
+import type {
+  BrowserDbRuntime,
+  CreateTransferBatchResult,
+  CreateTransferInput,
+  CreateTransferResult,
+} from './types';
 
 const INSERT_TRANSFER_SQL = `
   INSERT INTO transfer (
@@ -54,6 +59,7 @@ const readLastInsertRowId = (results: readonly QueryExecResult[]): number => {
 
 export interface TransferWriteService {
   createTransfer(input: CreateTransferInput): CreateTransferResult;
+  createTransfers(inputs: readonly CreateTransferInput[]): CreateTransferBatchResult;
 }
 
 type TransferWriteRuntime = Pick<BrowserDbRuntime, 'exec'>;
@@ -73,40 +79,48 @@ const rollbackOpenTransaction = (runtime: TransferWriteRuntime): void => {
 
 export const createTransferWriteService = (
   dbRuntime: TransferWriteRuntimeProvider,
-): TransferWriteService => ({
-  createTransfer(input: CreateTransferInput): CreateTransferResult {
+): TransferWriteService => {
+  const createTransfers = (inputs: readonly CreateTransferInput[]): CreateTransferBatchResult => {
+    if (inputs.length === 0) {
+      throw new DbRuntimeError('db_query_failed', 'Cannot create an empty transfer batch.');
+    }
+
     const runtime = resolveTransferWriteRuntime(dbRuntime);
     let transactionStarted = false;
     let transactionCommitted = false;
 
     try {
-      const [category1Id, category2Id, category3Id] = normalizeCategoryIds(input.categoryIds);
-      const buyplace = normalizeOptionalText(input.buyplace);
-      const insertParams: SqlValue[] = [
-        input.name,
-        input.fromAccountId,
-        input.toAccountId,
-        input.amountCents,
-        input.transferTypeId,
-        category1Id,
-        category2Id,
-        category3Id,
-        input.bookingDateEpochDay,
-        buyplace,
-      ];
-
       runtime.exec('BEGIN IMMEDIATE TRANSACTION;');
       transactionStarted = true;
 
-      runtime.exec(INSERT_TRANSFER_SQL, insertParams);
-      const transferId = readLastInsertRowId(runtime.exec(LAST_INSERT_ROW_ID_SQL));
-      runtime.exec(UPDATE_SOURCE_ACCOUNT_SQL, [input.amountCents, input.fromAccountId]);
-      runtime.exec(UPDATE_DESTINATION_ACCOUNT_SQL, [input.amountCents, input.toAccountId]);
+      const transferIds: number[] = [];
+      for (const input of inputs) {
+        const [category1Id, category2Id, category3Id] = normalizeCategoryIds(input.categoryIds);
+        const insertParams: SqlValue[] = [
+          input.name,
+          input.fromAccountId,
+          input.toAccountId,
+          input.amountCents,
+          input.transferTypeId,
+          category1Id,
+          category2Id,
+          category3Id,
+          input.bookingDateEpochDay,
+          normalizeOptionalText(input.buyplace),
+        ];
+
+        runtime.exec(INSERT_TRANSFER_SQL, insertParams);
+        transferIds.push(readLastInsertRowId(runtime.exec(LAST_INSERT_ROW_ID_SQL)));
+        runtime.exec(UPDATE_SOURCE_ACCOUNT_SQL, [input.amountCents, input.fromAccountId]);
+        runtime.exec(UPDATE_DESTINATION_ACCOUNT_SQL, [input.amountCents, input.toAccountId]);
+      }
+
       runtime.exec('COMMIT;');
       transactionCommitted = true;
 
       return {
-        transferId,
+        transferIds: Object.freeze(transferIds),
+        createdCount: transferIds.length,
         persistedAtIso: new Date().toISOString(),
       };
     } catch (error) {
@@ -120,7 +134,19 @@ export const createTransferWriteService = (
         'Failed to create transfer in the local SQLite database.',
       );
     }
-  },
-});
+  };
+
+  return {
+    createTransfer(input): CreateTransferResult {
+      const batchResult = createTransfers([input]);
+      const transferId = batchResult.transferIds[0];
+      if (transferId === undefined) {
+        throw new DbRuntimeError('db_query_failed', 'Transfer batch returned no inserted ID.');
+      }
+      return { transferId, persistedAtIso: batchResult.persistedAtIso };
+    },
+    createTransfers,
+  };
+};
 
 export const appTransferWriteService = createTransferWriteService(resolveAppBrowserDbRuntime);

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -58,3 +58,9 @@ export interface CreateTransferResult {
   readonly transferId: number;
   readonly persistedAtIso: string;
 }
+
+export interface CreateTransferBatchResult {
+  readonly transferIds: readonly number[];
+  readonly createdCount: number;
+  readonly persistedAtIso: string;
+}

--- a/src/features/README.md
+++ b/src/features/README.md
@@ -35,5 +35,9 @@ Receipt AI settings:
   accessible three-step progress state, and immutable in-memory command handoff. Its pure command
   builder resolves exact current category names, targets the sole primary spendings account, and
   reuses Add Transfer validation and type derivation without writing SQLite or OneDrive.
+- `app-shell/receiptTransferCommitController.ts` owns the app-shell-lifetime automatic batch commit,
+  original-eTag-bound byte-only transport retry, post-export authoritative recovery, explicit
+  conflict reapplication, and remote-commit reconciliation states so navigation cannot repeat a
+  local transaction or lose duplicate-safety context.
 - Cancellation, account/file context changes, and supersession clear selection, coverage proof,
   derivation, and prepared commands; public UI state never exposes raw or normalized image bytes.

--- a/src/features/app-shell/AppShell.svelte
+++ b/src/features/app-shell/AppShell.svelte
@@ -73,6 +73,11 @@
     type AddTransferSaveController,
     type AddTransferSaveState,
   } from './routes/addTransferSaveController';
+  import {
+    createReceiptTransferCommitController,
+    type ReceiptTransferCommitController,
+    type ReceiptTransferCommitState,
+  } from './receiptTransferCommitController';
 
   export let routeStore: Readable<AppRouteKey> = createHashRouteStore();
   export let syncStateStore: SyncStateStore = appSyncStateStore;
@@ -85,6 +90,8 @@
   export let receiptAnalysisController: ReceiptAnalysisController | null = null;
   export let receiptPreparationController: ReceiptTransferPreparationController =
     createReceiptTransferPreparationController();
+  export let receiptCommitController: ReceiptTransferCommitController =
+    createReceiptTransferCommitController();
   export let loadingDelayMs = 160;
   export let showLoadingPlaceholder = true;
 
@@ -95,6 +102,7 @@
   let currentRoute: AppRouteKey = DEFAULT_ROUTE;
   let addTransferFields: AddTransferFormFields = createInitialFormFields();
   let addTransferSaveState: AddTransferSaveState = addTransferSaveController.getState();
+  let receiptCommitState: ReceiptTransferCommitState = receiptCommitController.getState();
   let selectedBinding: DriveItemBinding | null = get(appSelectedDriveItemBindingStore);
   let addTransferHasLoadedDatabase = false;
   let appContentElement: HTMLElement | null = null;
@@ -139,7 +147,11 @@
   const unsubscribe = routeStore.subscribe((route) => {
     if (currentRoute === 'add' && route !== 'add') {
       effectiveReceiptCaptureController?.cancel();
+      effectiveReceiptAnalysisController?.reset();
       receiptPreparationController.reset();
+      if (receiptCommitController.getState().phase === 'saved') {
+        receiptCommitController.reset();
+      }
     }
     currentRoute = route;
   });
@@ -150,6 +162,12 @@
       addTransferFields = createInitialFormFields();
     }
   });
+  const unsubscribeReceiptCommitController = receiptCommitController.subscribe((state) => {
+    receiptCommitState = state;
+    if (state.phase === 'saved' && currentRoute !== 'add') {
+      receiptCommitController.reset();
+    }
+  });
 
   $: pendingTransferNeedsAttention =
     addTransferSaveState.phase === 'upload_failed' ||
@@ -158,6 +176,14 @@
   $: pendingTransferIsConflict =
     addTransferSaveState.phase === 'conflict' || addTransferSaveState.phase === 'conflict_syncing';
   $: pendingTransferIsOffline = !$networkStateStore;
+  $: pendingReceiptNeedsAttention = [
+    'upload_failed',
+    'conflict',
+    'conflict_ready',
+    'local_commit_recovery_failed',
+    'remote_commit_recovery_failed',
+    'invalidated',
+  ].includes(receiptCommitState.phase);
   $: startupSyncIsActive = $syncStateStore.state === 'syncing' && $syncStateStore.branch === null;
   $: staleTokenRecoveryIsRequired =
     $syncStateStore.state === 'error' && $syncStateStore.branch === 'online_auth_expired';
@@ -175,6 +201,28 @@
     if (typeof window !== 'undefined') {
       window.location.hash = '#/add';
     }
+  };
+
+  const openPendingReceipt = (): void => {
+    if (typeof window !== 'undefined') {
+      window.location.hash = '#/add';
+    }
+  };
+
+  const resolveReceiptCommitIdentity = () => {
+    const session = resolveAppAuthClient().getSession();
+    const binding = get(appSelectedDriveItemBindingStore);
+    return {
+      isAuthenticated: session.isAuthenticated && session.account !== null,
+      isVerifiedCurrent:
+        binding !== null &&
+        get(syncStateStore).state === 'synced' &&
+        resolveAppDbRuntime().isOpen(),
+      contextKey:
+        session.account === null || binding === null
+          ? null
+          : `${session.account.homeAccountId}|${binding.driveId}|${binding.itemId}`,
+    };
   };
 
   const openMissingFileRecovery = (): void => {
@@ -248,7 +296,9 @@
     selectedBinding !== null && addTransferHasLoadedDatabase && $syncStateStore.state !== 'idle';
   $: if (!addTransferDatabaseIsReady) {
     effectiveReceiptCaptureController?.cancel();
+    effectiveReceiptAnalysisController?.reset();
     receiptPreparationController.reset();
+    receiptCommitController.invalidate();
   }
 
   const resolveNavIconUrl = (iconPath: string): string => `${navIconBaseUrl}${iconPath}`;
@@ -364,7 +414,9 @@
     }
 
     effectiveReceiptCaptureController?.cancel();
+    effectiveReceiptAnalysisController?.reset();
     receiptPreparationController.reset();
+    receiptCommitController.invalidate();
 
     if (bindingRepairPersistenceIsRunning) {
       return;
@@ -576,6 +628,7 @@
   onDestroy(() => {
     unsubscribe();
     unsubscribeAddTransferSaveController();
+    unsubscribeReceiptCommitController();
     unsubscribeSelectedBinding();
     unsubscribeQueuedForegroundSync();
     if (ownedReceiptCaptureController === null) {
@@ -692,6 +745,29 @@
     </section>
   {/if}
 
+  {#if pendingReceiptNeedsAttention}
+    <section class="pending-transfer-sync" role="alert" data-testid="pending-receipt-sync">
+      <div>
+        <h2>{$_('addTransfer.receipt.commit.pendingTitle')}</h2>
+        <p>
+          {$_(
+            receiptCommitState.phase === 'remote_commit_recovery_failed'
+              ? 'addTransfer.receipt.commit.pendingRemoteSavedDescription'
+              : 'addTransfer.receipt.commit.pendingDescription',
+          )}
+        </p>
+      </div>
+      <button
+        type="button"
+        class="app-button app-button--primary"
+        data-testid="pending-receipt-open"
+        on:click={openPendingReceipt}
+      >
+        {$_('addTransfer.receipt.commit.pendingAction')}
+      </button>
+    </section>
+  {/if}
+
   {#if startupSyncIsActive}
     <section class="startup-sync-progress" data-testid="startup-sync-progress">
       <ProgressIndicator
@@ -727,6 +803,8 @@
           receiptCaptureController={effectiveReceiptCaptureController}
           receiptAnalysisController={effectiveReceiptAnalysisController}
           {receiptPreparationController}
+          {receiptCommitController}
+          {resolveReceiptCommitIdentity}
           {networkStateStore}
           canOpenPanel={addTransferDatabaseIsReady}
         />

--- a/src/features/app-shell/AppShell.test.ts
+++ b/src/features/app-shell/AppShell.test.ts
@@ -11,6 +11,10 @@ import type {
   AddTransferSaveController,
   AddTransferSaveState,
 } from './routes/addTransferSaveController';
+import type {
+  ReceiptTransferCommitController,
+  ReceiptTransferCommitState,
+} from './receiptTransferCommitController';
 
 const ROUTE_TEST_IDS: Record<AppRouteKey, string> = {
   accounts: 'route-accounts',
@@ -37,6 +41,23 @@ const createMockSaveController = (state: AddTransferSaveState): AddTransferSaveC
   submit: async () => ({ validationErrors: [] }),
   retry: async () => {},
   resolveConflict: async () => {},
+  reset: () => {},
+});
+
+const createMockReceiptCommitController = (
+  state: ReceiptTransferCommitState,
+): ReceiptTransferCommitController => ({
+  getState: () => state,
+  subscribe: (listener) => {
+    listener(state);
+    return () => {};
+  },
+  commit: async () => {},
+  retryUpload: async () => {},
+  resolveConflict: async () => {},
+  retryAfterConflict: async () => {},
+  retryLocalCommitRecovery: async () => {},
+  invalidate: () => {},
   reset: () => {},
 });
 
@@ -116,6 +137,26 @@ describe('AppShell component', () => {
     expect(body).toContain('data-testid="pending-transfer-review"');
     expect(body).toContain('data-testid="pending-transfer-retry"');
     expect(body).toContain('Transfersynchronisierung benötigt Aufmerksamkeit');
+  });
+
+  it('keeps duplicate-safe receipt recovery visible outside the Add Transfer route', () => {
+    const { body } = render(AppShell, {
+      props: {
+        routeStore: readable<AppRouteKey>('transfers'),
+        showLoadingPlaceholder: false,
+        receiptCommitController: createMockReceiptCommitController({
+          phase: 'upload_failed',
+          createdCount: 2,
+          error: { code: 'upload_failed', detail: null, preparationError: null },
+          progress: null,
+          recoveryProgress: null,
+        }),
+      },
+    });
+
+    expect(body).toContain('data-testid="pending-receipt-sync"');
+    expect(body).toContain('data-testid="pending-receipt-open"');
+    expect(body).toContain('Belegtransfer-Synchronisierung benötigt Aufmerksamkeit');
   });
 
   it('renders indeterminate progress throughout the startup metadata check', () => {

--- a/src/features/app-shell/databaseUploadHandoffService.test.ts
+++ b/src/features/app-shell/databaseUploadHandoffService.test.ts
@@ -148,6 +148,7 @@ describe('database upload handoff service', () => {
       name: 'DatabaseUploadError',
       code: 'conflict',
       cause: conflict,
+      expectedETag: '"etag-1"',
     });
 
     expect(cacheStore.writeSnapshot).not.toHaveBeenCalled();
@@ -155,6 +156,39 @@ describe('database upload handoff service', () => {
       state: 'stale',
       branch: 'upload_conflict',
     });
+  });
+
+  it('rejects retained bytes when the cached eTag advanced before retry', async () => {
+    const graphClient = createGraphClient();
+    const cacheStore = createCacheStore(
+      createSnapshot({
+        metadata: {
+          eTag: '"etag-2"',
+          lastSyncAtIso: '2026-03-11T10:15:00.000Z',
+        },
+      }),
+    );
+    const syncStateStore = createSyncStateStore();
+    const service = createDatabaseUploadHandoffService(
+      graphClient,
+      cacheStore,
+      () => DRIVE_ITEM_BINDING,
+      syncStateStore,
+    );
+
+    await expect(
+      service.uploadExportedDatabase(Uint8Array.from([1, 2, 3]), {
+        expectedETag: '"etag-1"',
+      }),
+    ).rejects.toMatchObject({
+      name: 'DatabaseUploadError',
+      code: 'conflict',
+      expectedETag: '"etag-1"',
+    });
+
+    expect(graphClient.uploadFile).not.toHaveBeenCalled();
+    expect(cacheStore.writeSnapshot).not.toHaveBeenCalled();
+    expect(get(syncStateStore)).toMatchObject({ state: 'stale', branch: 'upload_conflict' });
   });
 
   it('reports a cache recovery requirement after OneDrive accepts the upload', async () => {

--- a/src/features/app-shell/databaseUploadHandoffService.ts
+++ b/src/features/app-shell/databaseUploadHandoffService.ts
@@ -18,11 +18,18 @@ export type DatabaseUploadErrorCode =
 export class DatabaseUploadError extends Error {
   readonly code: DatabaseUploadErrorCode;
   readonly cause?: unknown;
+  readonly expectedETag: string | null;
 
-  constructor(code: DatabaseUploadErrorCode, message: string, cause?: unknown) {
+  constructor(
+    code: DatabaseUploadErrorCode,
+    message: string,
+    cause?: unknown,
+    expectedETag: string | null = null,
+  ) {
     super(message);
     this.name = 'DatabaseUploadError';
     this.code = code;
+    this.expectedETag = expectedETag;
     if (cause !== undefined) {
       this.cause = cause;
     }
@@ -50,16 +57,21 @@ const resolveBinding = (provider: BindingProvider): DriveItemBinding | null =>
 const isGraphConflict = (error: unknown): boolean =>
   typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 'conflict';
 
-const toUploadError = (error: unknown, conflictMessage: string, failureMessage: string): Error => {
+const toUploadError = (
+  error: unknown,
+  conflictMessage: string,
+  failureMessage: string,
+  expectedETag: string | null,
+): Error => {
   if (error instanceof DatabaseUploadError) {
     return error;
   }
 
   if (isGraphConflict(error)) {
-    return new DatabaseUploadError('conflict', conflictMessage, error);
+    return new DatabaseUploadError('conflict', conflictMessage, error, expectedETag);
   }
 
-  return new DatabaseUploadError('upload_failed', failureMessage, error);
+  return new DatabaseUploadError('upload_failed', failureMessage, error, expectedETag);
 };
 
 export const createDatabaseUploadHandoffService = (
@@ -97,6 +109,7 @@ export const createDatabaseUploadHandoffService = (
       syncStateStore.setSyncing(uploadingMessage, { branch: DEFAULT_UPLOAD_PROGRESS_BRANCH });
 
       let uploadResult: Awaited<ReturnType<GraphClient['uploadFile']>>;
+      let expectedETag = uploadOptions?.expectedETag ?? null;
 
       try {
         const currentSnapshot = await cacheStore.readSnapshot(binding);
@@ -107,17 +120,23 @@ export const createDatabaseUploadHandoffService = (
           );
         }
 
+        if (expectedETag !== null && currentSnapshot.metadata.eTag !== expectedETag) {
+          throw new DatabaseUploadError('conflict', conflictMessage, undefined, expectedETag);
+        }
+
+        expectedETag ??= currentSnapshot.metadata.eTag;
+
         uploadResult = await graphClient.uploadFile(
           binding,
           dbBytes,
-          currentSnapshot.metadata.eTag,
+          expectedETag,
           (loadedBytes, totalBytes) => {
             syncStateStore.updateProgress(loadedBytes, totalBytes, 'upload');
             uploadOptions?.onProgress?.({ loadedBytes, totalBytes });
           },
         );
       } catch (error) {
-        const uploadError = toUploadError(error, conflictMessage, failureMessage);
+        const uploadError = toUploadError(error, conflictMessage, failureMessage, expectedETag);
 
         if (
           uploadError instanceof DatabaseUploadError &&

--- a/src/features/app-shell/receiptTransferCommitController.test.ts
+++ b/src/features/app-shell/receiptTransferCommitController.test.ts
@@ -1,0 +1,370 @@
+// Verifies duplicate-safe receipt commit, byte-only retry, conflict, and reconciliation states.
+import { describe, expect, it, vi } from 'vitest';
+import {
+  PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID,
+  TRANSFER_TYPE_STD_EXPENSE,
+  type CreateTransferInput,
+} from '@db';
+import type { ToastStore } from '@shared';
+
+import { DatabaseUploadError } from './databaseUploadHandoffService';
+import type { DatabaseConflictRecoveryService } from './databaseConflictRecoveryService';
+import {
+  createReceiptTransferCommitController,
+  type ReceiptTransferCommitContext,
+} from './receiptTransferCommitController';
+import {
+  TransferBatchExportRecoveryRequiredError,
+  TransferBatchUploadPendingError,
+  type TransferBatchSaveExportService,
+} from './transferSaveExportService';
+
+const command = (name = 'Lebensmittel'): CreateTransferInput =>
+  Object.freeze({
+    bookingDateEpochDay: 20_665,
+    name,
+    amountCents: 350,
+    transferTypeId: TRANSFER_TYPE_STD_EXPENSE,
+    fromAccountId: 11,
+    toAccountId: 2,
+    categoryIds: Object.freeze([20]),
+    buyplace: 'Markt',
+  });
+
+const commands = (...names: string[]): readonly CreateTransferInput[] =>
+  Object.freeze(names.map((name) => command(name)));
+
+const context = (
+  overrides: Partial<ReceiptTransferCommitContext> = {},
+): ReceiptTransferCommitContext => ({
+  isOnline: true,
+  isAuthenticated: true,
+  isVerifiedCurrent: true,
+  contextKey: 'account|drive|item',
+  optionsState: {
+    operation: 'ready',
+    fromAccountOptions: [{ accountId: 11, name: 'Checking', accountTypeId: 3 }],
+    toAccountOptions: [
+      { accountId: 2, name: 'Primary Spendings', accountTypeId: PRIMARY_SPENDINGS_ACCOUNT_TYPE_ID },
+    ],
+    categoryOptions: [{ categoryId: 20, name: 'Einkauf' }],
+    error: null,
+  },
+  ...overrides,
+});
+
+const saveService = (): TransferBatchSaveExportService => ({
+  createTransferAndExport: vi.fn(async () => ({
+    transferId: 40,
+    persistedAtIso: '2026-07-31T00:00:00.000Z',
+  })),
+  createTransferBatchAndExport: vi.fn(async (inputs: readonly CreateTransferInput[], options) => {
+    options?.onUploadStart?.();
+    options?.onProgress?.({ loadedBytes: 5, totalBytes: 10 });
+    return {
+      transferIds: inputs.map((_, index) => 40 + index),
+      createdCount: inputs.length,
+      persistedAtIso: '2026-07-31T00:00:00.000Z',
+    };
+  }),
+  retryExportedDatabaseUpload: vi.fn(async () => {}),
+});
+
+const recoveryService = (): DatabaseConflictRecoveryService => ({
+  discardStaleRuntime: vi.fn(),
+  syncLatestDatabase: vi.fn(async () => {}),
+});
+
+const toastStore = (): Pick<ToastStore, 'show'> => ({ show: vi.fn() });
+const t = (key: string, options?: { readonly values?: Record<string, string | number> }): string =>
+  `${key}:${options?.values?.count ?? ''}`;
+
+describe('receipt transfer commit controller', () => {
+  it('requires an online authenticated verified-current context before writing', async () => {
+    const service = saveService();
+    const controller = createReceiptTransferCommitController(
+      service,
+      recoveryService(),
+      toastStore(),
+    );
+
+    await controller.commit(commands('Offline'), context({ isOnline: false }), t);
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'failed',
+      error: { code: 'offline' },
+    });
+    expect(service.createTransferBatchAndExport).not.toHaveBeenCalled();
+  });
+
+  it('commits one immutable batch and reports the exact created count after upload', async () => {
+    const service = saveService();
+    const toasts = toastStore();
+    const controller = createReceiptTransferCommitController(service, recoveryService(), toasts);
+
+    await controller.commit(commands('First', 'Second'), context(), t);
+
+    expect(service.createTransferBatchAndExport).toHaveBeenCalledOnce();
+    expect(controller.getState()).toMatchObject({ phase: 'saved', createdCount: 2, error: null });
+    expect(toasts.show).toHaveBeenCalledWith('addTransfer.receipt.commit.successMany:2', 'success');
+  });
+
+  it('retains only exported bytes for transport retry and never repeats the batch write', async () => {
+    const service = saveService();
+    const dbBytes = Uint8Array.from([1, 2, 3]);
+    vi.mocked(service.createTransferBatchAndExport).mockRejectedValueOnce(
+      new TransferBatchUploadPendingError(
+        {
+          batchResult: {
+            transferIds: [40],
+            createdCount: 1,
+            persistedAtIso: '2026-07-31T00:00:00.000Z',
+          },
+          dbBytes,
+        },
+        new DatabaseUploadError('upload_failed', 'Temporary upload failure', undefined, '"etag-1"'),
+      ),
+    );
+    const controller = createReceiptTransferCommitController(
+      service,
+      recoveryService(),
+      toastStore(),
+    );
+
+    await controller.commit(commands('Retry'), context(), t);
+    expect(controller.getState().phase).toBe('upload_failed');
+    await controller.retryUpload(context({ isVerifiedCurrent: false }), t);
+
+    expect(service.createTransferBatchAndExport).toHaveBeenCalledOnce();
+    expect(service.retryExportedDatabaseUpload).toHaveBeenCalledOnce();
+    expect(service.retryExportedDatabaseUpload).toHaveBeenCalledWith(
+      dbBytes,
+      expect.objectContaining({ expectedETag: '"etag-1"' }),
+    );
+    expect(controller.getState().phase).toBe('saved');
+  });
+
+  it('refreshes after conflict and waits for an explicit revalidated save retry', async () => {
+    const service = saveService();
+    vi.mocked(service.createTransferBatchAndExport)
+      .mockRejectedValueOnce(
+        new TransferBatchUploadPendingError(
+          {
+            batchResult: {
+              transferIds: [40],
+              createdCount: 1,
+              persistedAtIso: '2026-07-31T00:00:00.000Z',
+            },
+            dbBytes: Uint8Array.from([1]),
+          },
+          new DatabaseUploadError('conflict', 'Precondition failed'),
+        ),
+      )
+      .mockResolvedValueOnce({
+        transferIds: [41],
+        createdCount: 1,
+        persistedAtIso: '2026-07-31T00:01:00.000Z',
+      });
+    const recovery = recoveryService();
+    const controller = createReceiptTransferCommitController(service, recovery, toastStore());
+
+    await controller.commit(commands('Conflict'), context(), t);
+    expect(controller.getState().phase).toBe('conflict');
+    expect(recovery.discardStaleRuntime).toHaveBeenCalledOnce();
+
+    await controller.resolveConflict(async () => context(), t);
+    expect(controller.getState().phase).toBe('conflict_ready');
+    expect(service.createTransferBatchAndExport).toHaveBeenCalledOnce();
+
+    await controller.retryAfterConflict(context(), t);
+    expect(service.createTransferBatchAndExport).toHaveBeenCalledTimes(2);
+    expect(controller.getState().phase).toBe('saved');
+  });
+
+  it('discards and restores the authoritative runtime after a committed batch export failure', async () => {
+    const service = saveService();
+    vi.mocked(service.createTransferBatchAndExport).mockRejectedValueOnce(
+      new TransferBatchExportRecoveryRequiredError(
+        {
+          transferIds: [40],
+          createdCount: 1,
+          persistedAtIso: '2026-07-31T00:00:00.000Z',
+        },
+        new Error('Export failed'),
+      ),
+    );
+    const recovery = recoveryService();
+    const controller = createReceiptTransferCommitController(service, recovery, toastStore());
+
+    await controller.commit(commands('Unexported'), context(), t);
+
+    expect(recovery.discardStaleRuntime).toHaveBeenCalledOnce();
+    expect(recovery.syncLatestDatabase).toHaveBeenCalledOnce();
+    expect(controller.getState()).toMatchObject({
+      phase: 'failed',
+      error: { code: 'local_failed' },
+    });
+    expect(service.retryExportedDatabaseUpload).not.toHaveBeenCalled();
+  });
+
+  it('restores the authoritative runtime when cached upload metadata disappears after commit', async () => {
+    const service = saveService();
+    vi.mocked(service.createTransferBatchAndExport).mockRejectedValueOnce(
+      new TransferBatchUploadPendingError(
+        {
+          batchResult: {
+            transferIds: [40],
+            createdCount: 1,
+            persistedAtIso: '2026-07-31T00:00:00.000Z',
+          },
+          dbBytes: Uint8Array.from([1, 2, 3]),
+        },
+        new DatabaseUploadError('missing_cached_snapshot', 'Cached metadata disappeared'),
+      ),
+    );
+    const recovery = recoveryService();
+    const controller = createReceiptTransferCommitController(service, recovery, toastStore());
+
+    await controller.commit(commands('Missing cache'), context(), t);
+
+    expect(recovery.discardStaleRuntime).toHaveBeenCalledOnce();
+    expect(recovery.syncLatestDatabase).toHaveBeenCalledOnce();
+    expect(controller.getState()).toMatchObject({
+      phase: 'failed',
+      error: { code: 'local_failed' },
+    });
+    expect(service.retryExportedDatabaseUpload).not.toHaveBeenCalled();
+  });
+
+  it('keeps writes blocked until failed local-commit recovery succeeds on retry', async () => {
+    const service = saveService();
+    vi.mocked(service.createTransferBatchAndExport).mockRejectedValueOnce(
+      new TransferBatchExportRecoveryRequiredError(
+        {
+          transferIds: [40],
+          createdCount: 1,
+          persistedAtIso: '2026-07-31T00:00:00.000Z',
+        },
+        new Error('Empty export'),
+      ),
+    );
+    const recovery = recoveryService();
+    vi.mocked(recovery.syncLatestDatabase)
+      .mockRejectedValueOnce(new Error('Offline'))
+      .mockResolvedValueOnce(undefined);
+    const controller = createReceiptTransferCommitController(service, recovery, toastStore());
+
+    await controller.commit(commands('Recovery retry'), context(), t);
+    expect(controller.getState()).toMatchObject({
+      phase: 'local_commit_recovery_failed',
+      error: { code: 'local_commit_recovery_failed' },
+    });
+
+    await controller.retryLocalCommitRecovery(t);
+    expect(recovery.discardStaleRuntime).toHaveBeenCalledTimes(2);
+    expect(recovery.syncLatestDatabase).toHaveBeenCalledTimes(2);
+    expect(controller.getState()).toMatchObject({
+      phase: 'failed',
+      error: { code: 'local_failed' },
+    });
+  });
+
+  it('treats remote success during byte retry as reconciliation, never another upload retry', async () => {
+    const service = saveService();
+    const dbBytes = Uint8Array.from([1, 2, 3]);
+    vi.mocked(service.createTransferBatchAndExport).mockRejectedValueOnce(
+      new TransferBatchUploadPendingError(
+        {
+          batchResult: {
+            transferIds: [40],
+            createdCount: 1,
+            persistedAtIso: '2026-07-31T00:00:00.000Z',
+          },
+          dbBytes,
+        },
+        new DatabaseUploadError('upload_failed', 'Temporary upload failure', undefined, '"etag-1"'),
+      ),
+    );
+    vi.mocked(service.retryExportedDatabaseUpload).mockRejectedValueOnce(
+      new DatabaseUploadError('remote_commit_cache_failed', 'Cache failed after remote save'),
+    );
+    const recovery = recoveryService();
+    const controller = createReceiptTransferCommitController(service, recovery, toastStore());
+
+    await controller.commit(commands('Retry remote save'), context(), t);
+    await controller.retryUpload(context({ isVerifiedCurrent: false }), t);
+
+    expect(recovery.syncLatestDatabase).toHaveBeenCalledOnce();
+    expect(controller.getState().phase).toBe('saved');
+    await controller.retryUpload(context(), t);
+    expect(service.retryExportedDatabaseUpload).toHaveBeenCalledOnce();
+  });
+
+  it('never offers a write retry after remote success plus failed cache reconciliation', async () => {
+    const service = saveService();
+    vi.mocked(service.createTransferBatchAndExport).mockRejectedValueOnce(
+      new TransferBatchUploadPendingError(
+        {
+          batchResult: {
+            transferIds: [40],
+            createdCount: 1,
+            persistedAtIso: '2026-07-31T00:00:00.000Z',
+          },
+          dbBytes: Uint8Array.from([1]),
+        },
+        new DatabaseUploadError('remote_commit_cache_failed', 'Cache failed'),
+      ),
+    );
+    const recovery = recoveryService();
+    vi.mocked(recovery.syncLatestDatabase).mockRejectedValueOnce(new Error('Refresh failed'));
+    const controller = createReceiptTransferCommitController(service, recovery, toastStore());
+
+    await controller.commit(commands('Remote saved'), context(), t);
+    expect(controller.getState()).toMatchObject({
+      phase: 'remote_commit_recovery_failed',
+      createdCount: 1,
+    });
+    await controller.retryUpload(context(), t);
+    await controller.retryAfterConflict(context(), t);
+    expect(service.retryExportedDatabaseUpload).not.toHaveBeenCalled();
+    expect(service.createTransferBatchAndExport).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a late async completion after the file or account context is invalidated', async () => {
+    let finishUpload!: (result: {
+      transferIds: readonly number[];
+      createdCount: number;
+      persistedAtIso: string;
+    }) => void;
+    const uploadPromise = new Promise<{
+      transferIds: readonly number[];
+      createdCount: number;
+      persistedAtIso: string;
+    }>((resolve) => {
+      finishUpload = resolve;
+    });
+    const service = saveService();
+    vi.mocked(service.createTransferBatchAndExport).mockImplementationOnce(
+      async () => uploadPromise,
+    );
+    const controller = createReceiptTransferCommitController(
+      service,
+      recoveryService(),
+      toastStore(),
+    );
+
+    const pending = controller.commit(commands('Superseded'), context(), t);
+    controller.invalidate();
+    finishUpload({
+      transferIds: [40],
+      createdCount: 1,
+      persistedAtIso: '2026-07-31T00:00:00.000Z',
+    });
+    await pending;
+
+    expect(controller.getState()).toMatchObject({
+      phase: 'invalidated',
+      error: { code: 'context_changed' },
+    });
+  });
+});

--- a/src/features/app-shell/receiptTransferCommitController.ts
+++ b/src/features/app-shell/receiptTransferCommitController.ts
@@ -1,0 +1,550 @@
+// Owns duplicate-safe receipt batch commit, upload retry, conflict recovery, and reconciliation.
+import type { CreateTransferInput } from '@db';
+import type { ToastStore } from '@shared';
+import { appToastStore } from '@shared';
+
+import {
+  validatePreparedReceiptTransferCommands,
+  type ReceiptTransferPreparationError,
+} from '../receipt';
+import type { AddTransferOptionsState } from './routes/addTransferOptionsController';
+import { DatabaseUploadError } from './databaseUploadHandoffService';
+import {
+  createAppDatabaseConflictRecoveryService,
+  type DatabaseConflictRecoveryProgress,
+  type DatabaseConflictRecoveryService,
+} from './databaseConflictRecoveryService';
+import {
+  createAppTransferSaveExportService,
+  TransferBatchExportRecoveryRequiredError,
+  TransferBatchUploadPendingError,
+  type DatabaseUploadProgress,
+  type TransferBatchSaveExportService,
+} from './transferSaveExportService';
+
+export type ReceiptTransferCommitPhase =
+  | 'idle'
+  | 'validating'
+  | 'local_save'
+  | 'uploading'
+  | 'upload_failed'
+  | 'local_commit_syncing'
+  | 'local_commit_recovery_failed'
+  | 'conflict'
+  | 'conflict_syncing'
+  | 'conflict_ready'
+  | 'remote_commit_syncing'
+  | 'remote_commit_recovery_failed'
+  | 'saved'
+  | 'failed'
+  | 'invalidated';
+
+export type ReceiptTransferCommitErrorCode =
+  | 'offline'
+  | 'context_unavailable'
+  | 'context_changed'
+  | 'validation_failed'
+  | 'local_failed'
+  | 'local_commit_recovery_failed'
+  | 'upload_failed'
+  | 'conflict'
+  | 'conflict_sync_failed'
+  | 'remote_commit_recovery_failed';
+
+export interface ReceiptTransferCommitError {
+  readonly code: ReceiptTransferCommitErrorCode;
+  readonly detail: string | null;
+  readonly preparationError: ReceiptTransferPreparationError | null;
+}
+
+export interface ReceiptTransferCommitState {
+  readonly phase: ReceiptTransferCommitPhase;
+  readonly createdCount: number;
+  readonly error: ReceiptTransferCommitError | null;
+  readonly progress: DatabaseUploadProgress | null;
+  readonly recoveryProgress: DatabaseConflictRecoveryProgress | null;
+}
+
+export interface ReceiptTransferCommitContext {
+  readonly isOnline: boolean;
+  readonly isAuthenticated: boolean;
+  readonly isVerifiedCurrent: boolean;
+  readonly contextKey: string | null;
+  readonly optionsState: AddTransferOptionsState;
+}
+
+export type ReceiptTransferCommitTranslator = (
+  key: string,
+  options?: { readonly values?: Record<string, string | number> },
+) => string;
+
+export interface ReceiptTransferCommitController {
+  getState(): ReceiptTransferCommitState;
+  subscribe(listener: (state: ReceiptTransferCommitState) => void): () => void;
+  commit(
+    commands: readonly CreateTransferInput[],
+    context: ReceiptTransferCommitContext,
+    t: ReceiptTransferCommitTranslator,
+  ): Promise<void>;
+  retryUpload(
+    context: ReceiptTransferCommitContext,
+    t: ReceiptTransferCommitTranslator,
+  ): Promise<void>;
+  resolveConflict(
+    loadCurrentContext: () => Promise<ReceiptTransferCommitContext>,
+    t: ReceiptTransferCommitTranslator,
+  ): Promise<void>;
+  retryAfterConflict(
+    context: ReceiptTransferCommitContext,
+    t: ReceiptTransferCommitTranslator,
+  ): Promise<void>;
+  retryLocalCommitRecovery(t: ReceiptTransferCommitTranslator): Promise<void>;
+  invalidate(): void;
+  reset(): void;
+}
+
+const INITIAL_STATE: ReceiptTransferCommitState = Object.freeze({
+  phase: 'idle',
+  createdCount: 0,
+  error: null,
+  progress: null,
+  recoveryProgress: null,
+});
+
+const detailFrom = (error: unknown): string | null =>
+  error instanceof Error && error.message.trim().length > 0 ? error.message : null;
+
+const contextError = (
+  context: ReceiptTransferCommitContext,
+  expectedContextKey: string | null,
+  requireVerifiedCurrent: boolean,
+): ReceiptTransferCommitError | null => {
+  if (!context.isOnline) {
+    return { code: 'offline', detail: null, preparationError: null };
+  }
+  if (
+    !context.isAuthenticated ||
+    context.contextKey === null ||
+    (expectedContextKey !== null && context.contextKey !== expectedContextKey) ||
+    (requireVerifiedCurrent && !context.isVerifiedCurrent)
+  ) {
+    return { code: 'context_unavailable', detail: null, preparationError: null };
+  }
+  if (context.optionsState.operation !== 'ready') {
+    return {
+      code: 'validation_failed',
+      detail: null,
+      preparationError: { code: 'options_unavailable', detail: null },
+    };
+  }
+  return null;
+};
+
+const isBusy = (phase: ReceiptTransferCommitPhase): boolean =>
+  [
+    'validating',
+    'local_save',
+    'uploading',
+    'local_commit_syncing',
+    'conflict_syncing',
+    'remote_commit_syncing',
+  ].includes(phase);
+
+export const createReceiptTransferCommitController = (
+  saveService: TransferBatchSaveExportService = createAppTransferSaveExportService(),
+  conflictRecoveryService: DatabaseConflictRecoveryService = createAppDatabaseConflictRecoveryService(),
+  toastStore: Pick<ToastStore, 'show'> = appToastStore,
+): ReceiptTransferCommitController => {
+  let state = INITIAL_STATE;
+  let generation = 0;
+  let expectedContextKey: string | null = null;
+  let pendingBytes: Uint8Array | null = null;
+  let pendingETag: string | null = null;
+  let pendingCommands: readonly CreateTransferInput[] | null = null;
+  const listeners = new Set<(state: ReceiptTransferCommitState) => void>();
+
+  const publish = (nextState: ReceiptTransferCommitState): void => {
+    state = Object.freeze(nextState);
+    listeners.forEach((listener) => listener(state));
+  };
+
+  const publishError = (
+    phase: ReceiptTransferCommitPhase,
+    error: ReceiptTransferCommitError,
+  ): void => {
+    publish({
+      phase,
+      createdCount: state.createdCount,
+      error,
+      progress: null,
+      recoveryProgress: null,
+    });
+  };
+
+  const validateCommands = (
+    commands: readonly CreateTransferInput[],
+    context: ReceiptTransferCommitContext,
+    requireVerifiedCurrent: boolean,
+  ): ReceiptTransferCommitError | null => {
+    const invalidContext = contextError(context, expectedContextKey, requireVerifiedCurrent);
+    if (invalidContext !== null) return invalidContext;
+    const preparationError = validatePreparedReceiptTransferCommands(
+      commands,
+      context.optionsState,
+    );
+    return preparationError === null
+      ? null
+      : { code: 'validation_failed', detail: null, preparationError };
+  };
+
+  const setSaved = (createdCount: number, t: ReceiptTransferCommitTranslator): void => {
+    pendingBytes = null;
+    pendingETag = null;
+    pendingCommands = null;
+    publish({
+      phase: 'saved',
+      createdCount,
+      error: null,
+      progress: null,
+      recoveryProgress: null,
+    });
+    toastStore.show(
+      t(
+        createdCount === 1
+          ? 'addTransfer.receipt.commit.successOne'
+          : 'addTransfer.receipt.commit.successMany',
+        { values: { count: createdCount } },
+      ),
+      'success',
+    );
+  };
+
+  const recoverRemoteCommit = async (
+    token: number,
+    createdCount: number,
+    t: ReceiptTransferCommitTranslator,
+  ): Promise<void> => {
+    pendingBytes = null;
+    pendingETag = null;
+    pendingCommands = null;
+    publish({
+      phase: 'remote_commit_syncing',
+      createdCount,
+      error: null,
+      progress: null,
+      recoveryProgress: null,
+    });
+    try {
+      await conflictRecoveryService.syncLatestDatabase({
+        onProgress: (recoveryProgress) => {
+          if (token !== generation) return;
+          publish({ ...state, recoveryProgress });
+        },
+      });
+      if (token !== generation) return;
+      setSaved(createdCount, t);
+    } catch (error) {
+      if (token !== generation) return;
+      publishError('remote_commit_recovery_failed', {
+        code: 'remote_commit_recovery_failed',
+        detail: detailFrom(error),
+        preparationError: null,
+      });
+      toastStore.show(t('addTransfer.receipt.commit.remoteCommitRecoveryFailed'), 'error');
+    }
+  };
+
+  const recoverUnexportedLocalCommit = async (
+    token: number,
+    t: ReceiptTransferCommitTranslator,
+  ): Promise<void> => {
+    pendingBytes = null;
+    pendingETag = null;
+    pendingCommands = null;
+    conflictRecoveryService.discardStaleRuntime();
+    publish({
+      phase: 'local_commit_syncing',
+      createdCount: state.createdCount,
+      error: null,
+      progress: null,
+      recoveryProgress: null,
+    });
+    try {
+      await conflictRecoveryService.syncLatestDatabase({
+        onProgress: (recoveryProgress) => {
+          if (token === generation) publish({ ...state, recoveryProgress });
+        },
+      });
+      if (token !== generation) return;
+      publishError('failed', {
+        code: 'local_failed',
+        detail: null,
+        preparationError: null,
+      });
+      toastStore.show(t('addTransfer.receipt.commit.localFailed'), 'error');
+    } catch (error) {
+      if (token !== generation) return;
+      publishError('local_commit_recovery_failed', {
+        code: 'local_commit_recovery_failed',
+        detail: detailFrom(error),
+        preparationError: null,
+      });
+    }
+  };
+
+  const runBatch = async (
+    commands: readonly CreateTransferInput[],
+    t: ReceiptTransferCommitTranslator,
+    token: number,
+  ): Promise<void> => {
+    pendingCommands = commands;
+    publish({
+      phase: 'local_save',
+      createdCount: commands.length,
+      error: null,
+      progress: null,
+      recoveryProgress: null,
+    });
+    try {
+      const result = await saveService.createTransferBatchAndExport(commands, {
+        onUploadStart: () => {
+          if (token !== generation) return;
+          publish({ ...state, phase: 'uploading', progress: null });
+        },
+        onProgress: (progress) => {
+          if (token !== generation) return;
+          publish({ ...state, phase: 'uploading', progress });
+        },
+      });
+      if (token !== generation) return;
+      setSaved(result.createdCount, t);
+    } catch (error) {
+      if (token !== generation) return;
+      if (error instanceof TransferBatchUploadPendingError) {
+        const cause = error.cause;
+        if (cause instanceof DatabaseUploadError && cause.code === 'remote_commit_cache_failed') {
+          await recoverRemoteCommit(token, error.pendingUpload.batchResult.createdCount, t);
+          return;
+        }
+        if (cause instanceof DatabaseUploadError && cause.code === 'conflict') {
+          pendingBytes = null;
+          pendingETag = null;
+          conflictRecoveryService.discardStaleRuntime();
+          publishError('conflict', { code: 'conflict', detail: null, preparationError: null });
+          toastStore.show(t('addTransfer.receipt.commit.conflict'), 'error');
+          return;
+        }
+        if (cause instanceof DatabaseUploadError && cause.code === 'upload_failed') {
+          if (cause.expectedETag === null) {
+            await recoverUnexportedLocalCommit(token, t);
+            return;
+          }
+          pendingBytes = error.pendingUpload.dbBytes;
+          pendingETag = cause.expectedETag;
+          pendingCommands = null;
+          publishError('upload_failed', {
+            code: 'upload_failed',
+            detail: detailFrom(cause),
+            preparationError: null,
+          });
+          toastStore.show(t('addTransfer.receipt.commit.uploadFailed'), 'error');
+          return;
+        }
+        await recoverUnexportedLocalCommit(token, t);
+        return;
+      }
+      if (error instanceof TransferBatchExportRecoveryRequiredError) {
+        await recoverUnexportedLocalCommit(token, t);
+        return;
+      }
+      pendingBytes = null;
+      pendingETag = null;
+      pendingCommands = null;
+      publishError('failed', {
+        code: 'local_failed',
+        detail: detailFrom(error),
+        preparationError: null,
+      });
+      toastStore.show(t('addTransfer.receipt.commit.localFailed'), 'error');
+    }
+  };
+
+  return {
+    getState: () => state,
+
+    subscribe(listener): () => void {
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+
+    async commit(commands, context, t): Promise<void> {
+      if (state.phase !== 'idle') return;
+      expectedContextKey = context.contextKey;
+      const token = ++generation;
+      publish({
+        phase: 'validating',
+        createdCount: commands.length,
+        error: null,
+        progress: null,
+        recoveryProgress: null,
+      });
+      const error = validateCommands(commands, context, true);
+      if (error !== null) {
+        pendingCommands = null;
+        publishError('failed', error);
+        return;
+      }
+      await runBatch(commands, t, token);
+    },
+
+    async retryUpload(context, t): Promise<void> {
+      if (
+        state.phase !== 'upload_failed' ||
+        pendingBytes === null ||
+        pendingETag === null ||
+        isBusy(state.phase)
+      )
+        return;
+      const error = contextError(context, expectedContextKey, false);
+      if (error !== null) {
+        publishError('upload_failed', error);
+        return;
+      }
+      const token = generation;
+      const bytes = pendingBytes;
+      const expectedETag = pendingETag;
+      try {
+        publish({ ...state, phase: 'uploading', error: null, progress: null });
+        await saveService.retryExportedDatabaseUpload(bytes, {
+          expectedETag,
+          onProgress: (progress) => {
+            if (token === generation) publish({ ...state, progress });
+          },
+        });
+        if (token !== generation) return;
+        setSaved(state.createdCount, t);
+      } catch (retryError) {
+        if (token !== generation) return;
+        if (
+          retryError instanceof DatabaseUploadError &&
+          retryError.code === 'remote_commit_cache_failed'
+        ) {
+          await recoverRemoteCommit(token, state.createdCount, t);
+          return;
+        }
+        if (retryError instanceof DatabaseUploadError && retryError.code === 'conflict') {
+          pendingBytes = null;
+          pendingETag = null;
+          pendingCommands = null;
+          conflictRecoveryService.discardStaleRuntime();
+          publish({ ...state, phase: 'conflict_syncing', error: null, recoveryProgress: null });
+          try {
+            await conflictRecoveryService.syncLatestDatabase({
+              onProgress: (recoveryProgress) => {
+                if (token === generation) publish({ ...state, recoveryProgress });
+              },
+            });
+          } catch {
+            // The stale runtime stays closed; this byte-only retry cannot safely recreate commands.
+          } finally {
+            if (token === generation) {
+              publishError('failed', {
+                code: 'context_changed',
+                detail: null,
+                preparationError: null,
+              });
+            }
+          }
+          return;
+        }
+        if (retryError instanceof DatabaseUploadError && retryError.code !== 'upload_failed') {
+          pendingBytes = null;
+          pendingETag = null;
+          publishError('failed', {
+            code: 'context_unavailable',
+            detail: null,
+            preparationError: null,
+          });
+          return;
+        }
+        publishError('upload_failed', {
+          code: 'upload_failed',
+          detail: detailFrom(retryError),
+          preparationError: null,
+        });
+      }
+    },
+
+    async resolveConflict(loadCurrentContext, t): Promise<void> {
+      if (state.phase !== 'conflict' || pendingCommands === null) return;
+      const token = generation;
+      publish({ ...state, phase: 'conflict_syncing', error: null, recoveryProgress: null });
+      try {
+        await conflictRecoveryService.syncLatestDatabase({
+          onProgress: (recoveryProgress) => {
+            if (token === generation) publish({ ...state, recoveryProgress });
+          },
+        });
+        if (token !== generation) return;
+        const context = await loadCurrentContext();
+        if (token !== generation) return;
+        const error = validateCommands(pendingCommands, context, true);
+        if (error !== null) {
+          publishError('failed', error);
+          pendingCommands = null;
+          return;
+        }
+        publish({ ...state, phase: 'conflict_ready', error: null, recoveryProgress: null });
+        toastStore.show(t('addTransfer.receipt.commit.conflictReadyToast'), 'success');
+      } catch (error) {
+        if (token !== generation) return;
+        publishError('conflict', {
+          code: 'conflict_sync_failed',
+          detail: detailFrom(error),
+          preparationError: null,
+        });
+      }
+    },
+
+    async retryAfterConflict(context, t): Promise<void> {
+      if (state.phase !== 'conflict_ready' || pendingCommands === null) return;
+      const error = validateCommands(pendingCommands, context, true);
+      if (error !== null) {
+        pendingCommands = null;
+        publishError('failed', error);
+        return;
+      }
+      await runBatch(pendingCommands, t, generation);
+    },
+
+    async retryLocalCommitRecovery(t): Promise<void> {
+      if (state.phase !== 'local_commit_recovery_failed') return;
+      await recoverUnexportedLocalCommit(generation, t);
+    },
+
+    invalidate(): void {
+      if (state.phase === 'idle' || state.phase === 'saved' || state.phase === 'invalidated')
+        return;
+      generation += 1;
+      pendingBytes = null;
+      pendingETag = null;
+      pendingCommands = null;
+      expectedContextKey = null;
+      publishError('invalidated', {
+        code: 'context_changed',
+        detail: null,
+        preparationError: null,
+      });
+    },
+
+    reset(): void {
+      generation += 1;
+      pendingBytes = null;
+      pendingETag = null;
+      pendingCommands = null;
+      expectedContextKey = null;
+      publish(INITIAL_STATE);
+    },
+  };
+};

--- a/src/features/app-shell/routes/AddRoute.svelte
+++ b/src/features/app-shell/routes/AddRoute.svelte
@@ -1,6 +1,7 @@
 <!-- Renders manual Add Transfer entry and the transient staged receipt-preparation workflow. -->
 <script lang="ts">
   import { onDestroy, onMount, tick } from 'svelte';
+  import { get } from 'svelte/store';
   import { _ } from 'svelte-i18n';
   import {
     appAccountQueryService,
@@ -30,6 +31,12 @@
   } from '../../receipt';
   import BottomSheet from '../components/BottomSheet.svelte';
   import ProgressIndicator from '../components/ProgressIndicator.svelte';
+  import {
+    createReceiptTransferCommitController,
+    type ReceiptTransferCommitContext,
+    type ReceiptTransferCommitController,
+    type ReceiptTransferCommitState,
+  } from '../receiptTransferCommitController';
   import {
     createInitialFormFields,
     NO_CATEGORY_SELECTED,
@@ -67,6 +74,13 @@
   export let receiptAnalysisController: ReceiptAnalysisController | null = null;
   export let receiptPreparationController: ReceiptTransferPreparationController =
     createReceiptTransferPreparationController();
+  export let receiptCommitController: ReceiptTransferCommitController =
+    createReceiptTransferCommitController();
+  export let resolveReceiptCommitIdentity: () => {
+    readonly isAuthenticated: boolean;
+    readonly isVerifiedCurrent: boolean;
+    readonly contextKey: string | null;
+  } = () => ({ isAuthenticated: false, isVerifiedCurrent: false, contextKey: null });
 
   let isOpen = true;
   let componentHasMounted = false;
@@ -90,6 +104,7 @@
   };
   let receiptPreparationState: ReceiptTransferPreparationState =
     receiptPreparationController.getState();
+  let receiptCommitState: ReceiptTransferCommitState = receiptCommitController.getState();
   let lastObservedSyncState: SyncState = 'idle';
   $: isOffline = !$networkStateStore;
   $: isOptionsLoading = optionsState.operation === 'loading';
@@ -111,7 +126,32 @@
     receiptCaptureState.phase === 'handed_off' ||
     receiptAnalysisState.phase === 'extracting' ||
     receiptAnalysisState.phase === 'deriving';
-  $: receiptWorkflowIsActive = receiptPreparationState.phase !== 'idle';
+  $: receiptWorkflowIsActive =
+    receiptPreparationState.phase !== 'idle' || receiptCommitState.phase !== 'idle';
+  $: receiptCommitIsBusy = [
+    'validating',
+    'local_save',
+    'uploading',
+    'local_commit_syncing',
+    'conflict_syncing',
+    'remote_commit_syncing',
+  ].includes(receiptCommitState.phase);
+  $: displayedReceiptSteps =
+    receiptPreparationState.phase !== 'idle'
+      ? receiptPreparationState.steps
+      : [
+          { id: 'extraction' as const, status: 'complete' as const },
+          { id: 'derivation' as const, status: 'complete' as const },
+          {
+            id: 'creation' as const,
+            status:
+              receiptCommitState.phase === 'saved'
+                ? ('complete' as const)
+                : receiptCommitIsBusy
+                  ? ('active' as const)
+                  : ('error' as const),
+          },
+        ];
   $: receiptSourceAccountOptions = listReceiptSourceAccountOptions(optionsState);
   const translateReceiptPreparationError = (
     error: ReceiptTransferPreparationError | null,
@@ -126,6 +166,12 @@
     });
   };
   $: receiptPreparationError = translateReceiptPreparationError(receiptPreparationState.error);
+  $: receiptCommitError =
+    receiptCommitState.error === null
+      ? null
+      : receiptCommitState.error.preparationError !== null
+        ? translateReceiptPreparationError(receiptCommitState.error.preparationError)
+        : $_(`addTransfer.receipt.commit.errors.${receiptCommitState.error.code}`);
   $: receiptAnalysisError =
     receiptAnalysisState.phase !== 'error' || receiptAnalysisState.errorCode === null
       ? null
@@ -133,6 +179,7 @@
         ? $_(`addTransfer.receipt.analysisErrors.${receiptAnalysisState.errorCode}`)
         : `${$_(`addTransfer.receipt.analysisErrors.${receiptAnalysisState.errorCode}`)} ${receiptAnalysisState.errorReason}`;
   $: receiptCaptureError =
+    receiptCommitError ??
     receiptPreparationError ??
     receiptAnalysisError ??
     (receiptCaptureState.errorCode === null
@@ -145,7 +192,12 @@
     optionsState.error?.message ??
     null;
   $: controlsAreDisabled =
-    isSubmitting || isOptionsLoading || saveIsBusy || saveBlocksEditing || receiptCaptureIsBusy;
+    isSubmitting ||
+    isOptionsLoading ||
+    saveIsBusy ||
+    receiptCommitIsBusy ||
+    saveBlocksEditing ||
+    receiptCaptureIsBusy;
   $: sourceAccountIsDisabled = isSubmitting || isOptionsLoading || saveIsBusy || saveBlocksEditing;
   $: submitIsDisabled = controlsAreDisabled || isOffline || optionsState.operation !== 'ready';
   $: receiptCaptureIsDisabled =
@@ -261,6 +313,7 @@
     }
 
     clearValidation();
+    receiptCommitController.reset();
     receiptPreparationController.beginRun();
     void receiptCaptureController.capture(file);
   };
@@ -273,6 +326,40 @@
 
   const handleReceiptFileCancel = (event: Event): void => {
     (event.currentTarget as HTMLInputElement).value = '';
+  };
+
+  const createReceiptCommitContext = (): ReceiptTransferCommitContext => {
+    const identity = resolveReceiptCommitIdentity();
+    return {
+      isOnline: get(networkStateStore),
+      isAuthenticated: identity.isAuthenticated,
+      isVerifiedCurrent: identity.isVerifiedCurrent,
+      contextKey: identity.contextKey,
+      optionsState,
+    };
+  };
+
+  const retryReceiptUpload = async (): Promise<void> => {
+    receiptPreparationController.markCommitActive();
+    await receiptCommitController.retryUpload(createReceiptCommitContext(), $_);
+  };
+
+  const resolveReceiptConflict = async (): Promise<void> => {
+    receiptPreparationController.markCommitActive();
+    await receiptCommitController.resolveConflict(async () => {
+      await controller.load();
+      return createReceiptCommitContext();
+    }, $_);
+  };
+
+  const retryReceiptAfterConflict = async (): Promise<void> => {
+    receiptPreparationController.markCommitActive();
+    await receiptCommitController.retryAfterConflict(createReceiptCommitContext(), $_);
+  };
+
+  const retryReceiptLocalCommitRecovery = async (): Promise<void> => {
+    receiptPreparationController.markCommitActive();
+    await receiptCommitController.retryLocalCommitRecovery($_);
   };
 
   const getAccountName = (account: { name: string; accountTypeId: number | null }) => {
@@ -319,6 +406,39 @@
       }
     },
   );
+  const unsubscribeReceiptCommitController = receiptCommitController.subscribe((nextState) => {
+    receiptCommitState = nextState;
+    if (nextState.phase === 'saved') {
+      receiptPreparationController.markCommitted();
+      receiptCaptureController?.reset();
+      receiptAnalysisController?.reset();
+    } else if (
+      [
+        'upload_failed',
+        'local_commit_recovery_failed',
+        'conflict',
+        'conflict_ready',
+        'remote_commit_recovery_failed',
+        'failed',
+        'invalidated',
+      ].includes(nextState.phase)
+    ) {
+      receiptPreparationController.markCommitFailed();
+      receiptCaptureController?.reset();
+      receiptAnalysisController?.reset();
+    } else if (
+      [
+        'validating',
+        'local_save',
+        'uploading',
+        'local_commit_syncing',
+        'conflict_syncing',
+        'remote_commit_syncing',
+      ].includes(nextState.phase)
+    ) {
+      receiptPreparationController.markCommitActive();
+    }
+  });
   const unsubscribeSyncState = syncStateStore.subscribe((syncSnapshot) => {
     if (syncSnapshot.state === lastObservedSyncState) {
       return;
@@ -331,12 +451,15 @@
   });
 
   const handleClose = (): void => {
-    if (saveIsBusy) {
+    if (saveIsBusy || receiptCommitIsBusy) {
       return;
     }
 
     receiptCaptureController?.cancel();
     receiptPreparationController.reset();
+    if (receiptCommitController.getState().phase === 'saved') {
+      receiptCommitController.reset();
+    }
     isOpen = false;
     if (typeof window !== 'undefined') {
       window.location.hash = '#/transfers';
@@ -365,10 +488,23 @@
     componentHasMounted &&
     receiptWorkflowIsActive &&
     isOffline &&
-    receiptPreparationState.phase !== 'error'
+    ['processing', 'waiting_for_source', 'ready_for_commit'].includes(receiptPreparationState.phase)
   ) {
     receiptPreparationController.failForOffline();
     receiptCaptureController?.cancel();
+  }
+
+  $: if (
+    componentHasMounted &&
+    receiptPreparationState.phase === 'ready_for_commit' &&
+    receiptCommitState.phase === 'idle'
+  ) {
+    const commands = receiptPreparationController.claimReadyForCommit();
+    if (commands !== null) {
+      receiptCaptureController?.reset();
+      receiptAnalysisController?.reset();
+      void receiptCommitController.commit(commands, createReceiptCommitContext(), $_);
+    }
   }
 
   onMount(() => {
@@ -384,6 +520,7 @@
     unsubscribeReceiptCaptureController();
     unsubscribeReceiptAnalysisController();
     unsubscribeReceiptPreparationController();
+    unsubscribeReceiptCommitController();
     unsubscribeSyncState();
     receiptCaptureController?.cancel();
     receiptPreparationController.reset();
@@ -414,7 +551,7 @@
 
     <BottomSheet
       {isOpen}
-      canClose={!saveIsBusy}
+      canClose={!saveIsBusy && !receiptCommitIsBusy}
       title={$_('addTransfer.title')}
       on:close={handleClose}
     >
@@ -612,7 +749,7 @@
               aria-live="polite"
               data-testid="receipt-progress"
             >
-              {#each receiptPreparationState.steps as step (step.id)}
+              {#each displayedReceiptSteps as step (step.id)}
                 <li
                   class={`receipt-progress__step receipt-progress__step--${step.status}`}
                   data-testid={`receipt-step-${step.id}`}
@@ -628,7 +765,7 @@
               {/each}
             </ol>
 
-            {#if receiptPreparationState.phase === 'error'}
+            {#if receiptPreparationState.phase === 'error' || receiptCommitState.phase === 'failed' || receiptCommitState.phase === 'invalidated'}
               <button
                 type="button"
                 class="app-button app-button--secondary add-transfer-form__action"
@@ -640,7 +777,7 @@
                 <span aria-hidden="true">📷</span>
                 {$_('addTransfer.receipt.freshAction')}
               </button>
-            {:else}
+            {:else if receiptPreparationState.phase === 'processing' || receiptPreparationState.phase === 'waiting_for_source' || receiptPreparationState.phase === 'ready_for_commit'}
               <div class="add-transfer-form__field receipt-source-account">
                 <label class="add-transfer-form__label" for="receipt-source-account">
                   {$_('addTransfer.receipt.sourceAccount')}
@@ -681,6 +818,89 @@
                   )}
                 </p>
               {/if}
+            {:else if receiptCommitState.phase === 'upload_failed'}
+              <button
+                type="button"
+                class="app-button app-button--primary add-transfer-form__action"
+                data-testid="receipt-upload-retry"
+                disabled={isOffline}
+                on:click={retryReceiptUpload}
+              >
+                {$_('addTransfer.receipt.commit.retryUpload')}
+              </button>
+            {:else if receiptCommitState.phase === 'conflict'}
+              <button
+                type="button"
+                class="app-button app-button--primary add-transfer-form__action"
+                data-testid="receipt-conflict-refresh"
+                disabled={isOffline}
+                on:click={resolveReceiptConflict}
+              >
+                {$_('addTransfer.receipt.commit.refreshConflict')}
+              </button>
+            {:else if receiptCommitState.phase === 'conflict_ready'}
+              <p class="add-transfer-form__status" role="status">
+                {$_('addTransfer.receipt.commit.conflictReady')}
+              </p>
+              <button
+                type="button"
+                class="app-button app-button--primary add-transfer-form__action"
+                data-testid="receipt-conflict-retry"
+                disabled={isOffline}
+                on:click={retryReceiptAfterConflict}
+              >
+                {$_('addTransfer.receipt.commit.retryAfterConflict')}
+              </button>
+            {:else if receiptCommitState.phase === 'local_commit_recovery_failed'}
+              <button
+                type="button"
+                class="app-button app-button--primary add-transfer-form__action"
+                data-testid="receipt-local-recovery-retry"
+                disabled={isOffline}
+                on:click={retryReceiptLocalCommitRecovery}
+              >
+                {$_('addTransfer.receipt.commit.retryLocalRecovery')}
+              </button>
+            {:else if receiptCommitState.phase === 'local_commit_syncing' || receiptCommitState.phase === 'conflict_syncing' || receiptCommitState.phase === 'remote_commit_syncing'}
+              <p class="add-transfer-form__status" role="status">
+                {$_(
+                  receiptCommitState.phase === 'local_commit_syncing'
+                    ? 'addTransfer.receipt.commit.recoveringLocalCommit'
+                    : receiptCommitState.phase === 'conflict_syncing'
+                      ? 'addTransfer.receipt.commit.refreshingConflict'
+                      : 'addTransfer.receipt.commit.reconcilingRemoteCommit',
+                )}
+              </p>
+              {#if receiptCommitState.recoveryProgress !== null}
+                <ProgressIndicator
+                  kind="download"
+                  loaded={receiptCommitState.recoveryProgress.loadedBytes}
+                  total={receiptCommitState.recoveryProgress.totalBytes}
+                />
+              {/if}
+            {:else if receiptCommitState.phase === 'uploading' && receiptCommitState.progress !== null}
+              <ProgressIndicator
+                kind="upload"
+                loaded={receiptCommitState.progress.loadedBytes}
+                total={receiptCommitState.progress.totalBytes}
+              />
+            {:else if receiptCommitState.phase === 'saved'}
+              <p
+                class="add-transfer-form__success"
+                role="status"
+                data-testid="receipt-commit-success"
+              >
+                {$_(
+                  receiptCommitState.createdCount === 1
+                    ? 'addTransfer.receipt.commit.successOne'
+                    : 'addTransfer.receipt.commit.successMany',
+                  { values: { count: receiptCommitState.createdCount } },
+                )}
+              </p>
+            {:else if receiptCommitState.phase === 'remote_commit_recovery_failed'}
+              <p class="add-transfer-form__error" role="alert" data-testid="receipt-remote-saved">
+                {$_('addTransfer.receipt.commit.remoteCommitRecoveryFailed')}
+              </p>
             {/if}
           {/if}
         </section>
@@ -852,7 +1072,7 @@
               type="button"
               class="app-button app-button--secondary add-transfer-form__action"
               data-testid="add-transfer-close"
-              disabled={isSubmitting || saveIsBusy}
+              disabled={isSubmitting || saveIsBusy || receiptCommitIsBusy}
               on:click={handleClose}
             >
               {$_('addTransfer.close')}
@@ -896,7 +1116,7 @@
               type="button"
               class="app-button app-button--secondary add-transfer-form__action"
               data-testid="add-transfer-close"
-              disabled={isSubmitting || saveIsBusy}
+              disabled={isSubmitting || saveIsBusy || receiptCommitIsBusy}
               on:click={handleClose}
             >
               {$_('addTransfer.close')}

--- a/src/features/app-shell/routes/AddRoute.test.ts
+++ b/src/features/app-shell/routes/AddRoute.test.ts
@@ -20,6 +20,10 @@ import type {
   ReceiptTransferPreparationController,
   ReceiptTransferPreparationState,
 } from '../../receipt/receiptTransferPreparationController';
+import type {
+  ReceiptTransferCommitController,
+  ReceiptTransferCommitState,
+} from '../receiptTransferCommitController';
 
 const READY_OPTIONS_STATE: AddTransferOptionsState = {
   operation: 'ready',
@@ -102,9 +106,30 @@ const createMockReceiptPreparationController = (
   handleAnalysisState: () => {},
   selectSourceAccount: () => {},
   refreshOptions: () => {},
+  claimReadyForCommit: () => null,
+  markCommitActive: () => {},
+  markCommitFailed: () => {},
+  markCommitted: () => {},
   failForOffline: () => {},
   reset: () => {},
   dispose: () => {},
+});
+
+const createMockReceiptCommitController = (
+  state: ReceiptTransferCommitState,
+): ReceiptTransferCommitController => ({
+  getState: () => state,
+  subscribe: (listener) => {
+    listener(state);
+    return () => {};
+  },
+  commit: async () => {},
+  retryUpload: async () => {},
+  resolveConflict: async () => {},
+  retryAfterConflict: async () => {},
+  retryLocalCommitRecovery: async () => {},
+  invalidate: () => {},
+  reset: () => {},
 });
 
 const PROCESSING_STEPS = [
@@ -330,6 +355,122 @@ describe('AddRoute component', () => {
     });
 
     expect(body).toContain('Transferdaten für 2 Transfers wurden erstellt.');
+  });
+
+  it('keeps the final step active during upload and shows the exact committed count afterward', () => {
+    const committingPreparation = createMockReceiptPreparationController({
+      phase: 'committing',
+      steps: [
+        { id: 'extraction', status: 'complete' },
+        { id: 'derivation', status: 'complete' },
+        { id: 'creation', status: 'active' },
+      ],
+      sourceAccountId: 11,
+      readyForCommit: null,
+      error: null,
+    });
+    const uploading = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController(),
+      receiptPreparationController: committingPreparation,
+      receiptCommitController: createMockReceiptCommitController({
+        phase: 'uploading',
+        createdCount: 2,
+        error: null,
+        progress: { loadedBytes: 5, totalBytes: 10 },
+        recoveryProgress: null,
+      }),
+    }).body;
+    expect(uploading).toMatch(/data-testid="receipt-step-creation"[^>]*data-state="active"/);
+    expect(uploading).not.toContain('receipt-commit-success');
+
+    const saved = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController(),
+      receiptPreparationController: createMockReceiptPreparationController({
+        phase: 'committed',
+        steps: [
+          { id: 'extraction', status: 'complete' },
+          { id: 'derivation', status: 'complete' },
+          { id: 'creation', status: 'complete' },
+        ],
+        sourceAccountId: null,
+        readyForCommit: null,
+        error: null,
+      }),
+      receiptCommitController: createMockReceiptCommitController({
+        phase: 'saved',
+        createdCount: 2,
+        error: null,
+        progress: null,
+        recoveryProgress: null,
+      }),
+    }).body;
+    expect(saved).toMatch(/data-testid="receipt-step-creation"[^>]*data-state="complete"/);
+    expect(saved).toContain('data-testid="receipt-commit-success"');
+    expect(saved).toContain('2 Transfers erstellt');
+  });
+
+  it('offers only the appropriate duplicate-safe recovery action for receipt commit failures', () => {
+    const preparation = createMockReceiptPreparationController({
+      phase: 'commit_failed',
+      steps: [
+        { id: 'extraction', status: 'complete' },
+        { id: 'derivation', status: 'complete' },
+        { id: 'creation', status: 'error' },
+      ],
+      sourceAccountId: null,
+      readyForCommit: null,
+      error: null,
+    });
+    const uploadFailed = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController(),
+      receiptPreparationController: preparation,
+      receiptCommitController: createMockReceiptCommitController({
+        phase: 'upload_failed',
+        createdCount: 1,
+        error: { code: 'upload_failed', detail: null, preparationError: null },
+        progress: null,
+        recoveryProgress: null,
+      }),
+    }).body;
+    expect(uploadFailed).toContain('data-testid="receipt-upload-retry"');
+    expect(uploadFailed).not.toContain('receipt-photo-button');
+
+    const localRecoveryFailed = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController(),
+      receiptPreparationController: preparation,
+      receiptCommitController: createMockReceiptCommitController({
+        phase: 'local_commit_recovery_failed',
+        createdCount: 1,
+        error: {
+          code: 'local_commit_recovery_failed',
+          detail: null,
+          preparationError: null,
+        },
+        progress: null,
+        recoveryProgress: null,
+      }),
+    }).body;
+    expect(localRecoveryFailed).toContain('data-testid="receipt-local-recovery-retry"');
+    expect(localRecoveryFailed).not.toContain('receipt-photo-button');
+
+    const remoteSaved = renderAddRoute({
+      receiptCaptureController: createMockReceiptCaptureController(),
+      receiptPreparationController: preparation,
+      receiptCommitController: createMockReceiptCommitController({
+        phase: 'remote_commit_recovery_failed',
+        createdCount: 1,
+        error: {
+          code: 'remote_commit_recovery_failed',
+          detail: null,
+          preparationError: null,
+        },
+        progress: null,
+        recoveryProgress: null,
+      }),
+    }).body;
+    expect(remoteSaved).toContain('data-testid="receipt-remote-saved"');
+    expect(remoteSaved).not.toContain('receipt-upload-retry');
+    expect(remoteSaved).not.toContain('receipt-conflict-retry');
   });
 
   it('keeps source-account selection enabled throughout both analysis stages', () => {

--- a/src/features/app-shell/transferSaveExportService.test.ts
+++ b/src/features/app-shell/transferSaveExportService.test.ts
@@ -18,6 +18,8 @@ import {
 } from '../../shared/testUtils/dbIntegration';
 import {
   createTransferSaveExportService,
+  TransferBatchExportRecoveryRequiredError,
+  TransferBatchUploadPendingError,
   TransferUploadPendingError,
   type DatabaseUploadHandoff,
 } from './transferSaveExportService';
@@ -70,6 +72,106 @@ describe('transfer save export service', () => {
     expect(uploadedByteSets[0]?.length).toBeGreaterThan(0);
     runtime.close();
   });
+
+  it('commits a batch, exports once, and uploads one full snapshot', async () => {
+    const runtime = await createRuntimeFromTransferFixture();
+    const writeService = createTransferWriteService(runtime);
+    const exportSpy = vi.spyOn(runtime, 'exportBytes');
+    const uploadHandoff: DatabaseUploadHandoff = {
+      uploadExportedDatabase: vi.fn(async () => {}),
+    };
+    const service = createTransferSaveExportService(writeService, runtime, uploadHandoff);
+
+    const result = await service.createTransferBatchAndExport([
+      createBaseInput('Batch export first'),
+      { ...createBaseInput('Batch export second'), amountCents: 566 },
+    ]);
+
+    expect(result.createdCount).toBe(2);
+    expect(exportSpy).toHaveBeenCalledOnce();
+    expect(uploadHandoff.uploadExportedDatabase).toHaveBeenCalledOnce();
+    expect(countTransfersByName(runtime, 'Batch export first')).toBe(1);
+    expect(countTransfersByName(runtime, 'Batch export second')).toBe(1);
+    runtime.close();
+  });
+
+  it('retries a failed batch upload with the same bytes and no second write or export', async () => {
+    const writeService = {
+      createTransfer: vi.fn(),
+      createTransfers: vi.fn(() => ({
+        transferIds: [41, 42],
+        createdCount: 2,
+        persistedAtIso: '2026-07-31T00:00:00.000Z',
+      })),
+    };
+    const runtime = { exportBytes: vi.fn(() => Uint8Array.from([4, 5, 6])) };
+    const uploadHandoff: DatabaseUploadHandoff = {
+      uploadExportedDatabase: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('temporary upload failure'))
+        .mockResolvedValueOnce(undefined),
+    };
+    const service = createTransferSaveExportService(writeService, runtime, uploadHandoff);
+
+    const pendingError = await service
+      .createTransferBatchAndExport([
+        createBaseInput('Batch retry first'),
+        createBaseInput('Batch retry second'),
+      ])
+      .catch((error: unknown) => error);
+
+    expect(pendingError).toBeInstanceOf(TransferBatchUploadPendingError);
+    const bytes = (pendingError as TransferBatchUploadPendingError).pendingUpload.dbBytes;
+    await service.retryExportedDatabaseUpload(bytes);
+    expect(writeService.createTransfers).toHaveBeenCalledOnce();
+    expect(runtime.exportBytes).toHaveBeenCalledOnce();
+    expect(uploadHandoff.uploadExportedDatabase).toHaveBeenNthCalledWith(1, bytes, undefined);
+    expect(uploadHandoff.uploadExportedDatabase).toHaveBeenNthCalledWith(2, bytes, undefined);
+  });
+
+  it.each([
+    {
+      name: 'throws',
+      exportBytes: () => {
+        throw new DbRuntimeError('db_export_failed', 'export failed');
+      },
+    },
+    { name: 'returns empty bytes', exportBytes: () => new Uint8Array() },
+  ])(
+    'requires authoritative recovery when a committed batch export $name',
+    async ({ exportBytes }) => {
+      const batchResult = {
+        transferIds: [41],
+        createdCount: 1,
+        persistedAtIso: '2026-07-31T00:00:00.000Z',
+      };
+      const writeService = {
+        createTransfer: vi.fn(),
+        createTransfers: vi.fn(() => batchResult),
+      };
+      const uploadHandoff: DatabaseUploadHandoff = {
+        uploadExportedDatabase: vi.fn(async () => {}),
+      };
+      const service = createTransferSaveExportService(
+        writeService,
+        { exportBytes: vi.fn(exportBytes) },
+        uploadHandoff,
+      );
+
+      const error = await service
+        .createTransferBatchAndExport([createBaseInput('Committed before export')])
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(TransferBatchExportRecoveryRequiredError);
+      expect(error).toMatchObject({
+        name: 'TransferBatchExportRecoveryRequiredError',
+        batchResult,
+      });
+
+      expect(writeService.createTransfers).toHaveBeenCalledOnce();
+      expect(uploadHandoff.uploadExportedDatabase).not.toHaveBeenCalled();
+    },
+  );
 
   it('runs export and upload only after the local write succeeds', async () => {
     const calls: string[] = [];

--- a/src/features/app-shell/transferSaveExportService.ts
+++ b/src/features/app-shell/transferSaveExportService.ts
@@ -4,6 +4,7 @@ import {
   DbRuntimeError,
   resolveAppBrowserDbRuntime,
   type BrowserDbRuntime,
+  type CreateTransferBatchResult,
   type CreateTransferInput,
   type CreateTransferResult,
   type TransferWriteService,
@@ -23,6 +24,7 @@ export interface DatabaseUploadProgress {
 export interface DatabaseUploadOptions {
   readonly onUploadStart?: () => void;
   readonly onProgress?: (progress: DatabaseUploadProgress) => void;
+  readonly expectedETag?: string;
 }
 
 export interface TransferSaveExportService {
@@ -33,8 +35,20 @@ export interface TransferSaveExportService {
   retryExportedDatabaseUpload(dbBytes: Uint8Array, options?: DatabaseUploadOptions): Promise<void>;
 }
 
+export interface TransferBatchSaveExportService extends TransferSaveExportService {
+  createTransferBatchAndExport(
+    inputs: readonly CreateTransferInput[],
+    options?: DatabaseUploadOptions,
+  ): Promise<CreateTransferBatchResult>;
+}
+
 export interface PendingTransferUpload {
   readonly transferResult: CreateTransferResult;
+  readonly dbBytes: Uint8Array;
+}
+
+export interface PendingTransferBatchUpload {
+  readonly batchResult: CreateTransferBatchResult;
   readonly dbBytes: Uint8Array;
 }
 
@@ -51,6 +65,37 @@ export class TransferUploadPendingError extends Error {
     }
   }
 }
+
+export class TransferBatchUploadPendingError extends Error {
+  readonly pendingUpload: PendingTransferBatchUpload;
+  readonly cause?: unknown;
+
+  constructor(pendingUpload: PendingTransferBatchUpload, cause: unknown) {
+    super(cause instanceof Error ? cause.message : 'Uploading the transfer batch failed.');
+    this.name = 'TransferBatchUploadPendingError';
+    this.pendingUpload = pendingUpload;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+export class TransferBatchExportRecoveryRequiredError extends Error {
+  readonly batchResult: CreateTransferBatchResult;
+  readonly cause?: unknown;
+
+  constructor(batchResult: CreateTransferBatchResult, cause: unknown) {
+    super(cause instanceof Error ? cause.message : 'Exporting the transfer batch failed.');
+    this.name = 'TransferBatchExportRecoveryRequiredError';
+    this.batchResult = batchResult;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+type TransferWriteOperations = Pick<TransferWriteService, 'createTransfer'> &
+  Partial<Pick<TransferWriteService, 'createTransfers'>>;
 
 type TransferExportRuntime = Pick<BrowserDbRuntime, 'exportBytes'>;
 type TransferExportRuntimeProvider = TransferExportRuntime | (() => TransferExportRuntime);
@@ -71,10 +116,10 @@ const cloneExportedBytes = (dbBytes: Uint8Array): Uint8Array => {
 };
 
 export const createTransferSaveExportService = (
-  transferWriteService: Pick<TransferWriteService, 'createTransfer'>,
+  transferWriteService: TransferWriteOperations,
   dbRuntime: TransferExportRuntimeProvider,
   uploadHandoff: DatabaseUploadHandoff,
-): TransferSaveExportService => ({
+): TransferBatchSaveExportService => ({
   async createTransferAndExport(
     input: CreateTransferInput,
     options?: DatabaseUploadOptions,
@@ -98,6 +143,37 @@ export const createTransferSaveExportService = (
     return transferResult;
   },
 
+  async createTransferBatchAndExport(
+    inputs: readonly CreateTransferInput[],
+    options?: DatabaseUploadOptions,
+  ): Promise<CreateTransferBatchResult> {
+    if (transferWriteService.createTransfers === undefined) {
+      throw new DbRuntimeError('db_query_failed', 'Batch transfer writes are unavailable.');
+    }
+    const batchResult = transferWriteService.createTransfers(inputs);
+    let exportedBytes: Uint8Array;
+    try {
+      exportedBytes = cloneExportedBytes(resolveTransferExportRuntime(dbRuntime).exportBytes());
+    } catch (error) {
+      throw new TransferBatchExportRecoveryRequiredError(batchResult, error);
+    }
+
+    try {
+      options?.onUploadStart?.();
+      await uploadHandoff.uploadExportedDatabase(exportedBytes, options);
+    } catch (error) {
+      throw new TransferBatchUploadPendingError(
+        {
+          batchResult,
+          dbBytes: exportedBytes,
+        },
+        error,
+      );
+    }
+
+    return batchResult;
+  },
+
   async retryExportedDatabaseUpload(
     dbBytes: Uint8Array,
     options?: DatabaseUploadOptions,
@@ -107,7 +183,7 @@ export const createTransferSaveExportService = (
   },
 });
 
-export const createAppTransferSaveExportService = (): TransferSaveExportService =>
+export const createAppTransferSaveExportService = (): TransferBatchSaveExportService =>
   createTransferSaveExportService(
     appTransferWriteService,
     resolveAppBrowserDbRuntime,

--- a/src/features/receipt/index.ts
+++ b/src/features/receipt/index.ts
@@ -9,7 +9,10 @@ export type {
   ReceiptAnalysisStage,
   ReceiptAnalysisState,
 } from './receiptAnalysisController';
-export { listReceiptSourceAccountOptions } from './receiptTransferCommandBuilder';
+export {
+  listReceiptSourceAccountOptions,
+  validatePreparedReceiptTransferCommands,
+} from './receiptTransferCommandBuilder';
 export type {
   ReceiptTransferCommandBuildResult,
   ReceiptTransferPreparationError,

--- a/src/features/receipt/receiptTransferCommandBuilder.test.ts
+++ b/src/features/receipt/receiptTransferCommandBuilder.test.ts
@@ -11,6 +11,7 @@ import type { ReceiptTransferDerivation } from './receiptAnalysisContracts';
 import {
   buildReceiptTransferCommands,
   listReceiptSourceAccountOptions,
+  validatePreparedReceiptTransferCommands,
 } from './receiptTransferCommandBuilder';
 
 const OPTIONS: AddTransferOptionsState = {
@@ -157,5 +158,50 @@ describe('receipt transfer command builder', () => {
         OPTIONS,
       ),
     ).toMatchObject({ ok: false, error: { code: 'total_mismatch' } });
+  });
+
+  it('revalidates an immutable prepared batch against current accounts and categories', () => {
+    const result = buildReceiptTransferCommands(DERIVATION, [0, 1, 2], 11, OPTIONS);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(validatePreparedReceiptTransferCommands(result.commands, OPTIONS)).toBeNull();
+    expect(
+      validatePreparedReceiptTransferCommands(result.commands, {
+        ...OPTIONS,
+        categoryOptions: OPTIONS.categoryOptions.filter((category) => category.categoryId !== 22),
+      }),
+    ).toEqual({ code: 'invalid_transfer', detail: null });
+    expect(
+      validatePreparedReceiptTransferCommands(result.commands, {
+        ...OPTIONS,
+        fromAccountOptions: OPTIONS.fromAccountOptions.filter(
+          (account) => account.accountId !== 11,
+        ),
+      }),
+    ).toEqual({ code: 'source_account_unavailable', detail: null });
+  });
+
+  it('rejects mutable, empty, or tampered prepared commands', () => {
+    expect(validatePreparedReceiptTransferCommands([], OPTIONS)).toEqual({
+      code: 'options_unavailable',
+      detail: null,
+    });
+    const mutable = [
+      {
+        bookingDateEpochDay: 20665,
+        name: 'Lebensmittel',
+        amountCents: 350,
+        transferTypeId: TRANSFER_TYPE_STD_EXPENSE,
+        fromAccountId: 11,
+        toAccountId: 2,
+        categoryIds: [20],
+        buyplace: 'Markt',
+      },
+    ];
+    expect(validatePreparedReceiptTransferCommands(mutable, OPTIONS)).toEqual({
+      code: 'options_unavailable',
+      detail: null,
+    });
   });
 });

--- a/src/features/receipt/receiptTransferCommandBuilder.ts
+++ b/src/features/receipt/receiptTransferCommandBuilder.ts
@@ -268,3 +268,72 @@ export const buildReceiptTransferCommands = (
 
   return { ok: true, commands: Object.freeze(commands) };
 };
+
+export const validatePreparedReceiptTransferCommands = (
+  commands: readonly CreateTransferInput[],
+  optionsState: AddTransferOptionsState,
+): ReceiptTransferPreparationError | null => {
+  if (!Object.isFrozen(commands) || commands.length === 0 || optionsState.operation !== 'ready') {
+    return { code: 'options_unavailable', detail: null };
+  }
+
+  const destination = findPrimarySpendingsAccount(optionsState);
+  if (destination === null) {
+    return { code: 'primary_spendings_unavailable', detail: null };
+  }
+  const validSources = listReceiptSourceAccountOptions(optionsState);
+  const currentCategoryIds = new Set(
+    optionsState.categoryOptions.map((category) => category.categoryId),
+  );
+  const sourceAccountId = commands[0]?.fromAccountId;
+
+  for (const command of commands) {
+    if (
+      !Object.isFrozen(command) ||
+      !Object.isFrozen(command.categoryIds) ||
+      command.fromAccountId !== sourceAccountId ||
+      command.toAccountId !== destination.accountId ||
+      !Number.isSafeInteger(command.bookingDateEpochDay) ||
+      !Number.isSafeInteger(command.amountCents) ||
+      command.amountCents <= 0 ||
+      command.categoryIds.length > 3 ||
+      new Set(command.categoryIds).size !== command.categoryIds.length ||
+      command.categoryIds.some((categoryId) => !currentCategoryIds.has(categoryId))
+    ) {
+      return { code: 'invalid_transfer', detail: null };
+    }
+
+    const source = validSources.find((account) => account.accountId === command.fromAccountId);
+    if (source === undefined) {
+      return { code: 'source_account_unavailable', detail: null };
+    }
+    if (
+      deriveTransferType(source.accountTypeId, destination.accountTypeId) !== command.transferTypeId
+    ) {
+      return { code: 'invalid_transfer', detail: null };
+    }
+
+    const fields: AddTransferFormFields = {
+      date: new Date(command.bookingDateEpochDay * 86_400_000).toISOString().slice(0, 10),
+      name: command.name,
+      amount: formatAmountInputDigits(String(command.amountCents)),
+      fromAccountId: command.fromAccountId,
+      toAccountId: command.toAccountId,
+      category1Id: command.categoryIds[0] ?? -1,
+      category2Id: command.categoryIds[1] ?? -1,
+      category3Id: command.categoryIds[2] ?? -1,
+      buyplace: command.buyplace ?? '',
+    };
+    const validationErrors = validateAddTransfer(
+      fields,
+      optionsState.fromAccountOptions,
+      optionsState.toAccountOptions,
+      (key) => key,
+    );
+    if (validationErrors.length > 0) {
+      return { code: 'invalid_transfer', detail: validationErrors[0] ?? null };
+    }
+  }
+
+  return null;
+};

--- a/src/features/receipt/receiptTransferPreparationController.test.ts
+++ b/src/features/receipt/receiptTransferPreparationController.test.ts
@@ -213,4 +213,31 @@ describe('receipt transfer preparation controller', () => {
       readyForCommit: null,
     });
   });
+
+  it('hands the immutable batch off only once while retaining safe commit progress metadata', () => {
+    const controller = createReceiptTransferPreparationController();
+    controller.beginRun();
+    controller.selectSourceAccount(11, OPTIONS);
+    controller.handleAnalysisState(SUCCEEDED, OPTIONS);
+
+    const claimed = controller.claimReadyForCommit();
+    expect(claimed).toHaveLength(1);
+    expect(controller.claimReadyForCommit()).toBeNull();
+    expect(controller.getState()).toMatchObject({
+      phase: 'committing',
+      readyForCommit: null,
+      steps: [{ status: 'complete' }, { status: 'complete' }, { status: 'active' }],
+    });
+
+    controller.markCommitFailed();
+    expect(controller.getState()).toMatchObject({ phase: 'commit_failed' });
+    controller.markCommitActive();
+    controller.markCommitted();
+    expect(controller.getState()).toMatchObject({
+      phase: 'committed',
+      sourceAccountId: null,
+      readyForCommit: null,
+      steps: [{ status: 'complete' }, { status: 'complete' }, { status: 'complete' }],
+    });
+  });
 });

--- a/src/features/receipt/receiptTransferPreparationController.ts
+++ b/src/features/receipt/receiptTransferPreparationController.ts
@@ -17,6 +17,9 @@ export type ReceiptTransferPreparationPhase =
   | 'processing'
   | 'waiting_for_source'
   | 'ready_for_commit'
+  | 'committing'
+  | 'commit_failed'
+  | 'committed'
   | 'error';
 
 export interface ReceiptProcessingStep {
@@ -43,6 +46,10 @@ export interface ReceiptTransferPreparationController {
   ): void;
   selectSourceAccount(sourceAccountId: number | null, optionsState: AddTransferOptionsState): void;
   refreshOptions(optionsState: AddTransferOptionsState): void;
+  claimReadyForCommit(): readonly CreateTransferInput[] | null;
+  markCommitActive(): void;
+  markCommitFailed(): void;
+  markCommitted(): void;
   failForOffline(): void;
   reset(): void;
   dispose(): void;
@@ -226,12 +233,7 @@ export const createReceiptTransferPreparationController =
       },
 
       selectSourceAccount(sourceAccountId, optionsState): void {
-        if (
-          isDisposed ||
-          state.phase === 'idle' ||
-          state.phase === 'error' ||
-          state.phase === 'ready_for_commit'
-        ) {
+        if (isDisposed || !['processing', 'waiting_for_source'].includes(state.phase)) {
           return;
         }
         publish({ ...state, sourceAccountId });
@@ -251,12 +253,7 @@ export const createReceiptTransferPreparationController =
       },
 
       refreshOptions(optionsState): void {
-        if (
-          isDisposed ||
-          state.phase === 'idle' ||
-          state.phase === 'error' ||
-          state.phase === 'ready_for_commit'
-        ) {
+        if (isDisposed || !['processing', 'waiting_for_source'].includes(state.phase)) {
           return;
         }
         if (optionsState.operation !== 'ready') {
@@ -273,6 +270,48 @@ export const createReceiptTransferPreparationController =
         if (state.sourceAccountId !== null && derivation !== null) {
           tryPrepare(optionsState);
         }
+      },
+
+      claimReadyForCommit(): readonly CreateTransferInput[] | null {
+        if (isDisposed || state.phase !== 'ready_for_commit' || state.readyForCommit === null) {
+          return null;
+        }
+        const commands = state.readyForCommit;
+        publish({
+          phase: 'committing',
+          steps: steps('complete', 'complete', 'active'),
+          sourceAccountId: state.sourceAccountId,
+          readyForCommit: null,
+          error: null,
+        });
+        return commands;
+      },
+
+      markCommitActive(): void {
+        if (isDisposed || !['committing', 'commit_failed'].includes(state.phase)) return;
+        publish({ ...state, phase: 'committing', steps: steps('complete', 'complete', 'active') });
+      },
+
+      markCommitFailed(): void {
+        if (isDisposed || state.phase !== 'committing') return;
+        publish({
+          phase: 'commit_failed',
+          steps: steps('complete', 'complete', 'error'),
+          sourceAccountId: null,
+          readyForCommit: null,
+          error: null,
+        });
+      },
+
+      markCommitted(): void {
+        if (isDisposed || state.phase !== 'committing') return;
+        publish({
+          phase: 'committed',
+          steps: steps('complete', 'complete', 'complete'),
+          sourceAccountId: null,
+          readyForCommit: null,
+          error: null,
+        });
       },
 
       failForOffline(): void {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -130,6 +130,39 @@
         "output_limit": "Die Modellantwort war zu lang oder überschritt eine Verarbeitungsgrenze. Starte mit einem neuen Foto.",
         "invalid_prompt": "Der Ableitungs-Prompt enthält keine eindeutig prüfbaren Gruppen- und Kategoriezuordnungen. Prüfe die Beleg-KI-Einstellungen und starte mit einem neuen Foto.",
         "model_error": "Das Modell konnte den Beleg nicht eindeutig verarbeiten:"
+      },
+      "commit": {
+        "successOne": "1 Transfer erstellt",
+        "successMany": "{count} Transfers erstellt",
+        "pendingTitle": "Belegtransfer-Synchronisierung benötigt Aufmerksamkeit",
+        "pendingDescription": "Öffne den Belegablauf, um die duplikatsichere OneDrive-Wiederherstellung fortzusetzen.",
+        "pendingRemoteSavedDescription": "Die Transfers sind bereits in OneDrive gespeichert. Öffne den Belegablauf für den lokalen Aktualisierungsstatus und speichere nicht erneut.",
+        "pendingAction": "Belegstatus öffnen",
+        "retryUpload": "OneDrive-Upload wiederholen",
+        "refreshConflict": "Aktuelle Datenbank laden",
+        "refreshingConflict": "Aktuelle OneDrive-Datenbank wird geladen und geprüft...",
+        "conflictReady": "Die aktuelle Datenbank ist geprüft. Erstelle den unveränderten validierten Stapel ausdrücklich erneut.",
+        "retryAfterConflict": "Transfers erneut erstellen",
+        "recoveringLocalCommit": "Der lokale Export ist nach der Stapeltransaktion fehlgeschlagen. Die geprüfte OneDrive-Datenbank wird vor einem weiteren Schreibvorgang wiederhergestellt...",
+        "retryLocalRecovery": "Geprüfte Datenbank erneut wiederherstellen",
+        "reconcilingRemoteCommit": "Die Transfers sind in OneDrive gespeichert. Lokale Daten werden aktualisiert...",
+        "remoteCommitRecoveryFailed": "Die Transfers wurden in OneDrive gespeichert, aber die lokalen Daten konnten nicht aktualisiert werden. Speichere sie nicht erneut und öffne die App wieder, sobald OneDrive erreichbar ist.",
+        "uploadFailed": "Der Datenbank-Upload ist fehlgeschlagen. Die Wiederholung nutzt nur die bereits exportierte Datenbank und erzeugt keine doppelten Transfers.",
+        "localFailed": "Der vollständige Transferstapel wurde nicht hochgeladen. Die geprüfte OneDrive-Datenbank ist wieder aktiv.",
+        "conflict": "OneDrive enthält neuere Daten. Aktualisiere zuerst und erstelle den Stapel danach ausdrücklich erneut.",
+        "conflictReadyToast": "Aktuelle OneDrive-Daten wurden geladen. Der validierte Stapel kann ausdrücklich erstellt werden.",
+        "errors": {
+          "offline": "Zum Erstellen der Belegtransfers ist eine Internetverbindung erforderlich.",
+          "context_unavailable": "Die angemeldete OneDrive-Datenbank ist nicht geprüft und aktuell. Der Stapel wurde nicht erstellt.",
+          "context_changed": "Das Konto oder die OneDrive-Datei wurde geändert. Dieser Belegstapel kann nicht fortgesetzt werden.",
+          "validation_failed": "Der validierte Belegstapel passt nicht mehr zu den aktuellen Konten oder Kategorien.",
+          "local_failed": "Der vollständige Stapel konnte lokal nicht gespeichert werden. Es wurde kein Teilstapel behalten.",
+          "local_commit_recovery_failed": "Der lokale Export ist nach der Stapeltransaktion fehlgeschlagen und die geprüfte OneDrive-Datenbank konnte nicht wiederhergestellt werden. Stelle sie vor einem weiteren Schreibvorgang erneut wieder her.",
+          "upload_failed": "Der OneDrive-Upload ist vor bestätigter Annahme fehlgeschlagen. Die Wiederholung nutzt dieselben exportierten Datenbankbytes.",
+          "conflict": "OneDrive enthält neuere Daten. Lade sie, bevor du den Stapel ausdrücklich erneut erstellst.",
+          "conflict_sync_failed": "Die aktuelle OneDrive-Datenbank konnte nicht geladen und geprüft werden.",
+          "remote_commit_recovery_failed": "Die Transfers sind in OneDrive gespeichert, aber die geprüfte lokale Aktualisierung ist fehlgeschlagen. Speichere sie nicht erneut."
+        }
       }
     },
     "save": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -130,6 +130,39 @@
         "output_limit": "The model response was too long or exceeded a processing limit. Start with a new photo.",
         "invalid_prompt": "The derivation prompt has no unambiguously verifiable group and category mappings. Check Receipt AI settings and start with a new photo.",
         "model_error": "The model could not process the receipt unambiguously:"
+      },
+      "commit": {
+        "successOne": "1 transfer created",
+        "successMany": "{count} transfers created",
+        "pendingTitle": "Receipt transfer sync needs attention",
+        "pendingDescription": "Open the receipt workflow to continue the duplicate-safe OneDrive recovery.",
+        "pendingRemoteSavedDescription": "The transfers are already saved to OneDrive. Open the receipt workflow for the local refresh status; do not save again.",
+        "pendingAction": "Open receipt status",
+        "retryUpload": "Retry OneDrive upload",
+        "refreshConflict": "Download latest database",
+        "refreshingConflict": "Downloading and verifying the latest OneDrive database...",
+        "conflictReady": "The latest database is verified. Save the unchanged validated batch explicitly.",
+        "retryAfterConflict": "Create transfers again",
+        "recoveringLocalCommit": "The local export failed after the batch transaction. Restoring the verified OneDrive database before another write...",
+        "retryLocalRecovery": "Retry verified database restore",
+        "reconcilingRemoteCommit": "Transfers are saved to OneDrive. Refreshing local data...",
+        "remoteCommitRecoveryFailed": "The transfers were saved to OneDrive, but local data could not be refreshed. Do not save them again; reopen the app when OneDrive is reachable.",
+        "uploadFailed": "The database upload failed. Retry uses the already exported database and cannot create duplicate transfers.",
+        "localFailed": "The complete transfer batch was not uploaded. The verified OneDrive database is active again.",
+        "conflict": "OneDrive contains newer data. Refresh before explicitly creating the batch again.",
+        "conflictReadyToast": "Latest OneDrive data loaded. The validated batch can be created explicitly.",
+        "errors": {
+          "offline": "An internet connection is required to create receipt transfers.",
+          "context_unavailable": "The authenticated OneDrive database is not verified and current. The batch was not created.",
+          "context_changed": "The account or OneDrive file changed. This receipt batch can no longer continue.",
+          "validation_failed": "The validated receipt batch no longer matches the current accounts or categories.",
+          "local_failed": "The complete batch could not be saved locally. No partial batch was retained.",
+          "local_commit_recovery_failed": "The local export failed after the batch transaction, and the verified OneDrive database could not be restored. Retry the restore before another write.",
+          "upload_failed": "The OneDrive upload failed before confirmed acceptance. Retry uses the same exported database bytes.",
+          "conflict": "OneDrive has newer data. Download it before explicitly creating the batch again.",
+          "conflict_sync_failed": "The latest OneDrive database could not be downloaded and verified.",
+          "remote_commit_recovery_failed": "The transfers are saved to OneDrive, but the verified local refresh failed. Do not save them again."
+        }
       }
     },
     "save": {

--- a/tests/e2e/receipt-capture.spec.ts
+++ b/tests/e2e/receipt-capture.spec.ts
@@ -220,25 +220,29 @@ test('exposes one native outward-camera image input without custom capture or ga
   expect(captureSectionSize.scrollWidth).toBeLessThanOrEqual(captureSectionSize.clientWidth);
 });
 
-test('runs the two isolated OpenRouter stages while account selection remains open and performs no write', async ({
+test('runs both OpenRouter stages and automatically commits one validated transfer', async ({
   page,
 }) => {
   await installReadyReceiptConfiguration(page);
   const requests = await installReceiptAnalysisRoutes(page, [EXTRACTION, DERIVATION]);
-  await installReadyAddTransferTestDb(page, {
-    fromAccountOptionRows: [
-      { accountId: 1, name: 'Primary Income', amountCents: 0, accountTypeId: 1 },
-      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
-    ],
-    toAccountOptionRows: [
-      { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
-      { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
-    ],
-    categoryRows: [
-      { categoryId: 20, name: 'Einkauf' },
-      { categoryId: 21, name: 'Lebensmittel' },
-    ],
-  });
+  await installReadyAddTransferTestDb(
+    page,
+    {
+      fromAccountOptionRows: [
+        { accountId: 1, name: 'Primary Income', amountCents: 0, accountTypeId: 1 },
+        { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+      ],
+      toAccountOptionRows: [
+        { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+        { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+      ],
+      categoryRows: [
+        { categoryId: 20, name: 'Einkauf' },
+        { categoryId: 21, name: 'Lebensmittel' },
+      ],
+    },
+    { uploadDelayMs: 400 },
+  );
   await page.goto(appPath('#/add'));
 
   await page.getByTestId('receipt-image-input').setInputFiles({
@@ -259,10 +263,10 @@ test('runs the two isolated OpenRouter stages while account selection remains op
   await expect(page.getByTestId('receipt-step-derivation')).toHaveAttribute('data-state', 'active');
   await expect(page.getByTestId('add-transfer-from-account')).toBeEnabled();
   await expect(page.getByTestId('add-transfer-from-account')).toHaveValue('11');
-  await expect(page.getByTestId('receipt-analysis-success')).toContainText(
-    'Transfer data for 1 transfer is ready.',
-  );
   await expect(page.getByTestId('receipt-step-creation')).toHaveAttribute('data-state', 'active');
+  await expect(page.getByTestId('add-transfer-close')).toBeDisabled();
+  await expect(page.getByTestId('receipt-commit-success')).toContainText('1 transfer created');
+  await expect(page.getByTestId('receipt-step-creation')).toHaveAttribute('data-state', 'complete');
 
   expect(requests.catalogRequests).toHaveLength(2);
   expect(requests.completionRequests).toHaveLength(2);
@@ -285,11 +289,17 @@ test('runs the two isolated OpenRouter stages while account selection remains op
     type: 'json_schema',
     json_schema: { strict: true },
   });
-  expect(await getLocalTransferWriteCallCount(page)).toBe(0);
-  expect(await getGraphUploadCallCount(page)).toBe(0);
+  expect(await getLocalTransferWriteCallCount(page)).toBe(1);
+  expect(await getGraphUploadCallCount(page)).toBe(1);
+
+  await page.getByTestId('add-transfer-close').click();
+  await page.locator('a[href="#/add"]').click();
+  await expect(page.getByTestId('receipt-commit-success')).toHaveCount(0);
+  await expect(page.getByTestId('receipt-photo-button')).toBeEnabled();
+  await expect(page.getByTestId('add-transfer-date')).toBeVisible();
 });
 
-test('waits for a deliberate late source selection and prepares a multi-transfer batch automatically', async ({
+test('waits for a deliberate late source selection and commits a multi-transfer batch once', async ({
   page,
 }) => {
   await installReadyReceiptConfiguration(page);
@@ -331,14 +341,63 @@ test('waits for a deliberate late source selection and prepares a multi-transfer
 
   await page.getByTestId('add-transfer-from-account').selectOption('11');
 
-  await expect(page.getByTestId('receipt-analysis-success')).toContainText(
-    'Transfer data for 2 transfers is ready.',
-  );
-  await expect(page.getByTestId('receipt-step-creation')).toHaveAttribute('data-state', 'active');
-  await expect(page.getByTestId('add-transfer-from-account')).toBeDisabled();
+  await expect(page.getByTestId('receipt-commit-success')).toContainText('2 transfers created');
+  await expect(page.getByTestId('receipt-step-creation')).toHaveAttribute('data-state', 'complete');
   await expect(page.locator('[data-testid*="receipt-review"]')).toHaveCount(0);
-  expect(await getLocalTransferWriteCallCount(page)).toBe(0);
-  expect(await getGraphUploadCallCount(page)).toBe(0);
+  expect(await getLocalTransferWriteCallCount(page)).toBe(1);
+  expect(await getGraphUploadCallCount(page)).toBe(1);
+  await page.evaluate(() => {
+    window.location.hash = '#/transfers';
+  });
+  if ((await page.getByTestId('transfers-month-label').textContent())?.includes('August 2026')) {
+    await page.getByTestId('transfers-month-previous-button').click();
+  }
+  await expect(page.getByTestId('route-transfers')).toContainText('Lebensmittel');
+  await expect(page.getByTestId('route-transfers')).toContainText('Haushaltsartikel');
+});
+
+test('clears completed receipt state when upload finishes after leaving Add', async ({ page }) => {
+  await installReadyReceiptConfiguration(page);
+  await installReceiptAnalysisRoutes(page, [EXTRACTION, DERIVATION]);
+  await installReadyAddTransferTestDb(
+    page,
+    {
+      fromAccountOptionRows: [
+        { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+      ],
+      toAccountOptionRows: [
+        { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+      ],
+      categoryRows: [
+        { categoryId: 20, name: 'Einkauf' },
+        { categoryId: 21, name: 'Lebensmittel' },
+      ],
+    },
+    { uploadDelayMs: 800 },
+  );
+  await page.goto(appPath('#/add'));
+
+  await page.getByTestId('receipt-image-input').setInputFiles({
+    name: 'leave-during-upload.png',
+    mimeType: 'image/png',
+    buffer: RECEIPT_IMAGE,
+  });
+  await page.getByTestId('add-transfer-from-account').selectOption('11');
+  await expect(
+    page.locator('[data-testid="progress-indicator"][data-kind="upload"]'),
+  ).toBeVisible();
+  await page.evaluate(() => {
+    window.location.hash = '#/transfers';
+  });
+  await expect(page.getByTestId('route-transfers')).toBeVisible();
+  await expect(page.locator('.toast-container')).toContainText('1 transfer created');
+
+  await page.evaluate(() => {
+    window.location.hash = '#/add';
+  });
+  await expect(page.getByTestId('receipt-commit-success')).toHaveCount(0);
+  await expect(page.getByTestId('receipt-photo-button')).toBeEnabled();
+  await expect(page.getByTestId('add-transfer-date')).toBeVisible();
 });
 
 test('cancels an active run on route abandonment and never restores its source or results', async ({
@@ -366,7 +425,6 @@ test('cancels an active run on route abandonment and never restores its source o
     buffer: RECEIPT_IMAGE,
   });
   await expect(page.getByTestId('receipt-progress')).toBeVisible();
-  await page.getByTestId('add-transfer-from-account').selectOption('11');
   await page.getByTestId('add-transfer-close').click();
   await expect(page.getByTestId('route-transfers')).toBeVisible();
 
@@ -433,8 +491,186 @@ test('ends a model-declared failure and starts again only after a fresh file sel
   await input.setInputFiles({ name: 'second.png', mimeType: 'image/png', buffer: RECEIPT_IMAGE });
   await expect(page.getByTestId('add-transfer-from-account')).toBeEnabled();
   await page.getByTestId('add-transfer-from-account').selectOption('11');
-  await expect(page.getByTestId('receipt-analysis-success')).toBeVisible();
+  await expect(page.getByTestId('receipt-commit-success')).toContainText('1 transfer created');
   expect(requests.completionRequests).toHaveLength(3);
-  expect(await getLocalTransferWriteCallCount(page)).toBe(0);
-  expect(await getGraphUploadCallCount(page)).toBe(0);
+  expect(await getLocalTransferWriteCallCount(page)).toBe(1);
+  expect(await getGraphUploadCallCount(page)).toBe(1);
+});
+
+test('retries only exported bytes after a transport failure without another SQL or LLM run', async ({
+  page,
+}) => {
+  await installReadyReceiptConfiguration(page);
+  const requests = await installReceiptAnalysisRoutes(page, [EXTRACTION, DERIVATION]);
+  await installReadyAddTransferTestDb(
+    page,
+    {
+      fromAccountOptionRows: [
+        { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+      ],
+      toAccountOptionRows: [
+        { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+      ],
+      categoryRows: [
+        { categoryId: 20, name: 'Einkauf' },
+        { categoryId: 21, name: 'Lebensmittel' },
+      ],
+    },
+    {
+      uploadErrorSequence: [
+        { code: 'network_error', message: 'Temporary network failure', status: 503 },
+      ],
+    },
+  );
+  await page.goto(appPath('#/add'));
+
+  await page.getByTestId('receipt-image-input').setInputFiles({
+    name: 'retry-receipt.png',
+    mimeType: 'image/png',
+    buffer: RECEIPT_IMAGE,
+  });
+  await page.getByTestId('add-transfer-from-account').selectOption('11');
+  await expect(page.getByTestId('receipt-upload-retry')).toBeVisible();
+  expect(await getLocalTransferWriteCallCount(page)).toBe(1);
+  expect(await getGraphUploadCallCount(page)).toBe(1);
+  expect(requests.completionRequests).toHaveLength(2);
+
+  await page.getByTestId('receipt-upload-retry').click();
+  await expect(page.getByTestId('receipt-commit-success')).toContainText('1 transfer created');
+  expect(await getLocalTransferWriteCallCount(page)).toBe(1);
+  expect(await getGraphUploadCallCount(page)).toBe(2);
+  expect(requests.completionRequests).toHaveLength(2);
+});
+
+test('keeps byte-only retry visible when connectivity is lost during upload', async ({ page }) => {
+  await installReadyReceiptConfiguration(page);
+  const requests = await installReceiptAnalysisRoutes(page, [EXTRACTION, DERIVATION]);
+  await installReadyAddTransferTestDb(
+    page,
+    {
+      fromAccountOptionRows: [
+        { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+      ],
+      toAccountOptionRows: [
+        { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+      ],
+      categoryRows: [
+        { categoryId: 20, name: 'Einkauf' },
+        { categoryId: 21, name: 'Lebensmittel' },
+      ],
+    },
+    { uploadDelayMs: 800, failUploadWhenOfflineAfterDelay: true },
+  );
+  await page.goto(appPath('#/add'));
+
+  await page.getByTestId('receipt-image-input').setInputFiles({
+    name: 'offline-during-upload.png',
+    mimeType: 'image/png',
+    buffer: RECEIPT_IMAGE,
+  });
+  await page.getByTestId('add-transfer-from-account').selectOption('11');
+  await expect(
+    page.locator('[data-testid="progress-indicator"][data-kind="upload"]'),
+  ).toBeVisible();
+  await page.context().setOffline(true);
+
+  await expect(page.getByTestId('receipt-upload-retry')).toBeVisible();
+  await expect(page.getByTestId('receipt-upload-retry')).toBeDisabled();
+  expect(await getLocalTransferWriteCallCount(page)).toBe(1);
+  expect(await getGraphUploadCallCount(page)).toBe(1);
+  expect(requests.completionRequests).toHaveLength(2);
+
+  await page.context().setOffline(false);
+  await expect(page.getByTestId('receipt-upload-retry')).toBeEnabled();
+  await page.getByTestId('receipt-upload-retry').click();
+  await expect(page.getByTestId('receipt-commit-success')).toContainText('1 transfer created');
+  expect(await getLocalTransferWriteCallCount(page)).toBe(1);
+  expect(await getGraphUploadCallCount(page)).toBe(2);
+  expect(requests.completionRequests).toHaveLength(2);
+});
+
+test('refreshes an eTag conflict and waits for an explicit revalidated batch retry', async ({
+  page,
+}) => {
+  await installReadyReceiptConfiguration(page);
+  const requests = await installReceiptAnalysisRoutes(page, [EXTRACTION, DERIVATION]);
+  await installReadyAddTransferTestDb(
+    page,
+    {
+      fromAccountOptionRows: [
+        { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+      ],
+      toAccountOptionRows: [
+        { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+      ],
+      categoryRows: [
+        { categoryId: 20, name: 'Einkauf' },
+        { categoryId: 21, name: 'Lebensmittel' },
+      ],
+    },
+    {
+      uploadErrorSequence: [{ code: 'conflict', message: 'Precondition failed', status: 412 }],
+    },
+  );
+  await page.goto(appPath('#/add'));
+
+  await page.getByTestId('receipt-image-input').setInputFiles({
+    name: 'conflict-receipt.png',
+    mimeType: 'image/png',
+    buffer: RECEIPT_IMAGE,
+  });
+  await page.getByTestId('add-transfer-from-account').selectOption('11');
+  await expect(page.getByTestId('receipt-conflict-refresh')).toBeVisible();
+  expect(await getGraphUploadCallCount(page)).toBe(1);
+
+  await page.getByTestId('receipt-conflict-refresh').click();
+  await expect(page.getByTestId('receipt-conflict-retry')).toBeVisible();
+  expect(await getGraphUploadCallCount(page)).toBe(1);
+  await expect(page.locator('[data-testid*="receipt-review"]')).toHaveCount(0);
+
+  await page.getByTestId('receipt-conflict-retry').click();
+  await expect(page.getByTestId('receipt-commit-success')).toContainText('1 transfer created');
+  expect(await getLocalTransferWriteCallCount(page)).toBe(2);
+  expect(await getGraphUploadCallCount(page)).toBe(2);
+  expect(requests.completionRequests).toHaveLength(2);
+});
+
+test('shows remote-save reconciliation failure without any write or upload retry', async ({
+  page,
+}) => {
+  await installReadyReceiptConfiguration(page);
+  await installReceiptAnalysisRoutes(page, [EXTRACTION, DERIVATION]);
+  await installReadyAddTransferTestDb(
+    page,
+    {
+      fromAccountOptionRows: [
+        { accountId: 11, name: 'Checking', amountCents: 1000, accountTypeId: 3 },
+      ],
+      toAccountOptionRows: [
+        { accountId: 2, name: 'Primary Spendings', amountCents: 0, accountTypeId: 2 },
+      ],
+      categoryRows: [
+        { categoryId: 20, name: 'Einkauf' },
+        { categoryId: 21, name: 'Lebensmittel' },
+      ],
+    },
+    {},
+    { writeSnapshotErrorSequence: [false, true, true] },
+  );
+  await page.goto(appPath('#/add'));
+
+  await page.getByTestId('receipt-image-input').setInputFiles({
+    name: 'remote-saved-receipt.png',
+    mimeType: 'image/png',
+    buffer: RECEIPT_IMAGE,
+  });
+  await page.getByTestId('add-transfer-from-account').selectOption('11');
+
+  await expect(page.getByTestId('receipt-remote-saved')).toContainText(
+    'saved to OneDrive, but local data could not be refreshed',
+  );
+  await expect(page.getByTestId('receipt-upload-retry')).toHaveCount(0);
+  await expect(page.getByTestId('receipt-conflict-retry')).toHaveCount(0);
+  expect(await getLocalTransferWriteCallCount(page)).toBe(1);
+  expect(await getGraphUploadCallCount(page)).toBe(1);
 });

--- a/tests/e2e/support/app-test-harness.ts
+++ b/tests/e2e/support/app-test-harness.ts
@@ -248,6 +248,7 @@ export type MockGraphClientOptions = {
   readonly downloadErrorSequence?: readonly MockGraphError[];
   readonly uploadErrorSequence?: readonly MockGraphError[];
   readonly uploadDelayMs?: number;
+  readonly failUploadWhenOfflineAfterDelay?: boolean;
 };
 
 export type MockStartupSnapshot = {
@@ -267,6 +268,7 @@ export type MockStartupSnapshot = {
 export type MockCacheStoreOptions = {
   readonly failClearAll?: boolean;
   readonly clearAllDelayMs?: number;
+  readonly writeSnapshotErrorSequence?: readonly boolean[];
   readonly startupSnapshot?: MockStartupSnapshot | null;
 };
 
@@ -652,6 +654,13 @@ export const installMockGraphClient = async (
           });
         }
 
+        if (mockOptions.failUploadWhenOfflineAfterDelay && !window.navigator.onLine) {
+          throw {
+            code: 'network_error',
+            message: 'Mock upload lost connectivity.',
+          };
+        }
+
         return {
           eTag: '"etag-2"',
           sizeBytes: bytes.length,
@@ -704,6 +713,7 @@ export const installMockCacheStore = async (
       dbBytes: new Uint8Array(snapshot.dbBytes),
     });
 
+    const writeSnapshotErrorSequence = [...(mockOptions.writeSnapshotErrorSequence ?? [])];
     const storedSnapshots = new Map<
       string,
       {
@@ -762,6 +772,9 @@ export const installMockCacheStore = async (
         };
         dbBytes: Uint8Array;
       }) {
+        if (writeSnapshotErrorSequence.shift() === true) {
+          throw new Error('Mock cache snapshot write failure.');
+        }
         (
           window as Window & { __CONSPECTUS_LAST_WRITTEN_SYNC_AT__?: string }
         ).__CONSPECTUS_LAST_WRITTEN_SYNC_AT__ = snapshot.metadata.lastSyncAtIso;
@@ -1104,6 +1117,7 @@ export const installReadyAddTransferTestDb = async (
   page: Page,
   dbRuntimeOptions: MockDbRuntimeOptions = {},
   graphOptions: MockGraphClientOptions = {},
+  cacheOptions: MockCacheStoreOptions = {},
 ): Promise<void> => {
   await installPersistedBinding(page);
   await installMockDbRuntime(page, {
@@ -1111,6 +1125,7 @@ export const installReadyAddTransferTestDb = async (
     ...dbRuntimeOptions,
   });
   await installMockCacheStore(page, {
+    ...cacheOptions,
     startupSnapshot: {
       metadata: { eTag: 'existing-etag', lastSyncAtIso: new Date().toISOString() },
       dbBytes: createSqliteBytes([1, 2, 3]),


### PR DESCRIPTION
# Pull Request

## Linked Issue or Task

- Closes #255

## Context

- Problem: M9-04 stopped at an immutable validated receipt-transfer batch; it did not atomically write, export, and commit that batch to the authoritative OneDrive database.
- Goal: Complete M9-05 with automatic no-review batch creation, one eTag-guarded upload, exact success counts, and duplicate-safe recovery across every local, transport, conflict, cache, connectivity, and route lifecycle.

## Changes

- Add an atomic SQLite batch-write API and reuse the existing full-database export/upload boundary exactly once per batch.
- Add an app-shell-owned receipt commit controller with original-eTag-bound byte retry, explicit conflict reapplication, authoritative recovery after post-transaction export or missing-cache-metadata failures, and remote-success/local-reconciliation handling.
- Integrate the automatic lifecycle into Add Transfer with localized progress, exact created counts, persistent recovery actions, context invalidation, and safe completion reset.
- Expand unit and Chromium/Pixel 5 E2E coverage for one/multi-transfer success, byte-only retry, connectivity loss, conflict recovery, remote cache failure, export recovery, off-route completion, and duplicate prevention.
- Bump the app version to `0.9.05`, document the architecture invariants, mark M9-05 complete in the synchronized backlog, and raise the measured JavaScript budget from 690/210 KiB raw/gzip to 712/214 KiB. The final bundle is 727,544 B raw and 217,548 B gzip.

## Test Plan

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 83 files / 656 tests plus 15 files / 127 script tests
- [x] `npm run build`
- [x] `npm run test:e2e` — 163 passed, 1 expected skip across Chromium and Pixel 5
- [x] `npm run check:dead-code`
- [x] `npm run check:bundle-size`
- [x] `git diff --check`
- Notes: One independent reviewer agent approved the final working tree with no actionable findings after all identified safety gaps were corrected.

## Screenshots

- [ ] UI change: screenshots attached
- [ ] No UI change
- Automated responsive component and E2E coverage validates the UI states; no screenshot artifact is included.

## Manual Device QA (Release PRs Only)

- [x] Not a release PR; physical-device QA is not required here.
- [ ] Release PR: all required rows in
      [`docs/Manual-Device-QA.md`](https://github.com/Jon2050/Conspectus-Mobile/blob/main/docs/Manual-Device-QA.md)
      pass.
- Tested candidate URL / commit: local commit `9f3738c73203c659692760507bf3b9bd03167888`
- Completed results and evidence location in this PR: Test Plan above and GitHub checks.

## Release Process (Release PRs Only)

- [x] Not a release PR; the release-cut process is not required here.
- [ ] Release PR: the single checklist from
      [`docs/Release-Process.md`](https://github.com/Jon2050/Conspectus-Mobile/blob/main/docs/Release-Process.md)
      is copied into this PR or a dedicated PR comment and completed there.
- Planned version / tag: `0.9.05`; no release tag in this PR.
- Candidate commit / `Quality` / `Deploy Preview` evidence: local gate above; GitHub evidence pending.
- Reviewer-agent approval evidence: final local reviewer verdict `APPROVED`, no actionable findings.
- Human release-owner `APPROVED FOR RELEASE` evidence: not applicable.
- Approved release-notes location: not applicable.
- Production commit / `Deploy Production` / post-deploy evidence: not applicable.

## Risk Notes

- User impact: Validated receipt transfers are now created automatically without a review screen. Structural and arithmetic validation cannot prove that an AI-selected user-defined semantic grouping is conceptually correct; the capture UI and architecture documentation disclose this residual risk.
- Safety: Pending bytes remain bound to their original eTag; conflicts never silently overwrite OneDrive; pre-upload local-only failures restore authoritative bytes before another write; remote success is never retried as a write.
- Rollback plan: Revert this commit to restore the M9-04 preparation-only receipt flow and the previous bundle budget/version.

## QS Checklist

- [x] The linked issue or manual-task context is included in this PR.
- [x] Lint, typecheck, tests, and build were run and pass.
- [ ] Screenshots are included for UI changes.
- [x] Risk and rollback notes are documented.
- [x] No secrets, tokens, or credentials were added to the repository.
- [x] No unintended path/base URL changes were introduced (production remains rooted at `https://jon2050.de/conspectus/`).

## Merge And Cleanup (PR Path)

- [ ] Required GitHub checks are green.
- [x] PR will be merged into `main` with `Rebase and merge`.
- [x] PR will be merged into `main` once checks/review requirements are satisfied.
- [x] Head branch will be deleted after merge.
- [x] The backlog marker is included in this PR and becomes done on `main` only when this PR merges; issue #255 closes through this PR.
